### PR TITLE
MP3: Improve validation of frame headers

### DIFF
--- a/src/mpeg/header.rs
+++ b/src/mpeg/header.rs
@@ -240,15 +240,14 @@ impl Header {
 		let bitrate_index = (data >> 12) & 0xF;
 		header.bitrate = BITRATES[version_index][layer_index][bitrate_index as usize];
 		if header.bitrate == 0 {
-			return Some(header);
+			return None;
 		}
 
 		// Sample rate index
 		let sample_rate_index = (data >> 10) & 0b11;
 		header.sample_rate = match sample_rate_index {
-			// This is invalid, but it doesn't seem worth it to error here
-			// We will error if properties are read
-			3 => return Some(header),
+			// This is invalid
+			3 => return None,
 			_ => SAMPLE_RATES[header.version as usize][sample_rate_index as usize],
 		};
 


### PR DESCRIPTION
Some MP3 files have garbage before the MPEG frames. Lofty tries to skip them by looking for sync bits, reading a header, seeking to the next one and comparing that to the first header. This works fine most of the time.

The issue I had was that in a few MP3 files, I had garbage that contained long strings of `ff` bytes. A header `ff ff ff ff` has invalid bitrate and frequency (sample rate) but would be returned from `Header::read` as if it was valid -- the Header struct would be half-zeroed though. The frame length (`len`) is also zero, so for validation in `find_next_frame` the next 4 bytes would be read. If those happen to also be `ff ff ff ff`, it passes validation. The whole file is later determined to be invalid in `read_from`, which does check the sample rate.

I found this issue when debugging why Amberol wouldn't add some songs to its queue. I have an album of 14 songs where it could only add 6 -- that was gone when I rebuilt it with a version of Lofty with these changes.

My changes basically just turn the error branches into `return None`. The current behavior is to return the header struct half-filled.

I attached an [archive](https://github.com/Serial-ATA/lofty-rs/files/9486318/8ff-issue-samples.zip) with two small MP3 files:
1. `ok.mp3` will open fine with or without these changes.
2. `8ff.mp3` is the same file with 8 bytes of `0xff` prepended. It triggers the issue and will only open with these changes applied.

(I don't know for sure, but I have a feeling that garbage filled with `0xff` may be the reason that all-ones bitrate and frequency values are invalid in these headers)