### PR TITLE
Disambiguate ID3v2 TIT1/GRP1

### DIFF
--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -127,7 +127,8 @@ gen_map!(
 
 	"TALB"                  => AlbumTitle,
 	"TSST"                  => SetSubtitle,
-	"TIT1" | "GRP1"         => ContentGroup,
+	"TIT1"                  => ContentGroup,
+	"GRP1"                  => AppleId3v2ContentGroup,
 	"TIT2"                  => TrackTitle,
 	"TIT3"                  => TrackSubtitle,
 	"TOAL"                  => OriginalAlbumTitle,
@@ -558,6 +559,7 @@ gen_item_keys!(
 
 		// Vendor-specific
 		AppleXid,
+		AppleId3v2ContentGroup, // GRP1
 	]
 );
 


### PR DESCRIPTION
As discussed in #113 we can only disambiguate and not resolve this issue. Applications have to deal with that.

Note: Will cause a minor merge conflict with #117.