### PR TITLE
Remove obsolete metadata format features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ once_cell  = "1.16.0"
 paste      = "1.0.11"
 
 [features]
-default            = ["mp4_ilst", "ape", "id3v1", "id3v2", "aiff_text_chunks", "riff_info_list"]
-mp4_ilst           = []
+default            = ["ape", "id3v1", "id3v2", "aiff_text_chunks", "riff_info_list"]
 ape                = []
 id3v1              = []
 id3v2              = ["flate2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ once_cell  = "1.16.0"
 paste      = "1.0.11"
 
 [features]
-default            = ["ape", "id3v2", "aiff_text_chunks", "riff_info_list"]
-ape                = []
+default            = ["id3v2", "aiff_text_chunks", "riff_info_list"]
 id3v2              = ["flate2"]
 id3v2_restrictions = []
 aiff_text_chunks   = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include     = ["src", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT", "benches", 
 
 [dependencies]
 # Vorbis comments pictures
-base64     = { version = "0.20.0", optional = true }
+base64     = "0.20.0"
 byteorder  = "1.4.3"
 # TODO: rustfmt only works with cfg_if for now (https://github.com/rust-lang/rustfmt/issues/3253)
 cfg-if     = "1.0.0"
@@ -30,9 +30,8 @@ once_cell  = "1.16.0"
 paste      = "1.0.11"
 
 [features]
-default            = ["mp4_ilst", "vorbis_comments", "ape", "id3v1", "id3v2", "aiff_text_chunks", "riff_info_list"]
+default            = ["mp4_ilst", "ape", "id3v1", "id3v2", "aiff_text_chunks", "riff_info_list"]
 mp4_ilst           = []
-vorbis_comments    = ["base64"]
 ape                = []
 id3v1              = []
 id3v2              = ["flate2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,9 @@ once_cell  = "1.16.0"
 paste      = "1.0.11"
 
 [features]
-default            = ["id3v2", "riff_info_list"]
+default            = ["id3v2"]
 id3v2              = ["flate2"]
 id3v2_restrictions = []
-riff_info_list     = []
 
 [dev-dependencies]
 # WAV properties validity tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,8 @@ once_cell  = "1.16.0"
 paste      = "1.0.11"
 
 [features]
-default            = ["ape", "id3v1", "id3v2", "aiff_text_chunks", "riff_info_list"]
+default            = ["ape", "id3v2", "aiff_text_chunks", "riff_info_list"]
 ape                = []
-id3v1              = []
 id3v2              = ["flate2"]
 id3v2_restrictions = []
 aiff_text_chunks   = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,9 @@ once_cell  = "1.16.0"
 paste      = "1.0.11"
 
 [features]
-default            = ["id3v2", "aiff_text_chunks", "riff_info_list"]
+default            = ["id3v2", "riff_info_list"]
 id3v2              = ["flate2"]
 id3v2_restrictions = []
-aiff_text_chunks   = []
 riff_info_list     = []
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,8 @@ once_cell  = "1.16.0"
 paste      = "1.0.11"
 
 [features]
-default            = ["id3v2"]
-id3v2              = ["flate2"]
-id3v2_restrictions = []
+default                   = ["id3v2_compression_support"]
+id3v2_compression_support = ["flate2"]
 
 [dev-dependencies]
 # WAV properties validity tests

--- a/src/aac/mod.rs
+++ b/src/aac/mod.rs
@@ -20,7 +20,6 @@ pub use properties::AACProperties;
 #[lofty(read_fn = "read::read_from")]
 #[lofty(internal_write_module_do_not_use_anywhere_else)]
 pub struct AACFile {
-	#[cfg(feature = "id3v2")]
 	#[lofty(tag_type = "ID3v2")]
 	pub(crate) id3v2_tag: Option<ID3v2Tag>,
 	#[lofty(tag_type = "ID3v1")]

--- a/src/aac/mod.rs
+++ b/src/aac/mod.rs
@@ -23,7 +23,6 @@ pub struct AACFile {
 	#[cfg(feature = "id3v2")]
 	#[lofty(tag_type = "ID3v2")]
 	pub(crate) id3v2_tag: Option<ID3v2Tag>,
-	#[cfg(feature = "id3v1")]
 	#[lofty(tag_type = "ID3v1")]
 	pub(crate) id3v1_tag: Option<ID3v1Tag>,
 	pub(crate) properties: AACProperties,

--- a/src/aac/read.rs
+++ b/src/aac/read.rs
@@ -48,19 +48,16 @@ where
 
 				stream_len -= u64::from(header.size);
 
-				#[cfg(feature = "id3v2")]
-				{
-					let id3v2 = parse_id3v2(reader, header)?;
-					if let Some(existing_tag) = &mut file.id3v2_tag {
-						// https://github.com/Serial-ATA/lofty-rs/issues/87
-						// Duplicate tags should have their frames appended to the previous
-						for frame in id3v2.frames {
-							existing_tag.insert(frame);
-						}
-						continue;
+				let id3v2 = parse_id3v2(reader, header)?;
+				if let Some(existing_tag) = &mut file.id3v2_tag {
+					// https://github.com/Serial-ATA/lofty-rs/issues/87
+					// Duplicate tags should have their frames appended to the previous
+					for frame in id3v2.frames {
+						existing_tag.insert(frame);
 					}
-					file.id3v2_tag = Some(id3v2);
+					continue;
 				}
+				file.id3v2_tag = Some(id3v2);
 
 				// Skip over the footer
 				if skip_footer {

--- a/src/aac/read.rs
+++ b/src/aac/read.rs
@@ -91,7 +91,6 @@ where
 	#[allow(unused_variables)]
 	let ID3FindResults(header, id3v1) = find_id3v1(reader, true)?;
 
-	#[cfg(feature = "id3v1")]
 	if header.is_some() {
 		stream_len -= 128;
 		file.id3v1_tag = id3v1;

--- a/src/ape/constants.rs
+++ b/src/ape/constants.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "ape")]
 pub(super) const INVALID_KEYS: [&str; 4] = ["ID3", "TAG", "OGGS", "MP+"];
 
 // https://wiki.hydrogenaud.io/index.php?title=APE_Tags_Header

--- a/src/ape/header.rs
+++ b/src/ape/header.rs
@@ -10,7 +10,6 @@ use byteorder::{LittleEndian, ReadBytesExt};
 #[derive(Copy, Clone)]
 pub(crate) struct ApeHeader {
 	pub(crate) size: u32,
-	#[cfg(feature = "ape")]
 	pub(crate) item_count: u32,
 }
 
@@ -28,11 +27,7 @@ where
 		decode_err!(@BAIL APE, "APE tag has an invalid size (< 32)");
 	}
 
-	#[cfg(feature = "ape")]
 	let item_count = data.read_u32::<LittleEndian>()?;
-
-	#[cfg(not(feature = "ape"))]
-	data.seek(SeekFrom::Current(4))?;
 
 	if footer {
 		// No point in reading the rest of the footer, just seek back to the end of the header
@@ -54,9 +49,5 @@ where
 		decode_err!(@BAIL APE, "APE tag has an invalid size (> file size)");
 	}
 
-	Ok(ApeHeader {
-		size,
-		#[cfg(feature = "ape")]
-		item_count,
-	})
+	Ok(ApeHeader { size, item_count })
 }

--- a/src/ape/mod.rs
+++ b/src/ape/mod.rs
@@ -12,7 +12,6 @@ mod read;
 pub(crate) mod tag;
 
 use crate::id3::v1::tag::ID3v1Tag;
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
 
 use lofty_attr::LoftyFile;
@@ -33,7 +32,6 @@ pub struct ApeFile {
 	#[lofty(tag_type = "ID3v1")]
 	pub(crate) id3v1_tag: Option<ID3v1Tag>,
 	/// An ID3v2 tag (Not officially supported)
-	#[cfg(feature = "id3v2")]
 	#[lofty(tag_type = "ID3v2")]
 	pub(crate) id3v2_tag: Option<ID3v2Tag>,
 	/// An APEv1/v2 tag

--- a/src/ape/mod.rs
+++ b/src/ape/mod.rs
@@ -10,7 +10,6 @@ pub(crate) mod header;
 mod properties;
 mod read;
 
-#[cfg(feature = "id3v1")]
 use crate::id3::v1::tag::ID3v1Tag;
 #[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
@@ -37,7 +36,6 @@ pub use properties::ApeProperties;
 #[lofty(internal_write_module_do_not_use_anywhere_else)]
 pub struct ApeFile {
 	/// An ID3v1 tag
-	#[cfg(feature = "id3v1")]
 	#[lofty(tag_type = "ID3v1")]
 	pub(crate) id3v1_tag: Option<ID3v1Tag>,
 	/// An ID3v2 tag (Not officially supported)

--- a/src/ape/mod.rs
+++ b/src/ape/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod constants;
 pub(crate) mod header;
 mod properties;
 mod read;
+pub(crate) mod tag;
 
 use crate::id3::v1::tag::ID3v1Tag;
 #[cfg(feature = "id3v2")]
@@ -18,17 +19,10 @@ use lofty_attr::LoftyFile;
 
 // Exports
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "ape")] {
-		pub(crate) mod tag;
-		pub use tag::ApeTag;
-		pub use tag::item::ApeItem;
-
-		pub use crate::picture::APE_PICTURE_TYPES;
-	}
-}
-
+pub use crate::picture::APE_PICTURE_TYPES;
 pub use properties::ApeProperties;
+pub use tag::item::ApeItem;
+pub use tag::ApeTag;
 
 /// An APE file
 #[derive(LoftyFile)]
@@ -43,7 +37,6 @@ pub struct ApeFile {
 	#[lofty(tag_type = "ID3v2")]
 	pub(crate) id3v2_tag: Option<ID3v2Tag>,
 	/// An APEv1/v2 tag
-	#[cfg(feature = "ape")]
 	#[lofty(tag_type = "APE")]
 	pub(crate) ape_tag: Option<ApeTag>,
 	/// The file's audio properties

--- a/src/ape/read.rs
+++ b/src/ape/read.rs
@@ -4,7 +4,6 @@ use super::header::read_ape_header;
 use super::tag::{read::read_ape_tag, ApeTag};
 use super::{ApeFile, ApeProperties};
 use crate::error::Result;
-#[cfg(feature = "id3v1")]
 use crate::id3::v1::tag::ID3v1Tag;
 #[cfg(feature = "id3v2")]
 use crate::id3::v2::{read::parse_id3v2, tag::ID3v2Tag};
@@ -27,7 +26,6 @@ where
 
 	#[cfg(feature = "id3v2")]
 	let mut id3v2_tag: Option<ID3v2Tag> = None;
-	#[cfg(feature = "id3v1")]
 	let mut id3v1_tag: Option<ID3v1Tag> = None;
 	#[cfg(feature = "ape")]
 	let mut ape_tag: Option<ApeTag> = None;
@@ -107,10 +105,7 @@ where
 
 	if id3v1_header.is_some() {
 		stream_len -= 128;
-		#[cfg(feature = "id3v1")]
-		{
-			id3v1_tag = id3v1;
-		}
+		id3v1_tag = id3v1;
 	}
 
 	// Next, check for a Lyrics3v2 tag, and skip over it, as it's no use to us
@@ -150,7 +145,6 @@ where
 	data.seek(SeekFrom::Start(mac_start))?;
 
 	Ok(ApeFile {
-		#[cfg(feature = "id3v1")]
 		id3v1_tag,
 		#[cfg(feature = "id3v2")]
 		id3v2_tag,

--- a/src/ape/read.rs
+++ b/src/ape/read.rs
@@ -5,8 +5,8 @@ use super::tag::ApeTag;
 use super::{ApeFile, ApeProperties};
 use crate::error::Result;
 use crate::id3::v1::tag::ID3v1Tag;
-#[cfg(feature = "id3v2")]
-use crate::id3::v2::{read::parse_id3v2, tag::ID3v2Tag};
+use crate::id3::v2::read::parse_id3v2;
+use crate::id3::v2::tag::ID3v2Tag;
 use crate::id3::{find_id3v1, find_id3v2, find_lyrics3v2, ID3FindResults};
 use crate::macros::decode_err;
 use crate::probe::ParseOptions;
@@ -24,7 +24,6 @@ where
 
 	let mut stream_len = end - start;
 
-	#[cfg(feature = "id3v2")]
 	let mut id3v2_tag: Option<ID3v2Tag> = None;
 	let mut id3v1_tag: Option<ID3v1Tag> = None;
 	let mut ape_tag: Option<ApeTag> = None;
@@ -39,13 +38,10 @@ where
 			stream_len -= 10;
 		}
 
-		#[cfg(feature = "id3v2")]
-		{
-			let reader = &mut &*content;
+		let reader = &mut &*content;
 
-			let id3v2 = parse_id3v2(reader, header)?;
-			id3v2_tag = Some(id3v2)
-		}
+		let id3v2 = parse_id3v2(reader, header)?;
+		id3v2_tag = Some(id3v2);
 	}
 
 	let mut found_mac = false;
@@ -133,7 +129,6 @@ where
 
 	Ok(ApeFile {
 		id3v1_tag,
-		#[cfg(feature = "id3v2")]
 		id3v2_tag,
 		ape_tag,
 		properties: if parse_options.read_properties {

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,21 +70,16 @@ pub enum ErrorKind {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum ID3v2ErrorKind {
-	#[cfg(feature = "id3v2")]
 	/// Arises when an invalid picture format is parsed. Only applicable to [`ID3v2Version::V2`](crate::id3::v2::ID3v2Version::V2)
 	BadPictureFormat(String),
 	/// Arises when an invalid ID3v2 version is found
 	BadId3v2Version(u8, u8),
-	#[cfg(feature = "id3v2")]
 	/// Arises when a frame ID contains invalid characters (must be within `'A'..'Z'` or `'0'..'9'`)
 	BadFrameID,
-	#[cfg(feature = "id3v2")]
 	/// Arises when a frame doesn't have enough data
 	BadFrameLength,
-	#[cfg(feature = "id3v2")]
 	/// Arises when invalid data is encountered while reading an ID3v2 synchronized text frame
 	BadSyncText,
-	#[cfg(feature = "id3v2")]
 	/// Arises when attempting to write an invalid Frame (Bad `FrameID`/`FrameValue` pairing)
 	BadFrame(String, &'static str),
 	/// A catch-all for all remaining errors
@@ -101,22 +96,17 @@ impl Display for ID3v2ErrorKind {
 				"Found an invalid version (v{major}.{minor}), expected any major revision in: (2, \
 				 3, 4)"
 			),
-			#[cfg(feature = "id3v2")]
 			ID3v2ErrorKind::BadFrameID => write!(f, "Failed to parse a frame ID"),
-			#[cfg(feature = "id3v2")]
 			ID3v2ErrorKind::BadFrameLength => write!(
 				f,
 				"Frame isn't long enough to extract the necessary information"
 			),
-			#[cfg(feature = "id3v2")]
 			ID3v2ErrorKind::BadSyncText => write!(f, "Encountered invalid data in SYLT frame"),
-			#[cfg(feature = "id3v2")]
 			ID3v2ErrorKind::BadFrame(ref frame_id, frame_value) => write!(
 				f,
 				"Attempted to write an invalid frame. ID: \"{}\", Value: \"{}\"",
 				frame_id, frame_value
 			),
-			#[cfg(feature = "id3v2")]
 			ID3v2ErrorKind::BadPictureFormat(format) => {
 				write!(f, "Picture: Found unexpected format \"{format}\"")
 			},

--- a/src/file.rs
+++ b/src/file.rs
@@ -836,7 +836,6 @@ impl FileType {
 			FileType::Opus | FileType::FLAC | FileType::Vorbis | FileType::Speex => {
 				tag_type == TagType::VorbisComments
 			},
-			#[cfg(feature = "mp4_ilst")]
 			FileType::MP4 => tag_type == TagType::MP4ilst,
 			#[cfg(feature = "riff_info_list")]
 			FileType::WAV => tag_type == TagType::RIFFInfo,

--- a/src/file.rs
+++ b/src/file.rs
@@ -823,7 +823,6 @@ impl FileType {
 			{
 				true
 			},
-			#[cfg(feature = "aiff_text_chunks")]
 			FileType::AIFF if tag_type == TagType::AIFFText => true,
 			FileType::APE | FileType::MPEG | FileType::WavPack | FileType::AAC
 				if tag_type == TagType::ID3v1 =>

--- a/src/file.rs
+++ b/src/file.rs
@@ -834,7 +834,6 @@ impl FileType {
 				tag_type == TagType::VorbisComments
 			},
 			FileType::MP4 => tag_type == TagType::MP4ilst,
-			#[cfg(feature = "riff_info_list")]
 			FileType::WAV => tag_type == TagType::RIFFInfo,
 			FileType::Custom(c) => {
 				let resolver = crate::resolve::lookup_resolver(c);

--- a/src/file.rs
+++ b/src/file.rs
@@ -830,7 +830,6 @@ impl FileType {
 			{
 				true
 			},
-			#[cfg(feature = "ape")]
 			FileType::APE | FileType::MPEG | FileType::WavPack if tag_type == TagType::APE => true,
 			FileType::Opus | FileType::FLAC | FileType::Vorbis | FileType::Speex => {
 				tag_type == TagType::VorbisComments

--- a/src/file.rs
+++ b/src/file.rs
@@ -825,7 +825,6 @@ impl FileType {
 			},
 			#[cfg(feature = "aiff_text_chunks")]
 			FileType::AIFF if tag_type == TagType::AIFFText => true,
-			#[cfg(feature = "id3v1")]
 			FileType::APE | FileType::MPEG | FileType::WavPack | FileType::AAC
 				if tag_type == TagType::ID3v1 =>
 			{

--- a/src/file.rs
+++ b/src/file.rs
@@ -817,7 +817,6 @@ impl FileType {
 	/// ```
 	pub fn supports_tag_type(&self, tag_type: TagType) -> bool {
 		match self {
-			#[cfg(feature = "id3v2")]
 			FileType::AIFF | FileType::APE | FileType::MPEG | FileType::WAV | FileType::AAC
 				if tag_type == TagType::ID3v2 =>
 			{

--- a/src/file.rs
+++ b/src/file.rs
@@ -833,7 +833,6 @@ impl FileType {
 			},
 			#[cfg(feature = "ape")]
 			FileType::APE | FileType::MPEG | FileType::WavPack if tag_type == TagType::APE => true,
-			#[cfg(feature = "vorbis_comments")]
 			FileType::Opus | FileType::FLAC | FileType::Vorbis | FileType::Speex => {
 				tag_type == TagType::VorbisComments
 			},

--- a/src/flac/mod.rs
+++ b/src/flac/mod.rs
@@ -9,7 +9,6 @@ pub(crate) mod properties;
 mod read;
 pub(crate) mod write;
 
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
 use crate::ogg::VorbisComments;
 use crate::properties::FileProperties;
@@ -29,7 +28,6 @@ use lofty_attr::LoftyFile;
 #[lofty(read_fn = "read::read_from")]
 pub struct FlacFile {
 	/// An ID3v2 tag
-	#[cfg(feature = "id3v2")]
 	#[lofty(tag_type = "ID3v2")]
 	pub(crate) id3v2_tag: Option<ID3v2Tag>,
 	/// The vorbis comments contained in the file

--- a/src/flac/mod.rs
+++ b/src/flac/mod.rs
@@ -7,12 +7,10 @@
 pub(crate) mod block;
 pub(crate) mod properties;
 mod read;
-#[cfg(feature = "vorbis_comments")]
 pub(crate) mod write;
 
 #[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
-#[cfg(feature = "vorbis_comments")]
 use crate::ogg::VorbisComments;
 use crate::properties::FileProperties;
 
@@ -37,7 +35,6 @@ pub struct FlacFile {
 	/// The vorbis comments contained in the file
 	///
 	/// NOTE: This field being `Some` does not mean the file has vorbis comments, as Picture blocks exist.
-	#[cfg(feature = "vorbis_comments")]
 	#[lofty(tag_type = "VorbisComments")]
 	pub(crate) vorbis_comments_tag: Option<VorbisComments>,
 	/// The file's audio properties

--- a/src/flac/read.rs
+++ b/src/flac/read.rs
@@ -1,7 +1,6 @@
 use super::block::Block;
 use super::FlacFile;
 use crate::error::Result;
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::read::parse_id3v2;
 use crate::id3::{find_id3v2, ID3FindResults};
 use crate::macros::decode_err;
@@ -38,7 +37,6 @@ where
 	R: Read + Seek,
 {
 	let mut flac_file = FlacFile {
-		#[cfg(feature = "id3v2")]
 		id3v2_tag: None,
 		vorbis_comments_tag: None,
 		properties: FileProperties::default(),
@@ -46,13 +44,10 @@ where
 
 	// It is possible for a FLAC file to contain an ID3v2 tag
 	if let ID3FindResults(Some(header), Some(content)) = find_id3v2(data, true)? {
-		#[cfg(feature = "id3v2")]
-		{
-			let reader = &mut &*content;
+		let reader = &mut &*content;
 
-			let id3v2 = parse_id3v2(reader, header)?;
-			flac_file.id3v2_tag = Some(id3v2)
-		}
+		let id3v2 = parse_id3v2(reader, header)?;
+		flac_file.id3v2_tag = Some(id3v2);
 	}
 
 	let stream_info = verify_flac(data)?;

--- a/src/id3/mod.rs
+++ b/src/id3/mod.rs
@@ -45,16 +45,11 @@ where
 	Ok(ID3FindResults(header, size))
 }
 
-#[cfg(feature = "id3v1")]
-pub(crate) type FindID3v1Content = Option<v1::tag::ID3v1Tag>;
-#[cfg(not(feature = "id3v1"))]
-pub(crate) type FindID3v1Content = Option<()>;
-
 #[allow(unused_variables)]
 pub(crate) fn find_id3v1<R>(
 	data: &mut R,
 	read: bool,
-) -> Result<ID3FindResults<(), FindID3v1Content>>
+) -> Result<ID3FindResults<(), Option<v1::tag::ID3v1Tag>>>
 where
 	R: Read + Seek,
 {
@@ -71,7 +66,6 @@ where
 	if &id3v1_header == b"TAG" {
 		header = Some(());
 
-		#[cfg(feature = "id3v1")]
 		if read {
 			let mut id3v1_tag = [0; 128];
 			data.read_exact(&mut id3v1_tag)?;

--- a/src/id3/v1/constants.rs
+++ b/src/id3/v1/constants.rs
@@ -1,5 +1,4 @@
 /// All possible genres for ID3v1
-#[cfg(any(feature = "id3v1"))]
 pub const GENRES: [&str; 192] = [
 	"Blues",
 	"Classic rock",
@@ -195,18 +194,13 @@ pub const GENRES: [&str; 192] = [
 	"Psybient",
 ];
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "id3v1")] {
-		use crate::tag::item::ItemKey;
-
-		pub(crate) const VALID_ITEMKEYS: [ItemKey; 7] = [
-			ItemKey::TrackTitle,
-			ItemKey::TrackArtist,
-			ItemKey::AlbumTitle,
-			ItemKey::Year,
-			ItemKey::Comment,
-			ItemKey::TrackNumber,
-			ItemKey::Genre,
-		];
-	}
-}
+use crate::tag::item::ItemKey;
+pub(crate) const VALID_ITEMKEYS: [ItemKey; 7] = [
+	ItemKey::TrackTitle,
+	ItemKey::TrackArtist,
+	ItemKey::AlbumTitle,
+	ItemKey::Year,
+	ItemKey::Comment,
+	ItemKey::TrackNumber,
+	ItemKey::Genre,
+];

--- a/src/id3/v1/constants.rs
+++ b/src/id3/v1/constants.rs
@@ -1,5 +1,5 @@
 /// All possible genres for ID3v1
-#[cfg(any(feature = "id3v1", feature = "mp4_ilst"))]
+#[cfg(any(feature = "id3v1"))]
 pub const GENRES: [&str; 192] = [
 	"Blues",
 	"Classic rock",

--- a/src/id3/v1/mod.rs
+++ b/src/id3/v1/mod.rs
@@ -15,15 +15,11 @@
 //! A track number of 0 will be treated as an empty field.
 //! Additionally, there is no track total field.
 pub(crate) mod constants;
+pub(crate) mod read;
+pub(crate) mod tag;
+pub(crate) mod write;
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "id3v1")] {
-		pub use constants::GENRES;
+// Exports
 
-		pub(crate) mod tag;
-		pub use tag::ID3v1Tag;
-
-		pub(crate) mod read;
-		pub(crate) mod write;
-	}
-}
+pub use constants::GENRES;
+pub use tag::ID3v1Tag;

--- a/src/id3/v2/flags.rs
+++ b/src/id3/v2/flags.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "id3v2_restrictions")]
 use super::restrictions::TagRestrictions;
 
 /// Flags that apply to the entire tag
@@ -17,7 +16,6 @@ pub struct ID3v2TagFlags {
 	///
 	/// This is calculated if the tag is written
 	pub crc: bool,
-	#[cfg(feature = "id3v2_restrictions")]
 	/// Restrictions on the tag, written in the extended header
 	///
 	/// In addition to being setting this flag, all restrictions must be provided. See [`TagRestrictions`]

--- a/src/id3/v2/frame/read.rs
+++ b/src/id3/v2/frame/read.rs
@@ -31,6 +31,7 @@ impl Frame {
 			content = crate::id3::v2::util::unsynch_content(content.as_slice())?;
 		}
 
+		#[cfg(feature = "id3v2_compression_support")]
 		if flags.compression {
 			let mut decompressed = Vec::new();
 			flate2::Decompress::new(true)
@@ -42,6 +43,11 @@ impl Frame {
 				})?;
 
 			content = decompressed
+		}
+
+		#[cfg(not(feature = "id3v2_compression_support"))]
+		if flags.compression {
+			crate::macros::decode_err!(@BAIL ID3v2, "Encountered a compressed ID3v2 frame, support is disabled")
 		}
 
 		let mut content_reader = &*content;

--- a/src/id3/v2/util/mod.rs
+++ b/src/id3/v2/util/mod.rs
@@ -1,74 +1,70 @@
 //! Utilities for working with ID3v2 tags
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "id3v2")] {
-		pub(crate) mod upgrade;
+pub(crate) mod upgrade;
 
-		use crate::error::{ID3v2Error, ID3v2ErrorKind, Result};
+use crate::error::{ID3v2Error, ID3v2ErrorKind, Result};
 
-		pub(in crate::id3::v2) fn unsynch_content(content: &[u8]) -> Result<Vec<u8>> {
-			let mut unsynch_content = Vec::new();
+pub(in crate::id3::v2) fn unsynch_content(content: &[u8]) -> Result<Vec<u8>> {
+	let mut unsynch_content = Vec::new();
 
-			let mut discard = false;
+	let mut discard = false;
 
-			let mut i = 0;
-			let mut next = 0;
-			let content_len = content.len();
+	let mut i = 0;
+	let mut next = 0;
+	let content_len = content.len();
 
-			// Check for (0xFF, 0x00, 0x00), replace with (0xFF, 0x00)
-			while i < content_len && next < content_len {
-				// Verify the next byte is less than 0xE0 (0b111xxxxx)
-				// Then remove the next byte if it is a zero
-				if discard {
-					if content[next] >= 0xE0 {
-						return Err(ID3v2Error::new(ID3v2ErrorKind::Other(
-							"Encountered an invalid unsynchronisation",
-						))
-						.into());
-					}
+	// Check for (0xFF, 0x00, 0x00), replace with (0xFF, 0x00)
+	while i < content_len && next < content_len {
+		// Verify the next byte is less than 0xE0 (0b111xxxxx)
+		// Then remove the next byte if it is a zero
+		if discard {
+			if content[next] >= 0xE0 {
+				return Err(ID3v2Error::new(ID3v2ErrorKind::Other(
+					"Encountered an invalid unsynchronisation",
+				))
+				.into());
+			}
 
-					if content[next] == 0 {
-						discard = false;
-						next += 1;
-
-						continue;
-					}
-				}
-
+			if content[next] == 0 {
 				discard = false;
-
-				unsynch_content.push(content[next]);
-
-				if content[next] == 0xFF {
-					discard = true
-				}
-
-				i += 1;
 				next += 1;
-			}
 
-			Ok(unsynch_content)
+				continue;
+			}
 		}
 
-		/// Create a synchsafe integer
-		///
-		/// See [`FrameFlags::unsynchronisation`](crate::id3::v2::FrameFlags::unsynchronisation) for an explanation.
-		///
-		/// # Errors
-		///
-		/// `n` doesn't fit in 28 bits
-		// https://github.com/polyfloyd/rust-id3/blob/e142ec656bf70a8153f6e5b34a37f26df144c3c1/src/stream/unsynch.rs#L9-L15
-		pub fn synch_u32(n: u32) -> Result<u32> {
-			if n > 0x1000_0000 {
-				crate::macros::err!(TooMuchData);
-			}
+		discard = false;
 
-			let mut x: u32 = n & 0x7F | (n & 0xFFFF_FF80) << 1;
-			x = x & 0x7FFF | (x & 0xFFFF_8000) << 1;
-			x = x & 0x7F_FFFF | (x & 0xFF80_0000) << 1;
-			Ok(x)
+		unsynch_content.push(content[next]);
+
+		if content[next] == 0xFF {
+			discard = true
 		}
+
+		i += 1;
+		next += 1;
 	}
+
+	Ok(unsynch_content)
+}
+
+/// Create a synchsafe integer
+///
+/// See [`FrameFlags::unsynchronisation`](crate::id3::v2::FrameFlags::unsynchronisation) for an explanation.
+///
+/// # Errors
+///
+/// `n` doesn't fit in 28 bits
+// https://github.com/polyfloyd/rust-id3/blob/e142ec656bf70a8153f6e5b34a37f26df144c3c1/src/stream/unsynch.rs#L9-L15
+pub fn synch_u32(n: u32) -> Result<u32> {
+	if n > 0x1000_0000 {
+		crate::macros::err!(TooMuchData);
+	}
+
+	let mut x: u32 = n & 0x7F | (n & 0xFFFF_FF80) << 1;
+	x = x & 0x7FFF | (x & 0xFFFF_8000) << 1;
+	x = x & 0x7F_FFFF | (x & 0xFF80_0000) << 1;
+	Ok(x)
 }
 
 /// Unsynchronise a synchsafe integer

--- a/src/id3/v2/write/mod.rs
+++ b/src/id3/v2/write/mod.rs
@@ -105,7 +105,6 @@ pub(super) fn create_tag<'a, I: Iterator<Item = FrameRef<'a>> + 'a>(
 
 	let has_footer = tag.flags.footer;
 	let needs_crc = tag.flags.crc;
-	#[cfg(feature = "id3v2_restrictions")]
 	let has_restrictions = tag.flags.restrictions.is_some();
 
 	let (mut id3v2, extended_header_len) = create_tag_header(tag.flags)?;
@@ -126,7 +125,6 @@ pub(super) fn create_tag<'a, I: Iterator<Item = FrameRef<'a>> + 'a>(
 		// Past the CRC
 		let mut content_start_idx = 22;
 
-		#[cfg(feature = "id3v2_restrictions")]
 		if has_restrictions {
 			content_start_idx += 3;
 		}
@@ -169,10 +167,6 @@ fn create_tag_header(flags: ID3v2TagFlags) -> Result<(Cursor<Vec<u8>>, u32)> {
 	// Version 4, rev 0
 	header.write_all(&[4, 0])?;
 
-	#[cfg(not(feature = "id3v2_restrictions"))]
-	let extended_header = flags.crc;
-
-	#[cfg(feature = "id3v2_restrictions")]
 	let extended_header = flags.crc || flags.restrictions.is_some();
 
 	if flags.footer {
@@ -212,7 +206,6 @@ fn create_tag_header(flags: ID3v2TagFlags) -> Result<(Cursor<Vec<u8>>, u32)> {
 			header.write_all(&[0; 6])?;
 		}
 
-		#[cfg(feature = "id3v2_restrictions")]
 		if let Some(restrictions) = flags.restrictions {
 			ext_flags |= 0x10;
 			extended_header_size += 2;

--- a/src/iff/aiff/mod.rs
+++ b/src/iff/aiff/mod.rs
@@ -2,6 +2,7 @@
 
 mod properties;
 mod read;
+pub(crate) mod tag;
 
 #[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
@@ -11,13 +12,7 @@ use lofty_attr::LoftyFile;
 
 // Exports
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "aiff_text_chunks")] {
-		pub(crate) mod tag;
-		pub use tag::AIFFTextChunks;
-		pub use tag::Comment;
-	}
-}
+pub use tag::{AIFFTextChunks, Comment};
 
 /// An AIFF file
 #[derive(LoftyFile)]
@@ -25,7 +20,6 @@ cfg_if::cfg_if! {
 #[lofty(internal_write_module_do_not_use_anywhere_else)]
 pub struct AiffFile {
 	/// Any text chunks included in the file
-	#[cfg(feature = "aiff_text_chunks")]
 	#[lofty(tag_type = "AIFFText")]
 	pub(crate) text_chunks_tag: Option<AIFFTextChunks>,
 	/// An ID3v2 tag

--- a/src/iff/aiff/mod.rs
+++ b/src/iff/aiff/mod.rs
@@ -4,7 +4,6 @@ mod properties;
 mod read;
 pub(crate) mod tag;
 
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
 use crate::properties::FileProperties;
 
@@ -23,7 +22,6 @@ pub struct AiffFile {
 	#[lofty(tag_type = "AIFFText")]
 	pub(crate) text_chunks_tag: Option<AIFFTextChunks>,
 	/// An ID3v2 tag
-	#[cfg(feature = "id3v2")]
 	#[lofty(tag_type = "ID3v2")]
 	pub(crate) id3v2_tag: Option<ID3v2Tag>,
 	/// The file's audio properties

--- a/src/iff/aiff/read.rs
+++ b/src/iff/aiff/read.rs
@@ -1,7 +1,6 @@
 use super::tag::{AIFFTextChunks, Comment};
 use super::AiffFile;
 use crate::error::Result;
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
 use crate::iff::chunk::Chunks;
 use crate::macros::{decode_err, err};
@@ -46,14 +45,12 @@ where
 	let mut annotations = Vec::new();
 	let mut comments = Vec::new();
 
-	#[cfg(feature = "id3v2")]
 	let mut id3v2_tag: Option<ID3v2Tag> = None;
 
 	let mut chunks = Chunks::<BigEndian>::new(file_len);
 
 	while chunks.next(data).is_ok() {
 		match &chunks.fourcc {
-			#[cfg(feature = "id3v2")]
 			b"ID3 " | b"id3 " => {
 				let tag = chunks.id3_chunk(data)?;
 				if let Some(existing_tag) = id3v2_tag.as_mut() {
@@ -159,7 +156,6 @@ where
 			} => None,
 			_ => Some(text_chunks),
 		},
-		#[cfg(feature = "id3v2")]
 		id3v2_tag,
 	})
 }

--- a/src/iff/chunk.rs
+++ b/src/iff/chunk.rs
@@ -52,7 +52,6 @@ impl<B: ByteOrder> Chunks<B> {
 		Ok(value_str.trim_end_matches('\0').to_string())
 	}
 
-	#[cfg(feature = "aiff_text_chunks")]
 	pub fn read_pstring<R>(&mut self, data: &mut R, size: Option<u32>) -> Result<String>
 	where
 		R: Read + Seek,

--- a/src/iff/chunk.rs
+++ b/src/iff/chunk.rs
@@ -1,5 +1,4 @@
 use crate::error::Result;
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
 use crate::macros::{err, try_vec};
 
@@ -91,7 +90,6 @@ impl<B: ByteOrder> Chunks<B> {
 		Ok(content)
 	}
 
-	#[cfg(feature = "id3v2")]
 	pub fn id3_chunk<R>(&mut self, data: &mut R) -> Result<ID3v2Tag>
 	where
 		R: Read + Seek,

--- a/src/iff/wav/mod.rs
+++ b/src/iff/wav/mod.rs
@@ -4,7 +4,6 @@ mod properties;
 mod read;
 pub(crate) mod tag;
 
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
 
 use lofty_attr::LoftyFile;
@@ -22,7 +21,6 @@ pub struct WavFile {
 	#[lofty(tag_type = "RIFFInfo")]
 	pub(crate) riff_info_tag: Option<RIFFInfoList>,
 	/// An ID3v2 tag
-	#[cfg(feature = "id3v2")]
 	#[lofty(tag_type = "ID3v2")]
 	pub(crate) id3v2_tag: Option<ID3v2Tag>,
 	/// The file's audio properties

--- a/src/iff/wav/mod.rs
+++ b/src/iff/wav/mod.rs
@@ -2,6 +2,7 @@
 
 mod properties;
 mod read;
+pub(crate) mod tag;
 
 #[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
@@ -10,13 +11,7 @@ use lofty_attr::LoftyFile;
 
 // Exports
 pub use crate::iff::wav::properties::{WavFormat, WavProperties};
-
-cfg_if::cfg_if! {
-	if #[cfg(feature = "riff_info_list")] {
-		pub(crate) mod tag;
-		pub use tag::RIFFInfoList;
-	}
-}
+pub use tag::RIFFInfoList;
 
 /// A WAV file
 #[derive(LoftyFile)]
@@ -24,7 +19,6 @@ cfg_if::cfg_if! {
 #[lofty(internal_write_module_do_not_use_anywhere_else)]
 pub struct WavFile {
 	/// A RIFF INFO LIST
-	#[cfg(feature = "riff_info_list")]
 	#[lofty(tag_type = "RIFFInfo")]
 	pub(crate) riff_info_tag: Option<RIFFInfoList>,
 	/// An ID3v2 tag

--- a/src/iff/wav/read.rs
+++ b/src/iff/wav/read.rs
@@ -2,7 +2,6 @@ use super::properties::WavProperties;
 use super::tag::RIFFInfoList;
 use super::WavFile;
 use crate::error::Result;
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
 use crate::iff::chunk::Chunks;
 use crate::macros::decode_err;
@@ -46,7 +45,6 @@ where
 	let mut fmt = Vec::new();
 
 	let mut riff_info = RIFFInfoList::default();
-	#[cfg(feature = "id3v2")]
 	let mut id3v2_tag: Option<ID3v2Tag> = None;
 
 	let mut chunks = Chunks::<LittleEndian>::new(file_len);
@@ -89,7 +87,6 @@ where
 					},
 				}
 			},
-			#[cfg(feature = "id3v2")]
 			b"ID3 " | b"id3 " => {
 				let tag = chunks.id3_chunk(data)?;
 				if let Some(existing_tag) = id3v2_tag.as_mut() {
@@ -125,7 +122,6 @@ where
 	Ok(WavFile {
 		properties,
 		riff_info_tag: (!riff_info.items.is_empty()).then_some(riff_info),
-		#[cfg(feature = "id3v2")]
 		id3v2_tag,
 	})
 }

--- a/src/iff/wav/read.rs
+++ b/src/iff/wav/read.rs
@@ -1,5 +1,4 @@
 use super::properties::WavProperties;
-#[cfg(feature = "riff_info_list")]
 use super::tag::RIFFInfoList;
 use super::WavFile;
 use crate::error::Result;
@@ -46,7 +45,6 @@ where
 	let mut total_samples = 0_u32;
 	let mut fmt = Vec::new();
 
-	#[cfg(feature = "riff_info_list")]
 	let mut riff_info = RIFFInfoList::default();
 	#[cfg(feature = "id3v2")]
 	let mut id3v2_tag: Option<ID3v2Tag> = None;
@@ -81,7 +79,6 @@ where
 				data.read_exact(&mut list_type)?;
 
 				match &list_type {
-					#[cfg(feature = "riff_info_list")]
 					b"INFO" => {
 						let end = data.stream_position()? + u64::from(chunks.size - 4);
 						super::tag::read::parse_riff_info(data, &mut chunks, end, &mut riff_info)?;
@@ -127,7 +124,6 @@ where
 
 	Ok(WavFile {
 		properties,
-		#[cfg(feature = "riff_info_list")]
 		riff_info_tag: (!riff_info.items.is_empty()).then_some(riff_info),
 		#[cfg(feature = "id3v2")]
 		id3v2_tag,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,6 @@ pub use util::text::TextEncoding;
 
 pub use crate::traits::{Accessor, TagExt};
 
-#[cfg(feature = "vorbis_comments")]
 pub use picture::PictureInformation;
 
 pub use lofty_attr::LoftyFile;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,22 +94,6 @@
 //! # }
 //! ```
 //!
-//! # Features
-//!
-//! ## Individual metadata formats
-//! These features are available if you have a specific use case, or just don't want certain formats.
-//!
-//! * `aiff_text_chunks`
-//! * `ape`
-//! * `id3v1`
-//! * `id3v2`
-//! * `mp4_ilst`
-//! * `riff_info_list`
-//! * `vorbis_comments`
-//!
-//! ## Utilities
-//! * `id3v2_restrictions` - Parses ID3v2 extended headers and exposes flags for fine grained control
-//!
 //! # Important format-specific notes
 //!
 //! All formats have their own quirks that may produce unexpected results between conversions.

--- a/src/mp4/mod.rs
+++ b/src/mp4/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! The only supported tag format is [`Ilst`].
 mod atom_info;
+pub(crate) mod ilst;
 mod moov;
 mod properties;
 mod read;
@@ -12,24 +13,17 @@ use lofty_attr::LoftyFile;
 
 // Exports
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "mp4_ilst")] {
-		pub(crate) mod ilst;
-
-		pub use atom_info::AtomIdent;
-		pub use ilst::atom::{Atom, AtomData, AdvisoryRating};
-		pub use ilst::Ilst;
-
-		/// This module contains the codes for all of the [Well-known data types]
-		///
-		/// [Well-known data types]: https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/Metadata/Metadata.html#//apple_ref/doc/uid/TP40000939-CH1-SW34
-		pub mod constants {
-			pub use super::ilst::constants::*;
-		}
-	}
+/// This module contains the codes for all of the [Well-known data types]
+///
+/// [Well-known data types]: https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/Metadata/Metadata.html#//apple_ref/doc/uid/TP40000939-CH1-SW34
+pub mod constants {
+	pub use super::ilst::constants::*;
 }
 
 pub use crate::mp4::properties::{AudioObjectType, Mp4Codec, Mp4Properties};
+pub use atom_info::AtomIdent;
+pub use ilst::atom::{AdvisoryRating, Atom, AtomData};
+pub use ilst::Ilst;
 
 pub(crate) use properties::SAMPLE_RATES;
 
@@ -39,7 +33,6 @@ pub(crate) use properties::SAMPLE_RATES;
 pub struct Mp4File {
 	/// The file format from ftyp's "major brand" (Ex. "M4A ")
 	pub(crate) ftyp: String,
-	#[cfg(feature = "mp4_ilst")]
 	#[lofty(tag_type = "MP4ilst")]
 	/// The parsed `ilst` (metadata) atom, if it exists
 	pub(crate) ilst_tag: Option<Ilst>,

--- a/src/mp4/read.rs
+++ b/src/mp4/read.rs
@@ -163,7 +163,6 @@ where
 
 	Ok(Mp4File {
 		ftyp,
-		#[cfg(feature = "mp4_ilst")]
 		ilst_tag: moov.meta,
 		properties: if parse_options.read_properties {
 			super::properties::read_properties(&mut reader, &moov.traks, file_length)?
@@ -220,7 +219,6 @@ where
 	Ok(ret)
 }
 
-#[cfg(feature = "mp4_ilst")]
 // Creates a tree of nested atoms
 pub(super) fn atom_tree<R>(
 	reader: &mut R,
@@ -257,7 +255,6 @@ where
 	Ok((found_idx, buf))
 }
 
-#[cfg(feature = "mp4_ilst")]
 pub(super) fn meta_is_full<R>(reader: &mut R) -> Result<bool>
 where
 	R: Read + Seek,

--- a/src/mpeg/mod.rs
+++ b/src/mpeg/mod.rs
@@ -9,7 +9,6 @@ pub use properties::MPEGProperties;
 
 use crate::ape::tag::ApeTag;
 use crate::id3::v1::tag::ID3v1Tag;
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
 
 use lofty_attr::LoftyFile;
@@ -20,7 +19,6 @@ use lofty_attr::LoftyFile;
 #[lofty(internal_write_module_do_not_use_anywhere_else)]
 pub struct MPEGFile {
 	/// An ID3v2 tag
-	#[cfg(feature = "id3v2")]
 	#[lofty(tag_type = "ID3v2")]
 	pub(crate) id3v2_tag: Option<ID3v2Tag>,
 	/// An ID3v1 tag

--- a/src/mpeg/mod.rs
+++ b/src/mpeg/mod.rs
@@ -7,7 +7,6 @@ mod read;
 pub use header::{ChannelMode, Emphasis, Layer, MpegVersion};
 pub use properties::MPEGProperties;
 
-#[cfg(feature = "ape")]
 use crate::ape::tag::ApeTag;
 use crate::id3::v1::tag::ID3v1Tag;
 #[cfg(feature = "id3v2")]
@@ -28,7 +27,6 @@ pub struct MPEGFile {
 	#[lofty(tag_type = "ID3v1")]
 	pub(crate) id3v1_tag: Option<ID3v1Tag>,
 	/// An APEv1/v2 tag
-	#[cfg(feature = "ape")]
 	#[lofty(tag_type = "APE")]
 	pub(crate) ape_tag: Option<ApeTag>,
 	/// The file's audio properties

--- a/src/mpeg/mod.rs
+++ b/src/mpeg/mod.rs
@@ -9,7 +9,6 @@ pub use properties::MPEGProperties;
 
 #[cfg(feature = "ape")]
 use crate::ape::tag::ApeTag;
-#[cfg(feature = "id3v1")]
 use crate::id3::v1::tag::ID3v1Tag;
 #[cfg(feature = "id3v2")]
 use crate::id3::v2::tag::ID3v2Tag;
@@ -26,7 +25,6 @@ pub struct MPEGFile {
 	#[lofty(tag_type = "ID3v2")]
 	pub(crate) id3v2_tag: Option<ID3v2Tag>,
 	/// An ID3v1 tag
-	#[cfg(feature = "id3v1")]
 	#[lofty(tag_type = "ID3v1")]
 	pub(crate) id3v1_tag: Option<ID3v1Tag>,
 	/// An APEv1/v2 tag

--- a/src/mpeg/read.rs
+++ b/src/mpeg/read.rs
@@ -4,7 +4,6 @@ use crate::ape::constants::APE_PREAMBLE;
 use crate::ape::header::read_ape_header;
 use crate::ape::tag::read::read_ape_tag;
 use crate::error::Result;
-#[cfg(feature = "id3v2")]
 use crate::id3::v2::read::parse_id3v2;
 use crate::id3::v2::read_id3v2_header;
 use crate::id3::{find_id3v1, find_lyrics3v2, ID3FindResults};
@@ -42,19 +41,16 @@ where
 				let header = read_id3v2_header(reader)?;
 				let skip_footer = header.flags.footer;
 
-				#[cfg(feature = "id3v2")]
-				{
-					let id3v2 = parse_id3v2(reader, header)?;
-					if let Some(existing_tag) = &mut file.id3v2_tag {
-						// https://github.com/Serial-ATA/lofty-rs/issues/87
-						// Duplicate tags should have their frames appended to the previous
-						for frame in id3v2.frames {
-							existing_tag.insert(frame);
-						}
-						continue;
+				let id3v2 = parse_id3v2(reader, header)?;
+				if let Some(existing_tag) = &mut file.id3v2_tag {
+					// https://github.com/Serial-ATA/lofty-rs/issues/87
+					// Duplicate tags should have their frames appended to the previous
+					for frame in id3v2.frames {
+						existing_tag.insert(frame);
 					}
-					file.id3v2_tag = Some(id3v2);
+					continue;
 				}
+				file.id3v2_tag = Some(id3v2);
 
 				// Skip over the footer
 				if skip_footer {

--- a/src/mpeg/read.rs
+++ b/src/mpeg/read.rs
@@ -2,7 +2,6 @@ use super::header::{cmp_header, search_for_frame_sync, Header, HeaderCmpResult, 
 use super::{MPEGFile, MPEGProperties};
 use crate::ape::constants::APE_PREAMBLE;
 use crate::ape::header::read_ape_header;
-#[cfg(feature = "ape")]
 use crate::ape::tag::read::read_ape_tag;
 use crate::error::Result;
 #[cfg(feature = "id3v2")]
@@ -71,17 +70,7 @@ where
 				if &header_remaining == b"AGEX" {
 					let ape_header = read_ape_header(reader, false)?;
 
-					#[cfg(not(feature = "ape"))]
-					{
-						let size = ape_header.size;
-						reader.seek(SeekFrom::Current(size as i64))?;
-					}
-
-					#[cfg(feature = "ape")]
-					{
-						file.ape_tag =
-							Some(crate::ape::tag::read::read_ape_tag(reader, ape_header)?);
-					}
+					file.ape_tag = Some(crate::ape::tag::read::read_ape_tag(reader, ape_header)?);
 
 					continue;
 				}
@@ -124,11 +113,8 @@ where
 			let ape_header = read_ape_header(reader, true)?;
 			let size = ape_header.size;
 
-			#[cfg(feature = "ape")]
-			{
-				let ape = read_ape_tag(reader, ape_header)?;
-				file.ape_tag = Some(ape);
-			}
+			let ape = read_ape_tag(reader, ape_header)?;
+			file.ape_tag = Some(ape);
 
 			// Seek back to the start of the tag
 			let pos = reader.stream_position()?;

--- a/src/mpeg/read.rs
+++ b/src/mpeg/read.rs
@@ -108,7 +108,6 @@ where
 	#[allow(unused_variables)]
 	let ID3FindResults(header, id3v1) = find_id3v1(reader, true)?;
 
-	#[cfg(feature = "id3v1")]
 	if header.is_some() {
 		file.id3v1_tag = id3v1;
 	}

--- a/src/ogg/mod.rs
+++ b/src/ogg/mod.rs
@@ -7,7 +7,9 @@ pub(crate) mod constants;
 pub(crate) mod opus;
 pub(crate) mod read;
 pub(crate) mod speex;
+pub(crate) mod tag;
 pub(crate) mod vorbis;
+pub(crate) mod write;
 
 use crate::error::Result;
 use crate::macros::decode_err;
@@ -18,19 +20,11 @@ use ogg_pager::Page;
 
 // Exports
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "vorbis_comments")] {
-		pub(crate) mod write;
-
-		pub(crate) mod tag;
-		pub use tag::VorbisComments;
-	}
-}
-
 pub use opus::properties::OpusProperties;
 pub use opus::OpusFile;
 pub use speex::properties::SpeexProperties;
 pub use speex::SpeexFile;
+pub use tag::VorbisComments;
 pub use vorbis::properties::VorbisProperties;
 pub use vorbis::VorbisFile;
 

--- a/src/ogg/opus/mod.rs
+++ b/src/ogg/opus/mod.rs
@@ -1,7 +1,6 @@
 pub(super) mod properties;
 
 use super::find_last_page;
-#[cfg(feature = "vorbis_comments")]
 use super::tag::VorbisComments;
 use crate::error::Result;
 use crate::file::AudioFile;
@@ -21,7 +20,6 @@ pub struct OpusFile {
 	/// The vorbis comments contained in the file
 	///
 	/// NOTE: While a metadata packet is required, it isn't required to actually have any data.
-	#[cfg(feature = "vorbis_comments")]
 	#[lofty(tag_type = "VorbisComments")]
 	pub(crate) vorbis_comments_tag: VorbisComments,
 	/// The file's audio properties
@@ -38,8 +36,11 @@ impl AudioFile for OpusFile {
 		let file_information = super::read::read_from(reader, OPUSHEAD, OPUSTAGS, 2)?;
 
 		Ok(Self {
-			properties: if parse_options.read_properties { properties::read_properties(reader, file_information.1, &file_information.2)? } else { OpusProperties::default() },
-			#[cfg(feature = "vorbis_comments")]
+			properties: if parse_options.read_properties {
+				properties::read_properties(reader, file_information.1, &file_information.2)?
+			} else {
+				OpusProperties::default()
+			},
 			// Safe to unwrap, a metadata packet is mandatory in Opus
 			vorbis_comments_tag: file_information.0.unwrap(),
 		})

--- a/src/ogg/read.rs
+++ b/src/ogg/read.rs
@@ -1,24 +1,16 @@
-#[cfg(feature = "vorbis_comments")]
 use super::tag::VorbisComments;
 use super::verify_signature;
 use crate::error::Result;
 use crate::macros::{decode_err, err};
-#[cfg(feature = "vorbis_comments")]
 use crate::picture::Picture;
 
 use std::io::{Read, Seek, SeekFrom};
 
-#[cfg(feature = "vorbis_comments")]
 use byteorder::{LittleEndian, ReadBytesExt};
 use ogg_pager::{Packets, PageHeader};
 
-#[cfg(feature = "vorbis_comments")]
 pub type OGGTags = (Option<VorbisComments>, PageHeader, Packets);
 
-#[cfg(not(feature = "vorbis_comments"))]
-pub type OGGTags = (Option<()>, PageHeader, Packets);
-
-#[cfg(feature = "vorbis_comments")]
 pub(crate) fn read_comments<R>(data: &mut R, mut len: u64, tag: &mut VorbisComments) -> Result<()>
 where
 	R: Read,
@@ -128,16 +120,10 @@ where
 	// Remove the signature from the packet
 	metadata_packet = &metadata_packet[comment_sig.len()..];
 
-	#[cfg(feature = "vorbis_comments")]
-	{
-		let mut tag = VorbisComments::default();
+	let mut tag = VorbisComments::default();
 
-		let reader = &mut metadata_packet;
-		read_comments(reader, reader.len() as u64, &mut tag)?;
+	let reader = &mut metadata_packet;
+	read_comments(reader, reader.len() as u64, &mut tag)?;
 
-		Ok((Some(tag), first_page_header, packets))
-	}
-
-	#[cfg(not(feature = "vorbis_comments"))]
-	Ok((None, first_page_header, packets))
+	Ok((Some(tag), first_page_header, packets))
 }

--- a/src/ogg/speex/mod.rs
+++ b/src/ogg/speex/mod.rs
@@ -1,6 +1,5 @@
 pub(super) mod properties;
 
-#[cfg(feature = "vorbis_comments")]
 use super::tag::VorbisComments;
 use crate::error::Result;
 use crate::file::AudioFile;
@@ -20,7 +19,6 @@ pub struct SpeexFile {
 	/// The vorbis comments contained in the file
 	///
 	/// NOTE: While a metadata packet is required, it isn't required to actually have any data.
-	#[cfg(feature = "vorbis_comments")]
 	#[lofty(tag_type = "VorbisComments")]
 	pub(crate) vorbis_comments_tag: VorbisComments,
 	/// The file's audio properties
@@ -37,11 +35,14 @@ impl AudioFile for SpeexFile {
 		let file_information = super::read::read_from(reader, SPEEXHEADER, &[], 2)?;
 
 		Ok(Self {
-            properties: if parse_options.read_properties { properties::read_properties(reader, file_information.1, &file_information.2)? } else { SpeexProperties::default() },
-            #[cfg(feature = "vorbis_comments")]
-            // Safe to unwrap, a metadata packet is mandatory in Speex
-            vorbis_comments_tag: file_information.0.unwrap(),
-        })
+			properties: if parse_options.read_properties {
+				properties::read_properties(reader, file_information.1, &file_information.2)?
+			} else {
+				SpeexProperties::default()
+			},
+			// Safe to unwrap, a metadata packet is mandatory in Speex
+			vorbis_comments_tag: file_information.0.unwrap(),
+		})
 	}
 
 	fn properties(&self) -> &Self::Properties {

--- a/src/ogg/vorbis/mod.rs
+++ b/src/ogg/vorbis/mod.rs
@@ -1,7 +1,6 @@
 pub(super) mod properties;
 
 use super::find_last_page;
-#[cfg(feature = "vorbis_comments")]
 use super::tag::VorbisComments;
 use crate::error::Result;
 use crate::file::AudioFile;
@@ -21,7 +20,6 @@ pub struct VorbisFile {
 	/// The vorbis comments contained in the file
 	///
 	/// NOTE: While a metadata packet is required, it isn't required to actually have any data.
-	#[cfg(feature = "vorbis_comments")]
 	#[lofty(tag_type = "VorbisComments")]
 	pub(crate) vorbis_comments_tag: VorbisComments,
 	/// The file's audio properties
@@ -39,8 +37,11 @@ impl AudioFile for VorbisFile {
 			super::read::read_from(reader, VORBIS_IDENT_HEAD, VORBIS_COMMENT_HEAD, 3)?;
 
 		Ok(Self {
-			properties: if parse_options.read_properties { properties::read_properties(reader, file_information.1, &file_information.2)? } else { VorbisProperties::default() },
-			#[cfg(feature = "vorbis_comments")]
+			properties: if parse_options.read_properties {
+				properties::read_properties(reader, file_information.1, &file_information.2)?
+			} else {
+				VorbisProperties::default()
+			},
 			// Safe to unwrap, a metadata packet is mandatory in OGG Vorbis
 			vorbis_comments_tag: file_information.0.unwrap(),
 		})

--- a/src/ogg/write.rs
+++ b/src/ogg/write.rs
@@ -55,7 +55,6 @@ pub(crate) fn write_to(file: &mut File, tag: &Tag, file_type: FileType) -> Resul
 	write(file, &mut comments_ref, format)
 }
 
-#[cfg(feature = "vorbis_comments")]
 pub(crate) fn create_comments(
 	packet: &mut impl Write,
 	count: &mut u32,
@@ -82,7 +81,6 @@ pub(crate) fn create_comments(
 	Ok(())
 }
 
-#[cfg(feature = "vorbis_comments")]
 pub(super) fn write<'a, II, IP>(
 	file: &mut File,
 	tag: &mut VorbisCommentsRef<'a, II, IP>,

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,26 +1,13 @@
-use crate::error::{ErrorKind, LoftyError, Result};
+use crate::error::{ErrorKind, ID3v2Error, ID3v2ErrorKind, LoftyError, Result};
+use crate::id3::v2::ID3v2Version;
 use crate::macros::err;
-#[cfg(feature = "id3v2")]
-use crate::{
-	error::{ID3v2Error, ID3v2ErrorKind},
-	id3::v2::ID3v2Version,
-};
+use crate::util::text::TextEncoding;
 
 use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
-#[cfg(any(feature = "id3v2"))]
-use std::io::Cursor;
-#[cfg(feature = "id3v2")]
-use std::io::Write;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 
-#[cfg(feature = "id3v2")]
-use crate::util::text::TextEncoding;
-use byteorder::BigEndian;
-#[cfg(any(feature = "id3v2"))]
-use byteorder::ReadBytesExt;
-#[cfg(feature = "id3v2")]
-use byteorder::WriteBytesExt;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 /// Common picture item keys for APE
 pub const APE_PICTURE_TYPES: [&str; 21] = [
@@ -142,7 +129,6 @@ pub enum PictureType {
 impl PictureType {
 	// ID3/OGG specific methods
 
-	#[cfg(any(feature = "id3v2"))]
 	/// Get a u8 from a `PictureType` according to ID3v2 APIC
 	pub fn as_u8(&self) -> u8 {
 		match self {
@@ -171,7 +157,6 @@ impl PictureType {
 		}
 	}
 
-	#[cfg(any(feature = "id3v2"))]
 	/// Get a `PictureType` from a u8 according to ID3v2 APIC
 	pub fn from_u8(byte: u8) -> Self {
 		match byte {
@@ -554,7 +539,6 @@ impl Picture {
 		&self.data
 	}
 
-	#[cfg(feature = "id3v2")]
 	/// Convert a [`Picture`] to a ID3v2 A/PIC byte Vec
 	///
 	/// NOTE: This does not include the frame header
@@ -618,7 +602,6 @@ impl Picture {
 		Ok(data)
 	}
 
-	#[cfg(feature = "id3v2")]
 	/// Get a [`Picture`] and [`TextEncoding`] from ID3v2 A/PIC bytes:
 	///
 	/// NOTE: This expects *only* the frame content

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -8,24 +8,21 @@ use crate::{
 
 use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
-#[cfg(any(feature = "ape", feature = "id3v2"))]
+#[cfg(any(feature = "id3v2"))]
 use std::io::Cursor;
-use std::io::Read;
 #[cfg(feature = "id3v2")]
 use std::io::Write;
-#[cfg(any(feature = "ape"))]
-use std::io::{Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom};
 
 #[cfg(feature = "id3v2")]
 use crate::util::text::TextEncoding;
 use byteorder::BigEndian;
-#[cfg(any(feature = "id3v2", feature = "ape"))]
+#[cfg(any(feature = "id3v2"))]
 use byteorder::ReadBytesExt;
 #[cfg(feature = "id3v2")]
 use byteorder::WriteBytesExt;
 
 /// Common picture item keys for APE
-#[cfg(feature = "ape")]
 pub const APE_PICTURE_TYPES: [&str; 21] = [
 	"Cover Art (Other)",
 	"Cover Art (Png Icon)",
@@ -205,7 +202,6 @@ impl PictureType {
 
 	// APE specific methods
 
-	#[cfg(feature = "ape")]
 	/// Get an APE item key from a `PictureType`
 	pub fn as_ape_key(&self) -> Option<&str> {
 		match self {
@@ -234,7 +230,6 @@ impl PictureType {
 		}
 	}
 
-	#[cfg(feature = "ape")]
 	/// Get a `PictureType` from an APE item key
 	pub fn from_ape_key(key: &str) -> Self {
 		match key {
@@ -827,7 +822,6 @@ impl Picture {
 		err!(NotAPicture)
 	}
 
-	#[cfg(feature = "ape")]
 	/// Convert a [`Picture`] to an APE Cover Art byte vec:
 	///
 	/// NOTE: This is only the picture data and description, a
@@ -846,7 +840,6 @@ impl Picture {
 		data
 	}
 
-	#[cfg(feature = "ape")]
 	/// Get a [`Picture`] from an APEv2 binary item:
 	///
 	/// NOTE: This function expects `bytes` to contain *only* the APE item data

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -8,19 +8,18 @@ use crate::{
 
 use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
-#[cfg(any(feature = "vorbis_comments", feature = "ape", feature = "id3v2"))]
+#[cfg(any(feature = "ape", feature = "id3v2"))]
 use std::io::Cursor;
 use std::io::Read;
 #[cfg(feature = "id3v2")]
 use std::io::Write;
-#[cfg(any(feature = "vorbis_comments", feature = "ape"))]
+#[cfg(any(feature = "ape"))]
 use std::io::{Seek, SeekFrom};
 
 #[cfg(feature = "id3v2")]
 use crate::util::text::TextEncoding;
-#[cfg(any(feature = "vorbis_comments"))]
 use byteorder::BigEndian;
-#[cfg(any(feature = "vorbis_comments", feature = "id3v2", feature = "ape"))]
+#[cfg(any(feature = "id3v2", feature = "ape"))]
 use byteorder::ReadBytesExt;
 #[cfg(feature = "id3v2")]
 use byteorder::WriteBytesExt;
@@ -146,7 +145,7 @@ pub enum PictureType {
 impl PictureType {
 	// ID3/OGG specific methods
 
-	#[cfg(any(feature = "id3v2", feature = "vorbis_comments"))]
+	#[cfg(any(feature = "id3v2"))]
 	/// Get a u8 from a `PictureType` according to ID3v2 APIC
 	pub fn as_u8(&self) -> u8 {
 		match self {
@@ -175,7 +174,7 @@ impl PictureType {
 		}
 	}
 
-	#[cfg(any(feature = "id3v2", feature = "vorbis_comments"))]
+	#[cfg(any(feature = "id3v2"))]
 	/// Get a `PictureType` from a u8 according to ID3v2 APIC
 	pub fn from_u8(byte: u8) -> Self {
 		match byte {
@@ -269,7 +268,6 @@ impl PictureType {
 ///
 /// This information is necessary for FLAC's `METADATA_BLOCK_PICTURE`.
 /// See [`Picture::as_flac_bytes`] for more information.
-#[cfg(feature = "vorbis_comments")]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
 pub struct PictureInformation {
 	/// The picture's width in pixels
@@ -282,7 +280,6 @@ pub struct PictureInformation {
 	pub num_colors: u32,
 }
 
-#[cfg(feature = "vorbis_comments")]
 impl PictureInformation {
 	/// Attempt to extract [`PictureInformation`] from a [`Picture`]
 	///
@@ -685,7 +682,6 @@ impl Picture {
 		))
 	}
 
-	#[cfg(feature = "vorbis_comments")]
 	/// Convert a [`Picture`] to a base64 encoded FLAC `METADATA_BLOCK_PICTURE` String
 	///
 	/// Use `encode` to convert the picture to a base64 encoded String ([RFC 4648 §4](http://www.faqs.org/rfcs/rfc4648.html))
@@ -734,7 +730,6 @@ impl Picture {
 		}
 	}
 
-	#[cfg(feature = "vorbis_comments")]
 	/// Get a [`Picture`] from FLAC `METADATA_BLOCK_PICTURE` bytes:
 	///
 	/// NOTE: This takes both the base64 encoded string from Vorbis comments, and
@@ -754,7 +749,6 @@ impl Picture {
 		}
 	}
 
-	#[cfg(feature = "vorbis_comments")]
 	fn from_flac_bytes_inner(content: &[u8]) -> Result<(Self, PictureInformation)> {
 		use crate::macros::try_vec;
 

--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -687,7 +687,6 @@ impl TagItem {
 	}
 
 	pub(crate) fn re_map(&self, tag_type: TagType) -> bool {
-		#[cfg(feature = "id3v1")]
 		if tag_type == TagType::ID3v1 {
 			use crate::id3::v1::constants::VALID_ITEMKEYS;
 

--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -72,7 +72,6 @@ gen_map!(
 );
 
 gen_map!(
-	#[cfg(feature = "ape")]
 	APE_MAP;
 
 	"Album"                        => AlbumTitle,
@@ -419,7 +418,6 @@ gen_item_keys!(
 		#[cfg(feature = "aiff_text_chunks")]
 		[TagType::AIFFText, AIFF_TEXT_MAP],
 
-		#[cfg(feature = "ape")]
 		[TagType::APE, APE_MAP],
 
 		#[cfg(feature = "id3v2")]

--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -204,7 +204,6 @@ gen_map!(
 );
 
 gen_map!(
-	#[cfg(feature = "mp4_ilst")]
 	ILST_MAP;
 
 	"\u{a9}alb"                                   => AlbumTitle,
@@ -426,7 +425,6 @@ gen_item_keys!(
 		#[cfg(feature = "id3v2")]
 		[TagType::ID3v2, ID3V2_MAP],
 
-		#[cfg(feature = "mp4_ilst")]
 		[TagType::MP4ilst, ILST_MAP],
 
 		#[cfg(feature = "riff_info_list")]

--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -121,7 +121,6 @@ gen_map!(
 );
 
 gen_map!(
-	#[cfg(feature = "id3v2")]
 	ID3V2_MAP;
 
 	"TALB"                  => AlbumTitle,
@@ -417,7 +416,6 @@ gen_item_keys!(
 
 		[TagType::APE, APE_MAP],
 
-		#[cfg(feature = "id3v2")]
 		[TagType::ID3v2, ID3V2_MAP],
 
 		[TagType::MP4ilst, ILST_MAP],

--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -12,10 +12,9 @@ pub(crate) use first_key;
 
 // This is used to create the key/ItemKey maps
 //
-// First comes the feature attribute, followed by the name of the map.
+// First comes the name of the map.
 // Ex:
 //
-// #[cfg(feature = "ape")]
 // APE_MAP;
 //
 // This is followed by the key value pairs separated by `=>`, with the key being the
@@ -293,7 +292,6 @@ gen_map!(
 );
 
 gen_map!(
-	#[cfg(feature = "vorbis_comments")]
 	VORBIS_MAP;
 
 	"ALBUM"                                   => AlbumTitle,
@@ -434,7 +432,6 @@ gen_item_keys!(
 		#[cfg(feature = "riff_info_list")]
 		[TagType::RIFFInfo, RIFF_INFO_MAP],
 
-		#[cfg(feature = "vorbis_comments")]
 		[TagType::VorbisComments, VORBIS_MAP]
 	];
 

--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -62,7 +62,6 @@ macro_rules! gen_map {
 }
 
 gen_map!(
-	#[cfg(feature = "aiff_text_chunks")]
 	AIFF_TEXT_MAP;
 
 	"NAME"          => TrackTitle,
@@ -415,7 +414,6 @@ macro_rules! gen_item_keys {
 
 gen_item_keys!(
 	MAPS => [
-		#[cfg(feature = "aiff_text_chunks")]
 		[TagType::AIFFText, AIFF_TEXT_MAP],
 
 		[TagType::APE, APE_MAP],

--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -265,7 +265,6 @@ gen_map!(
 );
 
 gen_map!(
-	#[cfg(feature = "riff_info_list")]
 	RIFF_INFO_MAP;
 
 	"IPRD"          => AlbumTitle,
@@ -423,7 +422,6 @@ gen_item_keys!(
 
 		[TagType::MP4ilst, ILST_MAP],
 
-		#[cfg(feature = "riff_info_list")]
 		[TagType::RIFFInfo, RIFF_INFO_MAP],
 
 		[TagType::VorbisComments, VORBIS_MAP]

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -10,7 +10,6 @@ use crate::id3::v2::{self, tag::Id3v2TagRef, ID3v2TagFlags};
 use crate::mp4::Ilst;
 use crate::ogg::tag::{create_vorbis_comments_ref, VorbisCommentsRef};
 use ape::tag::ApeTagRef;
-#[cfg(feature = "aiff_text_chunks")]
 use iff::aiff::tag::AiffTextChunksRef;
 #[cfg(feature = "riff_info_list")]
 use iff::wav::tag::RIFFInfoListRef;
@@ -69,7 +68,6 @@ pub(crate) fn dump_tag<W: Write>(tag: &Tag, writer: &mut W) -> Result<()> {
 			items: iff::wav::tag::tagitems_into_riff(tag.items()),
 		}
 		.dump_to(writer),
-		#[cfg(feature = "aiff_text_chunks")]
 		TagType::AIFFText => {
 			use crate::tag::item::ItemKey;
 

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -10,7 +10,6 @@ use crate::id3::v1::tag::Id3v1TagRef;
 use crate::id3::v2::{self, tag::Id3v2TagRef, ID3v2TagFlags};
 #[cfg(feature = "mp4_ilst")]
 use crate::mp4::Ilst;
-#[cfg(feature = "vorbis_comments")]
 use crate::ogg::tag::{create_vorbis_comments_ref, VorbisCommentsRef};
 #[cfg(feature = "ape")]
 use ape::tag::ApeTagRef;
@@ -29,7 +28,6 @@ pub(crate) fn write_tag(tag: &Tag, file: &mut File, file_type: FileType) -> Resu
 		FileType::AIFF => iff::aiff::write::write_to(file, tag),
 		FileType::APE => ape::write::write_to(file, tag),
 		FileType::FLAC => flac::write::write_to(file, tag),
-		#[cfg(feature = "vorbis_comments")]
 		FileType::Opus | FileType::Speex | FileType::Vorbis => {
 			crate::ogg::write::write_to(file, tag, file_type)
 		},
@@ -63,7 +61,6 @@ pub(crate) fn dump_tag<W: Write>(tag: &Tag, writer: &mut W) -> Result<()> {
 		.dump_to(writer),
 		#[cfg(feature = "mp4_ilst")]
 		TagType::MP4ilst => Into::<Ilst>::into(tag.clone()).as_ref().dump_to(writer),
-		#[cfg(feature = "vorbis_comments")]
 		TagType::VorbisComments => {
 			let (vendor, items, pictures) = create_vorbis_comments_ref(tag);
 

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -5,8 +5,8 @@ use crate::tag::{Tag, TagType};
 use crate::{aac, ape, flac, iff, mpeg, wavpack};
 
 use crate::id3::v1::tag::Id3v1TagRef;
-#[cfg(feature = "id3v2")]
-use crate::id3::v2::{self, tag::Id3v2TagRef, ID3v2TagFlags};
+use crate::id3::v2::tag::Id3v2TagRef;
+use crate::id3::v2::{self, ID3v2TagFlags};
 use crate::mp4::Ilst;
 use crate::ogg::tag::{create_vorbis_comments_ref, VorbisCommentsRef};
 use ape::tag::ApeTagRef;
@@ -45,7 +45,6 @@ pub(crate) fn dump_tag<W: Write>(tag: &Tag, writer: &mut W) -> Result<()> {
 		}
 		.dump_to(writer),
 		TagType::ID3v1 => Into::<Id3v1TagRef<'_>>::into(tag).dump_to(writer),
-		#[cfg(feature = "id3v2")]
 		TagType::ID3v2 => Id3v2TagRef {
 			flags: ID3v2TagFlags::default(),
 			frames: v2::tag::tag_frames(tag),

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -4,7 +4,6 @@ use crate::macros::err;
 use crate::tag::{Tag, TagType};
 use crate::{aac, ape, flac, iff, mpeg, wavpack};
 
-#[cfg(feature = "id3v1")]
 use crate::id3::v1::tag::Id3v1TagRef;
 #[cfg(feature = "id3v2")]
 use crate::id3::v2::{self, tag::Id3v2TagRef, ID3v2TagFlags};
@@ -49,7 +48,6 @@ pub(crate) fn dump_tag<W: Write>(tag: &Tag, writer: &mut W) -> Result<()> {
 			items: ape::tag::tagitems_into_ape(tag.items()),
 		}
 		.dump_to(writer),
-		#[cfg(feature = "id3v1")]
 		TagType::ID3v1 => Into::<Id3v1TagRef<'_>>::into(tag).dump_to(writer),
 		#[cfg(feature = "id3v2")]
 		TagType::ID3v2 => Id3v2TagRef {

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -8,7 +8,6 @@ use crate::{aac, ape, flac, iff, mpeg, wavpack};
 use crate::id3::v1::tag::Id3v1TagRef;
 #[cfg(feature = "id3v2")]
 use crate::id3::v2::{self, tag::Id3v2TagRef, ID3v2TagFlags};
-#[cfg(feature = "mp4_ilst")]
 use crate::mp4::Ilst;
 use crate::ogg::tag::{create_vorbis_comments_ref, VorbisCommentsRef};
 #[cfg(feature = "ape")]
@@ -32,7 +31,6 @@ pub(crate) fn write_tag(tag: &Tag, file: &mut File, file_type: FileType) -> Resu
 			crate::ogg::write::write_to(file, tag, file_type)
 		},
 		FileType::MPEG => mpeg::write::write_to(file, tag),
-		#[cfg(feature = "mp4_ilst")]
 		FileType::MP4 => {
 			crate::mp4::ilst::write::write_to(file, &mut Into::<Ilst>::into(tag.clone()).as_ref())
 		},
@@ -59,7 +57,6 @@ pub(crate) fn dump_tag<W: Write>(tag: &Tag, writer: &mut W) -> Result<()> {
 			frames: v2::tag::tag_frames(tag),
 		}
 		.dump_to(writer),
-		#[cfg(feature = "mp4_ilst")]
 		TagType::MP4ilst => Into::<Ilst>::into(tag.clone()).as_ref().dump_to(writer),
 		TagType::VorbisComments => {
 			let (vendor, items, pictures) = create_vorbis_comments_ref(tag);

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -9,7 +9,6 @@ use crate::id3::v1::tag::Id3v1TagRef;
 use crate::id3::v2::{self, tag::Id3v2TagRef, ID3v2TagFlags};
 use crate::mp4::Ilst;
 use crate::ogg::tag::{create_vorbis_comments_ref, VorbisCommentsRef};
-#[cfg(feature = "ape")]
 use ape::tag::ApeTagRef;
 #[cfg(feature = "aiff_text_chunks")]
 use iff::aiff::tag::AiffTextChunksRef;
@@ -42,7 +41,6 @@ pub(crate) fn write_tag(tag: &Tag, file: &mut File, file_type: FileType) -> Resu
 #[allow(unreachable_patterns)]
 pub(crate) fn dump_tag<W: Write>(tag: &Tag, writer: &mut W) -> Result<()> {
 	match tag.tag_type() {
-		#[cfg(feature = "ape")]
 		TagType::APE => ApeTagRef {
 			read_only: false,
 			items: ape::tag::tagitems_into_ape(tag.items()),

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -11,7 +11,6 @@ use crate::mp4::Ilst;
 use crate::ogg::tag::{create_vorbis_comments_ref, VorbisCommentsRef};
 use ape::tag::ApeTagRef;
 use iff::aiff::tag::AiffTextChunksRef;
-#[cfg(feature = "riff_info_list")]
 use iff::wav::tag::RIFFInfoListRef;
 
 use std::fs::File;
@@ -63,7 +62,6 @@ pub(crate) fn dump_tag<W: Write>(tag: &Tag, writer: &mut W) -> Result<()> {
 			}
 			.dump_to(writer)
 		},
-		#[cfg(feature = "riff_info_list")]
 		TagType::RIFFInfo => RIFFInfoListRef {
 			items: iff::wav::tag::tagitems_into_riff(tag.items()),
 		}

--- a/src/wavpack/mod.rs
+++ b/src/wavpack/mod.rs
@@ -4,7 +4,6 @@ mod read;
 
 #[cfg(feature = "ape")]
 use crate::ape::tag::ApeTag;
-#[cfg(feature = "id3v1")]
 use crate::id3::v1::tag::ID3v1Tag;
 
 use lofty_attr::LoftyFile;
@@ -18,7 +17,6 @@ pub use properties::WavPackProperties;
 #[lofty(internal_write_module_do_not_use_anywhere_else)]
 pub struct WavPackFile {
 	/// An ID3v1 tag
-	#[cfg(feature = "id3v1")]
 	#[lofty(tag_type = "ID3v1")]
 	pub(crate) id3v1_tag: Option<ID3v1Tag>,
 	/// An APEv1/v2 tag

--- a/src/wavpack/mod.rs
+++ b/src/wavpack/mod.rs
@@ -2,7 +2,6 @@
 mod properties;
 mod read;
 
-#[cfg(feature = "ape")]
 use crate::ape::tag::ApeTag;
 use crate::id3::v1::tag::ID3v1Tag;
 
@@ -20,7 +19,6 @@ pub struct WavPackFile {
 	#[lofty(tag_type = "ID3v1")]
 	pub(crate) id3v1_tag: Option<ID3v1Tag>,
 	/// An APEv1/v2 tag
-	#[cfg(feature = "ape")]
 	#[lofty(tag_type = "APE")]
 	pub(crate) ape_tag: Option<ApeTag>,
 	/// The file's audio properties

--- a/src/wavpack/read.rs
+++ b/src/wavpack/read.rs
@@ -18,7 +18,6 @@ where
 	reader.seek(SeekFrom::Start(current_pos))?;
 
 	let mut id3v1_tag = None;
-	#[cfg(feature = "ape")]
 	let mut ape_tag = None;
 
 	let ID3FindResults(id3v1_header, id3v1) = find_id3v1(reader, true)?;
@@ -49,19 +48,12 @@ where
 		let ape_header = read_ape_header(reader, true)?;
 		stream_length -= u64::from(ape_header.size);
 
-		#[cfg(feature = "ape")]
-		{
-			let ape = read_ape_tag(reader, ape_header)?;
-			ape_tag = Some(ape)
-		}
-
-		#[cfg(not(feature = "ape"))]
-		data.seek(SeekFrom::Current(ape_header.size as i64))?;
+		let ape = read_ape_tag(reader, ape_header)?;
+		ape_tag = Some(ape);
 	}
 
 	Ok(WavPackFile {
 		id3v1_tag,
-		#[cfg(feature = "ape")]
 		ape_tag,
 		properties: if parse_options.read_properties {
 			super::properties::read_properties(reader, stream_length, parse_options.parsing_mode)?

--- a/src/wavpack/read.rs
+++ b/src/wavpack/read.rs
@@ -17,7 +17,6 @@ where
 	let mut stream_length = reader.seek(SeekFrom::End(0))?;
 	reader.seek(SeekFrom::Start(current_pos))?;
 
-	#[cfg(feature = "id3v1")]
 	let mut id3v1_tag = None;
 	#[cfg(feature = "ape")]
 	let mut ape_tag = None;
@@ -26,10 +25,7 @@ where
 
 	if id3v1_header.is_some() {
 		stream_length -= 128;
-		#[cfg(feature = "id3v1")]
-		{
-			id3v1_tag = id3v1;
-		}
+		id3v1_tag = id3v1;
 	}
 
 	// Next, check for a Lyrics3v2 tag, and skip over it, as it's no use to us
@@ -64,7 +60,6 @@ where
 	}
 
 	Ok(WavPackFile {
-		#[cfg(feature = "id3v1")]
 		id3v1_tag,
 		#[cfg(feature = "ape")]
 		ape_tag,


### PR DESCRIPTION
These features are useless, as they haven't added any extra dependencies for over a year at this point. They just made things more complicated internally.