### PR TITLE
lofty_attr: Return removed tags in <File>::remove_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **TagExt**: `TagExt::contains`
 
+### Changed
+- **Files**: Return the removed tag from `<File>::remove(TagType)`
+  - Previously, the only way to remove and take a tag was through `TaggedFile::take`.
+    This was not possible when using a concrete type, such as `OpusFile`.
+
 ## [0.9.0] - 2022-10-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Files**: Return the removed tag from `<File>::remove(TagType)`
-  - Previously, the only way to remove and take a tag was through `TaggedFile::take`.
+  - Previously, the only way to remove and take ownership of a tag was through `TaggedFile::take`.
     This was not possible when using a concrete type, such as `OpusFile`.
+- **TaggedFile**: Renamed `TaggedFile::take` to `TaggedFile::remove`
 
 ## [0.9.0] - 2022-10-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cfg-if     = "1.0.0"
 # ID3 compressed frames
 flate2     = { version = "1.0.24", optional = true }
 # Proc macros
-lofty_attr = "0.4.0"
+lofty_attr = { path = "lofty_attr" }
 # Debug logging
 log        = "0.4.17"
 # OGG Vorbis/Opus

--- a/lofty_attr/src/lofty_file.rs
+++ b/lofty_attr/src/lofty_file.rs
@@ -304,7 +304,7 @@ fn get_getters<'a>(
 		let remove_ident = Ident::new(&format!("remove_{}", name), Span::call_site());
 
 		let remover = if f.needs_option {
-			quote! {self.#field_name = None;}
+			quote! { self.#field_name.take() }
 		} else {
 			let assert_field_ty_default = quote_spanned! {f.name.span()=>
 				struct _AssertDefault where #field_ty: core::default::Default;
@@ -312,7 +312,7 @@ fn get_getters<'a>(
 
 			quote! {
 				#assert_field_ty_default
-				self.#field_name = <#field_ty>::default();
+				::core::mem::replace(&mut self.#field_name, <#field_ty>::default())
 			}
 		};
 
@@ -331,7 +331,7 @@ fn get_getters<'a>(
 				}
 
 				/// Removes the tag
-				pub fn #remove_ident(&mut self) {
+				pub fn #remove_ident(&mut self) -> #ty_prefix #field_ty #ty_suffix {
 					#remover
 				}
 			}

--- a/src/file.rs
+++ b/src/file.rs
@@ -297,7 +297,7 @@ impl TaggedFile {
 	/// # let path_to_mp3 = "tests/files/assets/minimal/full_test.mp3";
 	/// // Read an MP3 file without an ID3v2 tag
 	/// let mut tagged_file = lofty::read_from_path(path_to_mp3)?;
-	/// # let _ = tagged_file.take(TagType::ID3v2); // sneaky
+	/// # let _ = tagged_file.remove(TagType::ID3v2); // sneaky
 	///
 	/// assert!(!tagged_file.contains_tag_type(TagType::ID3v2));
 	///
@@ -312,7 +312,7 @@ impl TaggedFile {
 		let tag_type = tag.tag_type();
 
 		if self.supports_tag_type(tag_type) {
-			let ret = self.take(tag_type);
+			let ret = self.remove(tag_type);
 			self.tags.push(tag);
 
 			return ret;
@@ -336,12 +336,12 @@ impl TaggedFile {
 	/// assert!(tagged_file.contains_tag_type(TagType::ID3v2));
 	///
 	/// // Take the ID3v2 tag
-	/// let id3v2 = tagged_file.take(TagType::ID3v2);
+	/// let id3v2 = tagged_file.remove(TagType::ID3v2);
 	///
 	/// assert!(!tagged_file.contains_tag_type(TagType::ID3v2));
 	/// # Ok(()) }
 	/// ```
-	pub fn take(&mut self, tag_type: TagType) -> Option<Tag> {
+	pub fn remove(&mut self, tag_type: TagType) -> Option<Tag> {
 		self.tags
 			.iter()
 			.position(|t| t.tag_type() == tag_type)


### PR DESCRIPTION
Previously, we just removed and dropped the tag. That should really be left up to the user, though.