### PR TITLE
ID3v2: populate popularimeter tag from frame value

### DIFF
--- a/src/id3/v2/frame/mod.rs
+++ b/src/id3/v2/frame/mod.rs
@@ -296,6 +296,9 @@ impl From<TagItem> for Option<Frame> {
 							content: text,
 						})
 					},
+					(FrameID::Valid(ref s), ItemValue::Binary(text)) if s == "POPM" => {
+						FrameValue::Popularimeter(Popularimeter::from_bytes(&text).ok()?)
+					},
 					(_, value) => value.into(),
 				};
 
@@ -394,6 +397,9 @@ impl<'a> TryFrom<&'a TagItem> for FrameRef<'a> {
 					description: String::new(),
 					content: text.clone(),
 				}),
+				("POPM", ItemValue::Binary(contents)) => {
+					FrameValue::Popularimeter(Popularimeter::from_bytes(contents)?)
+				},
 				(_, value) => value.into(),
 			}),
 			flags: FrameFlags::default(),

--- a/src/id3/v2/items/popularimeter.rs
+++ b/src/id3/v2/items/popularimeter.rs
@@ -61,7 +61,7 @@ impl Popularimeter {
 				1 => pop.rating = *chunk.first().unwrap_or(&0),
 				2 => chunk.iter().for_each(|&b| {
 					pop.counter <<= 8;
-					pop.counter |= u64::from(b);
+					pop.counter += u64::from(b);
 				}),
 				_ => unreachable!(),
 			}

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -571,7 +571,9 @@ impl From<ID3v2Tag> for Tag {
 							tag.push_picture(picture);
 							continue;
 						},
-						FrameValue::Popularimeter(_) => continue,
+						FrameValue::Popularimeter(popularimeter) => {
+							ItemValue::Text(popularimeter.rating.to_string())
+						},
 						FrameValue::Binary(binary) => ItemValue::Binary(binary),
 					};
 
@@ -825,6 +827,15 @@ mod tests {
 		let tag: Tag = id3v2.into();
 
 		crate::tag::utils::test_utils::verify_tag(&tag, true, true);
+	}
+
+	#[test]
+	fn id3v2_to_tag_popm() {
+		let id3v2 = read_tag("tests/tags/assets/id3v2/test_popm.id3v24");
+
+		let tag: Tag = id3v2.into();
+
+		assert_eq!(tag.get_string(&ItemKey::Popularimeter), Some("196"))
 	}
 
 	#[test]


### PR DESCRIPTION
Use the `rating` field as the value of the Popularimeter tags when handling ID3v2 tags.

closes #63 