### PR TITLE
Reduce memory allocations for id3v2::FrameID

### DIFF
--- a/src/id3/v2/frame/header.rs
+++ b/src/id3/v2/frame/header.rs
@@ -27,7 +27,7 @@ where
 		.map_err(|_| ID3v2Error::new(ID3v2ErrorKind::BadFrameID))?;
 	let id = upgrade_v2(id_str).map_or_else(|| Cow::Owned(id_str.to_owned()), Cow::Borrowed);
 
-	let frame_id = FrameID::new(id)?;
+	let frame_id = FrameID::new_cow(id)?;
 
 	let size = u32::from_be_bytes([0, frame_header[3], frame_header[4], frame_header[5]]);
 
@@ -84,7 +84,7 @@ where
 	} else {
 		Cow::Owned(id_str.to_owned())
 	};
-	let frame_id = FrameID::new(id)?;
+	let frame_id = FrameID::new_cow(id)?;
 
 	// unsynch the frame size if necessary
 	if synchsafe {

--- a/src/id3/v2/frame/id.rs
+++ b/src/id3/v2/frame/id.rs
@@ -1,33 +1,35 @@
+use std::borrow::Cow;
+
 use crate::error::{ID3v2Error, ID3v2ErrorKind, LoftyError, Result};
 use crate::tag::item::ItemKey;
 use crate::tag::TagType;
 
 /// An `ID3v2` frame ID
 #[derive(PartialEq, Clone, Debug, Eq, Hash)]
-pub enum FrameID {
+pub enum FrameID<'a> {
 	/// A valid `ID3v2.3/4` frame
-	Valid(String),
+	Valid(Cow<'a, str>),
 	/// When an `ID3v2.2` key couldn't be upgraded
 	///
 	/// This **will not** be written. It is up to the user to upgrade and store the key as [`Id3v2Frame::Valid`](Self::Valid).
 	///
 	/// The entire frame is stored as [`ItemValue::Binary`](crate::ItemValue::Binary).
-	Outdated(String),
+	Outdated(Cow<'a, str>),
 }
 
-impl FrameID {
+impl<'a> FrameID<'a> {
 	/// Attempts to create a `FrameID` from an ID string
 	///
 	/// # Errors
 	///
 	/// * `id` contains invalid characters (must be 'A'..='Z' and '0'..='9')
 	/// * `id` is an invalid length (must be 3 or 4)
-	pub fn new(id: &str) -> Result<Self> {
-		Self::verify_id(id)?;
+	pub fn new(id: Cow<'a, str>) -> Result<Self> {
+		Self::verify_id(&id)?;
 
 		match id.len() {
-			3 => Ok(FrameID::Outdated(id.to_string())),
-			4 => Ok(FrameID::Valid(id.to_string())),
+			3 => Ok(FrameID::Outdated(id)),
+			4 => Ok(FrameID::Valid(id)),
 			_ => Err(ID3v2Error::new(ID3v2ErrorKind::BadFrameID).into()),
 		}
 	}
@@ -35,11 +37,11 @@ impl FrameID {
 	/// Extracts the string from the ID
 	pub fn as_str(&self) -> &str {
 		match self {
-			FrameID::Valid(v) | FrameID::Outdated(v) => v.as_str(),
+			FrameID::Valid(v) | FrameID::Outdated(v) => &v,
 		}
 	}
 
-	pub(crate) fn verify_id(id_str: &str) -> Result<()> {
+	pub(super) fn verify_id(id_str: &str) -> Result<()> {
 		for c in id_str.chars() {
 			if !c.is_ascii_uppercase() && !c.is_ascii_digit() {
 				return Err(ID3v2Error::new(ID3v2ErrorKind::BadFrameID).into());
@@ -48,12 +50,19 @@ impl FrameID {
 
 		Ok(())
 	}
+
+	pub(super) fn into_owned(self) -> FrameID<'static> {
+		match self {
+			Self::Valid(inner) => FrameID::Valid(Cow::Owned(inner.into_owned())),
+			Self::Outdated(inner) => FrameID::Outdated(Cow::Owned(inner.into_owned())),
+		}
+	}
 }
 
-impl TryFrom<&ItemKey> for FrameID {
+impl<'a> TryFrom<&'a ItemKey> for FrameID<'a> {
 	type Error = LoftyError;
 
-	fn try_from(value: &ItemKey) -> std::prelude::rust_2015::Result<Self, Self::Error> {
+	fn try_from(value: &'a ItemKey) -> std::prelude::rust_2015::Result<Self, Self::Error> {
 		match value {
 			ItemKey::Unknown(unknown)
 				if unknown.len() == 4
@@ -61,11 +70,11 @@ impl TryFrom<&ItemKey> for FrameID {
 						.chars()
 						.all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()) =>
 			{
-				Ok(Self::Valid(unknown.clone()))
+				Ok(Self::Valid(Cow::Borrowed(unknown)))
 			},
 			k => k.map_key(TagType::ID3v2, false).map_or(
 				Err(ID3v2Error::new(ID3v2ErrorKind::BadFrameID).into()),
-				|id| Ok(Self::Valid(id.to_string())),
+				|id| Ok(Self::Valid(Cow::Borrowed(id))),
 			),
 		}
 	}

--- a/src/id3/v2/frame/id.rs
+++ b/src/id3/v2/frame/id.rs
@@ -24,7 +24,15 @@ impl<'a> FrameID<'a> {
 	///
 	/// * `id` contains invalid characters (must be 'A'..='Z' and '0'..='9')
 	/// * `id` is an invalid length (must be 3 or 4)
-	pub fn new(id: Cow<'a, str>) -> Result<Self> {
+	pub fn new<I>(id: I) -> Result<Self>
+	where
+		I: Into<Cow<'a, str>>,
+	{
+		Self::new_cow(id.into())
+	}
+
+	// Split from generic, public method to avoid code bloat by monomorphization.
+	pub(super) fn new_cow(id: Cow<'a, str>) -> Result<Self> {
 		Self::verify_id(&id)?;
 
 		match id.len() {

--- a/src/id3/v2/frame/read.rs
+++ b/src/id3/v2/frame/read.rs
@@ -9,7 +9,7 @@ use std::io::Read;
 
 use byteorder::{BigEndian, ReadBytesExt};
 
-impl Frame {
+impl<'a> Frame<'a> {
 	pub(crate) fn read<R>(reader: &mut R, version: ID3v2Version) -> Result<(Option<Self>, bool)>
 	where
 		R: Read,

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -742,7 +742,7 @@ mod tests {
 
 		expected_tag.insert(
 			Frame::new(
-				Cow::Borrowed("TPE1"),
+				"TPE1",
 				FrameValue::Text {
 					encoding,
 					value: String::from("Bar artist"),
@@ -754,7 +754,7 @@ mod tests {
 
 		expected_tag.insert(
 			Frame::new(
-				Cow::Borrowed("TIT2"),
+				"TIT2",
 				FrameValue::Text {
 					encoding,
 					value: String::from("Foo title"),
@@ -766,7 +766,7 @@ mod tests {
 
 		expected_tag.insert(
 			Frame::new(
-				Cow::Borrowed("TALB"),
+				"TALB",
 				FrameValue::Text {
 					encoding,
 					value: String::from("Baz album"),
@@ -778,7 +778,7 @@ mod tests {
 
 		expected_tag.insert(
 			Frame::new(
-				Cow::Borrowed("COMM"),
+				"COMM",
 				FrameValue::Comment(LanguageFrame {
 					encoding,
 					language: *b"eng",
@@ -792,7 +792,7 @@ mod tests {
 
 		expected_tag.insert(
 			Frame::new(
-				Cow::Borrowed("TDRC"),
+				"TDRC",
 				FrameValue::Text {
 					encoding,
 					value: String::from("1984"),
@@ -804,7 +804,7 @@ mod tests {
 
 		expected_tag.insert(
 			Frame::new(
-				Cow::Borrowed("TRCK"),
+				"TRCK",
 				FrameValue::Text {
 					encoding,
 					value: String::from("1"),
@@ -816,7 +816,7 @@ mod tests {
 
 		expected_tag.insert(
 			Frame::new(
-				Cow::Borrowed("TCON"),
+				"TCON",
 				FrameValue::Text {
 					encoding,
 					value: String::from("Classical"),
@@ -1194,7 +1194,7 @@ mod tests {
 		let mut tag = ID3v2Tag::default();
 		tag.insert(
 			Frame::new(
-				Cow::Borrowed("TXXX"),
+				"TXXX",
 				FrameValue::UserText(EncodedTextFrame {
 					encoding: TextEncoding::UTF8,
 					description: String::from("REPLAYGAIN_ALBUM_GAIN"),
@@ -1220,7 +1220,7 @@ mod tests {
 	#[test]
 	fn txxx_wxxx_tag_conversion() {
 		let txxx_frame = Frame::new(
-			Cow::Borrowed("TXXX"),
+			"TXXX",
 			FrameValue::UserText(EncodedTextFrame {
 				encoding: TextEncoding::UTF8,
 				description: String::from("FOO_TEXT_FRAME"),
@@ -1231,7 +1231,7 @@ mod tests {
 		.unwrap();
 
 		let wxxx_frame = Frame::new(
-			Cow::Borrowed("WXXX"),
+			"WXXX",
 			FrameValue::UserURL(EncodedTextFrame {
 				encoding: TextEncoding::UTF8,
 				description: String::from("BAR_URL_FRAME"),

--- a/tests/tags/conversions.rs
+++ b/tests/tags/conversions.rs
@@ -1,5 +1,7 @@
 // Tests for special case conversions
 
+use std::borrow::Cow;
+
 use lofty::id3::v2::{Frame, FrameFlags, FrameValue, ID3v2Tag, LanguageFrame};
 use lofty::{ItemKey, Tag, TagType, TextEncoding};
 
@@ -14,7 +16,7 @@ fn tag_to_id3v2_lang_frame() {
 	assert_eq!(
 		id3.get("USLT"),
 		Frame::new(
-			"USLT",
+			Cow::Borrowed("USLT"),
 			FrameValue::UnSyncText(LanguageFrame {
 				encoding: TextEncoding::UTF8,
 				language: *b"eng",
@@ -30,7 +32,7 @@ fn tag_to_id3v2_lang_frame() {
 	assert_eq!(
 		id3.get("COMM"),
 		Frame::new(
-			"COMM",
+			Cow::Borrowed("COMM"),
 			FrameValue::Comment(LanguageFrame {
 				encoding: TextEncoding::UTF8,
 				language: *b"eng",

--- a/tests/tags/conversions.rs
+++ b/tests/tags/conversions.rs
@@ -1,7 +1,5 @@
 // Tests for special case conversions
 
-use std::borrow::Cow;
-
 use lofty::id3::v2::{Frame, FrameFlags, FrameValue, ID3v2Tag, LanguageFrame};
 use lofty::{ItemKey, Tag, TagType, TextEncoding};
 
@@ -16,7 +14,7 @@ fn tag_to_id3v2_lang_frame() {
 	assert_eq!(
 		id3.get("USLT"),
 		Frame::new(
-			Cow::Borrowed("USLT"),
+			"USLT",
 			FrameValue::UnSyncText(LanguageFrame {
 				encoding: TextEncoding::UTF8,
 				language: *b"eng",
@@ -32,7 +30,7 @@ fn tag_to_id3v2_lang_frame() {
 	assert_eq!(
 		id3.get("COMM"),
 		Frame::new(
-			Cow::Borrowed("COMM"),
+			"COMM",
 			FrameValue::Comment(LanguageFrame {
 				encoding: TextEncoding::UTF8,
 				language: *b"eng",


### PR DESCRIPTION
The next step towards more efficient memory management. Most of the predefined string constants have a `'static` lifetime.