### PR TITLE
Recognize `image/jpg` as `MimeType::Jpeg`

### DIFF
--- a/src/picture.rs
+++ b/src/picture.rs
@@ -87,7 +87,7 @@ impl MimeType {
 	/// Get a `MimeType` from a string
 	pub fn from_str(mime_type: &str) -> Self {
 		match &*mime_type.to_lowercase() {
-			"image/jpeg" => Self::Jpeg,
+			"image/jpeg" | "image/jpg" => Self::Jpeg,
 			"image/png" => Self::Png,
 			"image/tiff" => Self::Tiff,
 			"image/bmp" => Self::Bmp,


### PR DESCRIPTION
With this patch, when MIME type is `image/jpg`, Lofty will recognize it as `MimeType::Jpeg` too, instead of falling back to `Unknown`.

I tested this patch with [Amberol](https://gitlab.gnome.org/World/amberol) (Which uses [MimeType::](https://gitlab.gnome.org/World/amberol/-/blob/3ea0b2e40c3c2fff8593b04b08ad54de8076639f/src/audio/song.rs#L84-86) enums to decide whether to show album arts) and now it displays JPG album arts just fine.

In my opinion, I don't see a reason for creating a `MimeType::Jpg` enum, since actually JPG and JPEG are the same thing but with a different extension.