### PR TITLE
Allow to create AtomIdent constants with 'static lifetime

### DIFF
--- a/src/mp4/ilst/ref.rs
+++ b/src/mp4/ilst/ref.rs
@@ -36,42 +36,16 @@ where
 	}
 }
 
-impl Atom {
+impl<'a> Atom<'a> {
 	pub(super) fn as_ref(&self) -> AtomRef<'_, impl IntoIterator<Item = &AtomData>> {
 		AtomRef {
-			ident: (&self.ident).into(),
+			ident: self.ident.as_borrowed(),
 			data: (&self.data).into_iter(),
 		}
 	}
 }
 
 pub(crate) struct AtomRef<'a, I> {
-	pub(crate) ident: AtomIdentRef<'a>,
+	pub(crate) ident: AtomIdent<'a>,
 	pub(crate) data: I,
-}
-
-pub(crate) enum AtomIdentRef<'a> {
-	Fourcc([u8; 4]),
-	Freeform { mean: &'a str, name: &'a str },
-}
-
-impl<'a> Into<AtomIdentRef<'a>> for &'a AtomIdent {
-	fn into(self) -> AtomIdentRef<'a> {
-		match self {
-			AtomIdent::Fourcc(fourcc) => AtomIdentRef::Fourcc(*fourcc),
-			AtomIdent::Freeform { mean, name } => AtomIdentRef::Freeform { mean, name },
-		}
-	}
-}
-
-impl<'a> From<AtomIdentRef<'a>> for AtomIdent {
-	fn from(input: AtomIdentRef<'a>) -> Self {
-		match input {
-			AtomIdentRef::Fourcc(fourcc) => AtomIdent::Fourcc(fourcc),
-			AtomIdentRef::Freeform { mean, name } => AtomIdent::Freeform {
-				mean: mean.to_string(),
-				name: name.to_string(),
-			},
-		}
-	}
 }

--- a/src/mp4/ilst/write.rs
+++ b/src/mp4/ilst/write.rs
@@ -3,7 +3,7 @@ use crate::error::{FileEncodingError, Result};
 use crate::file::FileType;
 use crate::macros::{err, try_vec};
 use crate::mp4::atom_info::{AtomIdent, AtomInfo};
-use crate::mp4::ilst::r#ref::{AtomIdentRef, AtomRef};
+use crate::mp4::ilst::r#ref::AtomRef;
 use crate::mp4::moov::Moov;
 use crate::mp4::read::{atom_tree, meta_is_full, nested_atom, verify_mp4, AtomReader};
 use crate::mp4::AtomData;
@@ -322,8 +322,8 @@ where
 		writer.write_all(&[0; 4])?;
 
 		match atom.ident {
-			AtomIdentRef::Fourcc(ref fourcc) => writer.write_all(fourcc)?,
-			AtomIdentRef::Freeform { mean, name } => write_freeform(mean, name, &mut writer)?,
+			AtomIdent::Fourcc(ref fourcc) => writer.write_all(fourcc)?,
+			AtomIdent::Freeform { mean, name } => write_freeform(&mean, &name, &mut writer)?,
 		}
 
 		write_atom_data(atom.data, &mut writer)?;


### PR DESCRIPTION
Otherwise you would need to use `once_cell` for constants. This extension by using `Cow` also makes `AtomIdentRef` obsolete.