### PR TITLE
OGG: Switch to using packets instead of individual pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **TagExt**: `TagExt::contains`
 - **Ilst**: `AtomData::Bool` for the various flag atoms such as `cpil`, `pcst`, etc.
+- **ogg_pager**: Support for reading packets with the new `Packets` struct.
 
 ### Changed
 - **Files**: Return the removed tag from `<File>::remove(TagType)`
   - Previously, the only way to remove and take ownership of a tag was through `TaggedFile::take`.
     This was not possible when using a concrete type, such as `OpusFile`.
 - **TaggedFile**: Renamed `TaggedFile::take` to `TaggedFile::remove`
+- **OGG**: The reading of OGG files has switched to using packets opposed to pages, making it more
+           spec-compliant and efficient.
 
 ## [0.9.0] - 2022-10-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TagExt**: `TagExt::contains`
 - **Ilst**: `AtomData::Bool` for the various flag atoms such as `cpil`, `pcst`, etc.
 - **ogg_pager**: Support for reading packets with the new `Packets` struct.
+- **ogg_pager**: `PageHeader` struct.
 
 ### Changed
 - **Files**: Return the removed tag from `<File>::remove(TagType)`
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TaggedFile**: Renamed `TaggedFile::take` to `TaggedFile::remove`
 - **OGG**: The reading of OGG files has switched to using packets opposed to pages, making it more
            spec-compliant and efficient.
+- **ogg_pager**: Most fields in `Page` have been separated out into the new `PageHeader` struct.
 
 ## [0.9.0] - 2022-10-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lofty_attr = { path = "lofty_attr" }
 # Debug logging
 log        = "0.4.17"
 # OGG Vorbis/Opus
-ogg_pager  = "0.3.2"
+ogg_pager  = { path = "ogg_pager" }
 # Key maps
 once_cell  = "1.13.0"
 paste      = "1.0.7"

--- a/ogg_pager/src/error.rs
+++ b/ogg_pager/src/error.rs
@@ -15,6 +15,8 @@ pub enum PageError {
 	MissingMagic,
 	/// The reader contains too much data for a single page
 	TooMuchData,
+	/// The reader contains too little data to extract the expected information
+	NotEnoughData,
 	/// Any std::io::Error
 	Io(std::io::Error),
 }
@@ -28,6 +30,9 @@ impl fmt::Display for PageError {
 			PageError::BadSegmentCount => write!(f, "Page has a segment count < 1"),
 			PageError::MissingMagic => write!(f, "Page is missing a magic signature"),
 			PageError::TooMuchData => write!(f, "Too much data was provided"),
+			PageError::NotEnoughData => {
+				write!(f, "Too little data is available for the expected read")
+			},
 			PageError::Io(err) => write!(f, "{}", err),
 		}
 	}

--- a/ogg_pager/src/header.rs
+++ b/ogg_pager/src/header.rs
@@ -1,0 +1,94 @@
+use crate::{PageError, Result};
+
+use std::io::{Read, Seek};
+
+use byteorder::{LittleEndian, ReadBytesExt};
+
+// An OGG page header
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct PageHeader {
+	/// The position in the stream the page started at
+	pub start: u64,
+	pub(crate) header_type_flag: u8,
+	/// The page's absolute granule position
+	pub abgp: u64,
+	/// The page's stream serial number
+	pub stream_serial: u32,
+	/// The page's sequence number
+	pub sequence_number: u32,
+	pub(crate) checksum: u32,
+}
+
+impl PageHeader {
+	pub fn new(header_type_flag: u8, abgp: u64, stream_serial: u32, sequence_number: u32) -> Self {
+		Self {
+			start: 0,
+			header_type_flag,
+			abgp,
+			stream_serial,
+			sequence_number,
+			checksum: 0,
+		}
+	}
+
+	pub fn read<R>(data: &mut R) -> Result<(Self, Vec<u8>)>
+	where
+		R: Read + Seek,
+	{
+		let start = data.stream_position()?;
+
+		let mut sig = [0; 4];
+		data.read_exact(&mut sig)?;
+
+		if &sig != b"OggS" {
+			return Err(PageError::MissingMagic);
+		}
+
+		// Version, always 0
+		let version = data.read_u8()?;
+
+		if version != 0 {
+			return Err(PageError::InvalidVersion);
+		}
+
+		let header_type_flag = data.read_u8()?;
+
+		let abgp = data.read_u64::<LittleEndian>()?;
+		let stream_serial = data.read_u32::<LittleEndian>()?;
+		let sequence_number = data.read_u32::<LittleEndian>()?;
+		let checksum = data.read_u32::<LittleEndian>()?;
+
+		let segments = data.read_u8()?;
+
+		if segments < 1 {
+			return Err(PageError::BadSegmentCount);
+		}
+
+		let mut segment_table = vec![0; segments as usize];
+		data.read_exact(&mut segment_table)?;
+
+		let header = Self {
+			start,
+			header_type_flag,
+			abgp,
+			stream_serial,
+			sequence_number,
+			checksum,
+		};
+
+		Ok((header, segment_table))
+	}
+
+	/// Returns the page's header type flag
+	pub fn header_type_flag(&self) -> u8 {
+		self.header_type_flag
+	}
+
+	/// Returns the page's checksum
+	///
+	/// NOTE: This will not generate a new CRC. It will return
+	/// the CRC as-is. Use [`Page::gen_crc`] to generate a new one.
+	pub fn checksum(&self) -> u32 {
+		self.checksum
+	}
+}

--- a/ogg_pager/src/header.rs
+++ b/ogg_pager/src/header.rs
@@ -85,9 +85,6 @@ impl PageHeader {
 	}
 
 	/// Returns the page's checksum
-	///
-	/// NOTE: This will not generate a new CRC. It will return
-	/// the CRC as-is. Use [`Page::gen_crc`] to generate a new one.
 	pub fn checksum(&self) -> u32 {
 		self.checksum
 	}

--- a/src/ogg/mod.rs
+++ b/src/ogg/mod.rs
@@ -34,10 +34,10 @@ pub use speex::SpeexFile;
 pub use vorbis::properties::VorbisProperties;
 pub use vorbis::VorbisFile;
 
-pub(self) fn verify_signature(page: &Page, sig: &[u8]) -> Result<()> {
+pub(self) fn verify_signature(content: &[u8], sig: &[u8]) -> Result<()> {
 	let sig_len = sig.len();
 
-	if page.content().len() < sig_len || &page.content()[..sig_len] != sig {
+	if content.len() < sig_len || &content[..sig_len] != sig {
 		decode_err!(@BAIL Vorbis, "File missing magic signature");
 	}
 

--- a/src/ogg/opus/mod.rs
+++ b/src/ogg/opus/mod.rs
@@ -38,7 +38,7 @@ impl AudioFile for OpusFile {
 		let file_information = super::read::read_from(reader, OPUSHEAD, OPUSTAGS)?;
 
 		Ok(Self {
-			properties: if parse_options.read_properties { properties::read_properties(reader, &file_information.1)? } else { OpusProperties::default() },
+			properties: if parse_options.read_properties { properties::read_properties(reader, file_information.1, &file_information.2)? } else { OpusProperties::default() },
 			#[cfg(feature = "vorbis_comments")]
 			// Safe to unwrap, a metadata packet is mandatory in Opus
 			vorbis_comments_tag: file_information.0.unwrap(),

--- a/src/ogg/opus/properties.rs
+++ b/src/ogg/opus/properties.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::time::Duration;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use ogg_pager::Page;
+use ogg_pager::{Packets, PageHeader};
 
 /// An Opus file's audio properties
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
@@ -66,35 +66,35 @@ impl OpusProperties {
 	}
 }
 
-pub(in crate::ogg) fn read_properties<R>(data: &mut R, first_page: &Page) -> Result<OpusProperties>
+pub(in crate::ogg) fn read_properties<R>(
+	data: &mut R,
+	first_page_header: PageHeader,
+	packets: &Packets,
+) -> Result<OpusProperties>
 where
 	R: Read + Seek,
 {
-	let (stream_len, file_length) = {
-		let current = data.stream_position()?;
-		let end = data.seek(SeekFrom::End(0))?;
-		data.seek(SeekFrom::Start(current))?;
-
-		(end - first_page.start, end)
-	};
-
 	let mut properties = OpusProperties::default();
 
-	let first_page_abgp = first_page.abgp;
+	let first_page_abgp = first_page_header.abgp;
+
+	// Safe to unwrap, it is impossible to get this far without
+	// an identification packet.
+	let identification_packet = packets.get(0).unwrap();
 
 	// Skip identification header
-	let first_page_content = &mut &first_page.content()[8..];
+	let identification_packet_reader = &mut &identification_packet[8..];
 
-	properties.version = first_page_content.read_u8()?;
-	properties.channels = first_page_content.read_u8()?;
+	properties.version = identification_packet_reader.read_u8()?;
+	properties.channels = identification_packet_reader.read_u8()?;
 
-	let pre_skip = first_page_content.read_u16::<LittleEndian>()?;
+	let pre_skip = identification_packet_reader.read_u16::<LittleEndian>()?;
 
-	properties.input_sample_rate = first_page_content.read_u32::<LittleEndian>()?;
+	properties.input_sample_rate = identification_packet_reader.read_u32::<LittleEndian>()?;
 
-	let _output_gain = first_page_content.read_u16::<LittleEndian>()?;
+	let _output_gain = identification_packet_reader.read_u16::<LittleEndian>()?;
 
-	let channel_mapping_family = first_page_content.read_u8()?;
+	let channel_mapping_family = identification_packet_reader.read_u8()?;
 
 	// https://datatracker.ietf.org/doc/html/rfc7845.html#section-5.1.1
 	if (channel_mapping_family == 0 && properties.channels > 2)
@@ -103,18 +103,27 @@ where
 		decode_err!(@BAIL Opus, "Invalid channel count for mapping family");
 	}
 
-	// Subtract the identification and metadata packet length from the total
-	let audio_size = stream_len - data.stream_position()?;
+	// Get the last pages' absolute granule position
 
 	let last_page = find_last_page(data)?;
-	let last_page_abgp = last_page.abgp;
+	let last_page_abgp = last_page.header().abgp;
+
+	// Get the stream length
+
+	// Also safe to unwrap, metadata is checked prior
+	let metadata_packet = packets.get(1).unwrap();
+
+	let header_size = identification_packet.len() + metadata_packet.len();
+
+	let file_length = data.seek(SeekFrom::End(0))?;
+	let stream_len = file_length - header_size as u64;
 
 	if let Some(frame_count) = last_page_abgp.checked_sub(first_page_abgp + u64::from(pre_skip)) {
 		let length = (frame_count as f64) * 1000.0 / 48000.0_f64 + 0.5;
 		properties.duration = Duration::from_millis(length as u64);
 
 		properties.overall_bitrate = ((file_length as f64) * 8.0 / length) as u32;
-		properties.audio_bitrate = ((audio_size as f64) * 8.0 / length) as u32;
+		properties.audio_bitrate = ((stream_len as f64) * 8.0 / length) as u32;
 	}
 
 	Ok(properties)

--- a/src/ogg/speex/mod.rs
+++ b/src/ogg/speex/mod.rs
@@ -37,7 +37,7 @@ impl AudioFile for SpeexFile {
 		let file_information = super::read::read_from(reader, SPEEXHEADER, &[])?;
 
 		Ok(Self {
-            properties: if parse_options.read_properties { properties::read_properties(reader, &file_information.1)? } else { SpeexProperties::default() },
+            properties: if parse_options.read_properties { properties::read_properties(reader, file_information.1, &file_information.2)? } else { SpeexProperties::default() },
             #[cfg(feature = "vorbis_comments")]
             // Safe to unwrap, a metadata packet is mandatory in Speex
             vorbis_comments_tag: file_information.0.unwrap(),

--- a/src/ogg/vorbis/mod.rs
+++ b/src/ogg/vorbis/mod.rs
@@ -41,7 +41,7 @@ impl AudioFile for VorbisFile {
 			super::read::read_from(reader, VORBIS_IDENT_HEAD, VORBIS_COMMENT_HEAD)?;
 
 		Ok(Self {
-			properties: if parse_options.read_properties { properties::read_properties(reader, &file_information.1)? } else { VorbisProperties::default() },
+			properties: if parse_options.read_properties { properties::read_properties(reader, file_information.1, &file_information.2)? } else { VorbisProperties::default() },
 			#[cfg(feature = "vorbis_comments")]
 			// Safe to unwrap, a metadata packet is mandatory in OGG Vorbis
 			vorbis_comments_tag: file_information.0.unwrap(),

--- a/src/ogg/vorbis/write.rs
+++ b/src/ogg/vorbis/write.rs
@@ -36,8 +36,8 @@ pub(crate) fn write_to(
 	loop {
 		let p = Page::read(data, false)?;
 
-		if p.header_type() & 0x01 != 1 {
-			data.seek(SeekFrom::Start(p.start))?;
+		if p.header().header_type_flag() & 0x01 != 1 {
+			data.seek(SeekFrom::Start(p.header().start))?;
 			data.read_to_end(&mut remaining)?;
 
 			reached_md_end = true;

--- a/src/ogg/write.rs
+++ b/src/ogg/write.rs
@@ -146,7 +146,7 @@ where
 {
 	let first_page = Page::read(data, false)?;
 
-	let ser = first_page.serial;
+	let ser = first_page.header().stream_serial;
 
 	let mut writer = Vec::new();
 	writer.write_all(&first_page.as_bytes()?)?;
@@ -155,7 +155,7 @@ where
 
 	let comment_signature = format.comment_signature();
 	if let Some(comment_signature) = comment_signature {
-		verify_signature(&first_md_page, comment_signature)?;
+		verify_signature(first_md_page.content(), comment_signature)?;
 	}
 
 	let comment_signature = comment_signature.unwrap_or_default();
@@ -211,8 +211,8 @@ fn replace_packet(
 	loop {
 		let p = Page::read(data, true)?;
 
-		if p.header_type() & 0x01 != 0x01 {
-			data.seek(SeekFrom::Start(p.start))?;
+		if p.header().header_type_flag() & 0x01 != 0x01 {
+			data.seek(SeekFrom::Start(p.header().start))?;
 			reached_md_end = true;
 			break;
 		}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -17,7 +17,7 @@ use once_cell::sync::Lazy;
 ///
 /// This trait allows for the creation of custom [`FileType`]s, that can make use of
 /// lofty's API. Registering a `FileResolver` ([`register_custom_resolver`]) makes it possible
-/// to detect and read files using [`crate::probe::Probe`].
+/// to detect and read files using [`Probe`](crate::Probe).
 pub trait FileResolver: Send + Sync + AudioFile {
 	/// The extension associated with the [`FileType`] without the '.'
 	fn extension() -> Option<&'static str>;


### PR DESCRIPTION
This makes the handling of OGG files a lot more spec-compliant, and simpler overall.