### PR TITLE
id3v2: Distinguish COMM frames by content descriptor

### DIFF
--- a/src/id3/v2/frame/mod.rs
+++ b/src/id3/v2/frame/mod.rs
@@ -20,12 +20,24 @@ use crate::id3::v2::items::popularimeter::Popularimeter;
 use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
 
-// <https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2.4.0-structure.html>
-//
-// > The three byte language field, present in several frames, is used to describe
-// > the language of the frame’s content, according to ISO-639-2 [ISO-639-2].
-// > The language should be represented in lower case. If the language is not known
-// > the string “XXX” should be used.
+/// Empty content descriptor in text frame
+///
+/// Unspecific [`LanguageFrame`]s and [`EncodedTextFrame`] frames
+/// are supposed to have an empty content descriptor. Only those
+/// are currently supported as [`TagItem`]s to avoid ambiguities
+/// and to prevent inconsistencies when writing them.
+pub(super) const fn empty_content_descriptor() -> String {
+	String::new()
+}
+
+/// Unknown language-aware text frame
+///
+/// <https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2.4.0-structure.html>
+///
+/// > The three byte language field, present in several frames, is used to describe
+/// > the language of the frame’s content, according to ISO-639-2 [ISO-639-2].
+/// > The language should be represented in lower case. If the language is not known
+/// > the string “XXX” should be used.
 pub(super) const UNKNOWN_LANGUAGE: [u8; 3] = *b"XXX";
 
 // TODO: Messy module, rough conversions
@@ -283,7 +295,7 @@ impl From<TagItem> for Option<Frame<'static>> {
 						FrameValue::Comment(LanguageFrame {
 							encoding: TextEncoding::UTF8,
 							language: UNKNOWN_LANGUAGE,
-							description: String::new(),
+							description: empty_content_descriptor(),
 							content: text,
 						})
 					},
@@ -291,7 +303,7 @@ impl From<TagItem> for Option<Frame<'static>> {
 						FrameValue::UnSyncText(LanguageFrame {
 							encoding: TextEncoding::UTF8,
 							language: UNKNOWN_LANGUAGE,
-							description: String::new(),
+							description: empty_content_descriptor(),
 							content: text,
 						})
 					},
@@ -300,14 +312,14 @@ impl From<TagItem> for Option<Frame<'static>> {
 					{
 						FrameValue::UserURL(EncodedTextFrame {
 							encoding: TextEncoding::UTF8,
-							description: String::new(),
+							description: empty_content_descriptor(),
 							content: text,
 						})
 					},
 					(FrameID::Valid(ref s), ItemValue::Text(text)) if s == "TXXX" => {
 						FrameValue::UserText(EncodedTextFrame {
 							encoding: TextEncoding::UTF8,
-							description: String::new(),
+							description: empty_content_descriptor(),
 							content: text,
 						})
 					},
@@ -391,25 +403,25 @@ impl<'a> TryFrom<&'a TagItem> for FrameRef<'a> {
 				("COMM", ItemValue::Text(text)) => FrameValue::Comment(LanguageFrame {
 					encoding: TextEncoding::UTF8,
 					language: UNKNOWN_LANGUAGE,
-					description: String::new(),
+					description: empty_content_descriptor(),
 					content: text.clone(),
 				}),
 				("USLT", ItemValue::Text(text)) => FrameValue::UnSyncText(LanguageFrame {
 					encoding: TextEncoding::UTF8,
 					language: UNKNOWN_LANGUAGE,
-					description: String::new(),
+					description: empty_content_descriptor(),
 					content: text.clone(),
 				}),
 				("WXXX", ItemValue::Locator(text) | ItemValue::Text(text)) => {
 					FrameValue::UserURL(EncodedTextFrame {
 						encoding: TextEncoding::UTF8,
-						description: String::new(),
+						description: empty_content_descriptor(),
 						content: text.clone(),
 					})
 				},
 				("TXXX", ItemValue::Text(text)) => FrameValue::UserText(EncodedTextFrame {
 					encoding: TextEncoding::UTF8,
-					description: String::new(),
+					description: empty_content_descriptor(),
 					content: text.clone(),
 				}),
 				("POPM", ItemValue::Binary(contents)) => {

--- a/src/id3/v2/frame/mod.rs
+++ b/src/id3/v2/frame/mod.rs
@@ -26,9 +26,7 @@ use std::hash::{Hash, Hasher};
 /// are supposed to have an empty content descriptor. Only those
 /// are currently supported as [`TagItem`]s to avoid ambiguities
 /// and to prevent inconsistencies when writing them.
-pub(super) const fn empty_content_descriptor() -> String {
-	String::new()
-}
+pub(super) const EMPTY_CONTENT_DESCRIPTOR: String = String::new();
 
 /// Unknown language-aware text frame
 ///
@@ -295,7 +293,7 @@ impl From<TagItem> for Option<Frame<'static>> {
 						FrameValue::Comment(LanguageFrame {
 							encoding: TextEncoding::UTF8,
 							language: UNKNOWN_LANGUAGE,
-							description: empty_content_descriptor(),
+							description: EMPTY_CONTENT_DESCRIPTOR,
 							content: text,
 						})
 					},
@@ -303,7 +301,7 @@ impl From<TagItem> for Option<Frame<'static>> {
 						FrameValue::UnSyncText(LanguageFrame {
 							encoding: TextEncoding::UTF8,
 							language: UNKNOWN_LANGUAGE,
-							description: empty_content_descriptor(),
+							description: EMPTY_CONTENT_DESCRIPTOR,
 							content: text,
 						})
 					},
@@ -312,14 +310,14 @@ impl From<TagItem> for Option<Frame<'static>> {
 					{
 						FrameValue::UserURL(EncodedTextFrame {
 							encoding: TextEncoding::UTF8,
-							description: empty_content_descriptor(),
+							description: EMPTY_CONTENT_DESCRIPTOR,
 							content: text,
 						})
 					},
 					(FrameID::Valid(ref s), ItemValue::Text(text)) if s == "TXXX" => {
 						FrameValue::UserText(EncodedTextFrame {
 							encoding: TextEncoding::UTF8,
-							description: empty_content_descriptor(),
+							description: EMPTY_CONTENT_DESCRIPTOR,
 							content: text,
 						})
 					},
@@ -403,25 +401,25 @@ impl<'a> TryFrom<&'a TagItem> for FrameRef<'a> {
 				("COMM", ItemValue::Text(text)) => FrameValue::Comment(LanguageFrame {
 					encoding: TextEncoding::UTF8,
 					language: UNKNOWN_LANGUAGE,
-					description: empty_content_descriptor(),
+					description: EMPTY_CONTENT_DESCRIPTOR,
 					content: text.clone(),
 				}),
 				("USLT", ItemValue::Text(text)) => FrameValue::UnSyncText(LanguageFrame {
 					encoding: TextEncoding::UTF8,
 					language: UNKNOWN_LANGUAGE,
-					description: empty_content_descriptor(),
+					description: EMPTY_CONTENT_DESCRIPTOR,
 					content: text.clone(),
 				}),
 				("WXXX", ItemValue::Locator(text) | ItemValue::Text(text)) => {
 					FrameValue::UserURL(EncodedTextFrame {
 						encoding: TextEncoding::UTF8,
-						description: empty_content_descriptor(),
+						description: EMPTY_CONTENT_DESCRIPTOR,
 						content: text.clone(),
 					})
 				},
 				("TXXX", ItemValue::Text(text)) => FrameValue::UserText(EncodedTextFrame {
 					encoding: TextEncoding::UTF8,
-					description: empty_content_descriptor(),
+					description: EMPTY_CONTENT_DESCRIPTOR,
 					content: text.clone(),
 				}),
 				("POPM", ItemValue::Binary(contents)) => {

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -22,6 +22,8 @@ use lofty_attr::tag;
 
 const COMMENT_FRAME_ID: &str = "COMM";
 
+const V4_MULTI_VALUE_SEPARATOR: char = '\0';
+const NUMBER_PAIR_SEPARATOR: char = '/';
 
 macro_rules! impl_accessor {
 	($($name:ident => $id:literal;)+) => {
@@ -164,11 +166,13 @@ impl ID3v2Tag {
 			..
 		}) = frame
 		{
-			if !value.contains('\0') || self.original_version != ID3v2Version::V4 {
+			if !value.contains(V4_MULTI_VALUE_SEPARATOR)
+				|| self.original_version != ID3v2Version::V4
+			{
 				return Some(Cow::Borrowed(value.as_str()));
 			}
 
-			return Some(Cow::Owned(value.replace('\0', "/")));
+			return Some(Cow::Owned(value.replace(V4_MULTI_VALUE_SEPARATOR, "/")));
 		}
 
 		None
@@ -281,7 +285,9 @@ impl ID3v2Tag {
 			..
 		}) = self.get(id)
 		{
-			let mut split = value.split(&['\0', '/'][..]).flat_map(str::parse::<u32>);
+			let mut split = value
+				.split(&[V4_MULTI_VALUE_SEPARATOR, NUMBER_PAIR_SEPARATOR][..])
+				.flat_map(str::parse::<u32>);
 			return (split.next(), split.next());
 		}
 
@@ -529,7 +535,8 @@ impl From<ID3v2Tag> for Tag {
 			current_key: ItemKey,
 			total_key: ItemKey,
 		) -> Option<()> {
-			let mut split = content.splitn(2, &['\0', '/'][..]);
+			let mut split =
+				content.splitn(2, &[V4_MULTI_VALUE_SEPARATOR, NUMBER_PAIR_SEPARATOR][..]);
 			let current = split.next()?.to_string();
 			tag.items
 				.push(TagItem::new(current_key, ItemValue::Text(current)));
@@ -587,7 +594,7 @@ impl From<ID3v2Tag> for Tag {
 					}),
 				) => {
 					let item_key = ItemKey::from_key(TagType::ID3v2, description);
-					for c in content.split('\0') {
+					for c in content.split(V4_MULTI_VALUE_SEPARATOR) {
 						tag.items.push(TagItem::new(
 							item_key.clone(),
 							ItemValue::Text(c.to_string()),
@@ -688,7 +695,7 @@ impl From<Tag> for ID3v2Tag {
 					let mut s = String::with_capacity(iter.size_hint().0);
 					s.push_str(&first);
 					iter.for_each(|i| {
-						s.push('\0');
+						s.push(V4_MULTI_VALUE_SEPARATOR);
 						s.push_str(&i);
 					});
 

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -1,6 +1,6 @@
 use super::flags::ID3v2TagFlags;
 use super::frame::id::FrameID;
-use super::frame::{empty_content_descriptor, Frame, FrameFlags, FrameValue, UNKNOWN_LANGUAGE};
+use super::frame::{Frame, FrameFlags, FrameValue, EMPTY_CONTENT_DESCRIPTOR, UNKNOWN_LANGUAGE};
 use super::ID3v2Version;
 use crate::error::{LoftyError, Result};
 use crate::id3::v2::frame::FrameRef;
@@ -275,7 +275,7 @@ impl ID3v2Tag {
 	/// Returns all `COMM` frames with an empty content descriptor
 	pub fn comments(&self) -> impl Iterator<Item = &LanguageFrame> {
 		self.frames.iter().filter_map(|frame| {
-			filter_comment_frame_by_description(frame, &empty_content_descriptor())
+			filter_comment_frame_by_description(frame, &EMPTY_CONTENT_DESCRIPTOR)
 		})
 	}
 
@@ -426,9 +426,7 @@ impl Accessor for ID3v2Tag {
 	fn comment(&self) -> Option<Cow<'_, str>> {
 		self.frames
 			.iter()
-			.find_map(|frame| {
-				filter_comment_frame_by_description(frame, &empty_content_descriptor())
-			})
+			.find_map(|frame| filter_comment_frame_by_description(frame, &EMPTY_CONTENT_DESCRIPTOR))
 			.map(|LanguageFrame { content, .. }| Cow::Borrowed(content.as_str()))
 	}
 
@@ -438,7 +436,7 @@ impl Accessor for ID3v2Tag {
 			.frames
 			.iter_mut()
 			.find_map(|frame| {
-				filter_comment_frame_by_description_mut(frame, &empty_content_descriptor())
+				filter_comment_frame_by_description_mut(frame, &EMPTY_CONTENT_DESCRIPTOR)
 			})
 			.map(|LanguageFrame { content, .. }| content)
 		{
@@ -451,7 +449,7 @@ impl Accessor for ID3v2Tag {
 			value: FrameValue::Comment(LanguageFrame {
 				encoding: TextEncoding::UTF8,
 				language: UNKNOWN_LANGUAGE,
-				description: empty_content_descriptor(),
+				description: EMPTY_CONTENT_DESCRIPTOR,
 				content: value,
 			}),
 			flags: FrameFlags::default(),
@@ -460,7 +458,7 @@ impl Accessor for ID3v2Tag {
 
 	fn remove_comment(&mut self) {
 		self.frames.retain(|frame| {
-			filter_comment_frame_by_description(frame, &empty_content_descriptor()).is_none()
+			filter_comment_frame_by_description(frame, &EMPTY_CONTENT_DESCRIPTOR).is_none()
 		})
 	}
 }
@@ -636,7 +634,7 @@ impl From<ID3v2Tag> for Tag {
 							description,
 							..
 						}) => {
-							if description == empty_content_descriptor() {
+							if description == EMPTY_CONTENT_DESCRIPTOR {
 								for c in content.split(V4_MULTI_VALUE_SEPARATOR) {
 									tag.items.push(TagItem::new(
 										item_key.clone(),
@@ -798,7 +796,7 @@ mod tests {
 		Accessor, ItemKey, ItemValue, MimeType, Picture, PictureType, Tag, TagExt, TagItem, TagType,
 	};
 
-	use super::{empty_content_descriptor, COMMENT_FRAME_ID};
+	use super::{COMMENT_FRAME_ID, EMPTY_CONTENT_DESCRIPTOR};
 
 	fn read_tag(path: &str) -> ID3v2Tag {
 		let tag_bytes = crate::tag::utils::test_utils::read_path(path);
@@ -858,7 +856,7 @@ mod tests {
 				FrameValue::Comment(LanguageFrame {
 					encoding,
 					language: *b"eng",
-					description: empty_content_descriptor(),
+					description: EMPTY_CONTENT_DESCRIPTOR,
 					content: String::from("Qux comment"),
 				}),
 				flags,
@@ -1035,7 +1033,7 @@ mod tests {
 			&FrameValue::Comment(LanguageFrame {
 				encoding: TextEncoding::Latin1,
 				language: *b"eng",
-				description: empty_content_descriptor(),
+				description: EMPTY_CONTENT_DESCRIPTOR,
 				content: String::from("Qux comment")
 			})
 		);

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -20,6 +20,11 @@ use std::path::Path;
 
 use lofty_attr::tag;
 
+const COMMENT_FRAME_ID: &str = "COMM";
+
+// Unspecific comment frames have an empty content descriptor.
+const COMMENT_DESCRIPTION: &str = "";
+
 macro_rules! impl_accessor {
 	($($name:ident => $id:literal;)+) => {
 		paste::paste! {
@@ -265,16 +270,11 @@ impl ID3v2Tag {
 		})
 	}
 
-	/// Returns all `COMM` frames
-	pub fn comments(&self) -> impl Iterator<Item = &LanguageFrame> + Clone {
-		self.frames.iter().filter_map(|f| match f {
-			Frame {
-				id: FrameID::Valid(id),
-				value: FrameValue::Comment(val),
-				..
-			} if id == "COMM" => Some(val),
-			_ => None,
-		})
+	/// Returns all `COMM` frames with an empty content descriptor
+	pub fn comments(&self) -> impl Iterator<Item = &LanguageFrame> {
+		self.frames
+			.iter()
+			.filter_map(|frame| filter_comment_frame_by_description(frame, COMMENT_DESCRIPTION))
 	}
 
 	fn split_num_pair(&self, id: &str) -> (Option<u32>, Option<u32>) {
@@ -288,6 +288,33 @@ impl ID3v2Tag {
 		}
 
 		(None, None)
+	}
+}
+
+fn filter_comment_frame_by_description<'a>(
+	frame: &'a Frame<'_>,
+	description: &str,
+) -> Option<&'a LanguageFrame> {
+	match &frame.value {
+		FrameValue::Comment(lang_frame) if frame.id_str() == COMMENT_FRAME_ID => {
+			(lang_frame.description == description).then_some(lang_frame)
+		},
+		_ => None,
+	}
+}
+
+fn filter_comment_frame_by_description_mut<'a>(
+	frame: &'a mut Frame<'_>,
+	description: &str,
+) -> Option<&'a mut LanguageFrame> {
+	if frame.id_str() != COMMENT_FRAME_ID {
+		return None;
+	}
+	match &mut frame.value {
+		FrameValue::Comment(lang_frame) => {
+			(lang_frame.description == description).then_some(lang_frame)
+		},
+		_ => None,
 	}
 }
 
@@ -393,45 +420,40 @@ impl Accessor for ID3v2Tag {
 	}
 
 	fn comment(&self) -> Option<Cow<'_, str>> {
-		if let Some(Frame {
-			value: FrameValue::Comment(LanguageFrame { content, .. }),
-			..
-		}) = self.get("COMM")
-		{
-			return Some(Cow::Borrowed(content));
-		}
-
-		None
+		self.frames
+			.iter()
+			.find_map(|frame| filter_comment_frame_by_description(frame, COMMENT_DESCRIPTION))
+			.map(|LanguageFrame { content, .. }| Cow::Borrowed(content.as_str()))
 	}
 
 	fn set_comment(&mut self, value: String) {
 		// We'll just replace the first comment's content if it exists, otherwise create a new one
-		let first_comment = self.frames.iter_mut().find(|f| f.id_str() == "COMM");
-		if let Some(Frame {
-			value: FrameValue::Comment(LanguageFrame { content, .. }),
-			..
-		}) = first_comment
+		if let Some(content) = self
+			.frames
+			.iter_mut()
+			.find_map(|frame| filter_comment_frame_by_description_mut(frame, COMMENT_DESCRIPTION))
+			.map(|LanguageFrame { content, .. }| content)
 		{
 			*content = value;
 			return;
 		}
 
-		if !value.is_empty() {
-			self.insert(Frame {
-				id: FrameID::Valid(Cow::Borrowed("COMM")),
-				value: FrameValue::Comment(LanguageFrame {
-					encoding: TextEncoding::UTF8,
-					language: UNKNOWN_LANGUAGE,
-					description: String::new(),
-					content: value,
-				}),
-				flags: FrameFlags::default(),
-			});
-		}
+		self.insert(Frame {
+			id: FrameID::Valid(Cow::Borrowed(COMMENT_FRAME_ID)),
+			value: FrameValue::Comment(LanguageFrame {
+				encoding: TextEncoding::UTF8,
+				language: UNKNOWN_LANGUAGE,
+				description: COMMENT_DESCRIPTION.to_owned(),
+				content: value,
+			}),
+			flags: FrameFlags::default(),
+		});
 	}
 
 	fn remove_comment(&mut self) {
-		self.remove("COMM");
+		self.frames.retain(|frame| {
+			filter_comment_frame_by_description(frame, COMMENT_DESCRIPTION).is_none()
+		})
 	}
 }
 
@@ -727,6 +749,7 @@ mod tests {
 	use std::borrow::Cow;
 
 	use crate::id3::v2::items::popularimeter::Popularimeter;
+	use crate::id3::v2::tag::filter_comment_frame_by_description;
 	use crate::id3::v2::{
 		read_id3v2_header, EncodedTextFrame, Frame, FrameFlags, FrameID, FrameValue, ID3v2Tag,
 		ID3v2Version, LanguageFrame,
@@ -734,8 +757,10 @@ mod tests {
 	use crate::tag::utils::test_utils::read_path;
 	use crate::util::text::TextEncoding;
 	use crate::{
-		ItemKey, ItemValue, MimeType, Picture, PictureType, Tag, TagExt, TagItem, TagType,
+		Accessor, ItemKey, ItemValue, MimeType, Picture, PictureType, Tag, TagExt, TagItem, TagType,
 	};
+
+	use super::{COMMENT_DESCRIPTION, COMMENT_FRAME_ID};
 
 	fn read_tag(path: &str) -> ID3v2Tag {
 		let tag_bytes = crate::tag::utils::test_utils::read_path(path);
@@ -791,11 +816,11 @@ mod tests {
 
 		expected_tag.insert(
 			Frame::new(
-				"COMM",
+				COMMENT_FRAME_ID,
 				FrameValue::Comment(LanguageFrame {
 					encoding,
 					language: *b"eng",
-					description: String::new(),
+					description: COMMENT_DESCRIPTION.to_owned(),
 					content: String::from("Qux comment"),
 				}),
 				flags,
@@ -966,7 +991,7 @@ mod tests {
 		verify_frame(&id3v2_tag, "TPE1", "Bar artist");
 		verify_frame(&id3v2_tag, "TALB", "Baz album");
 
-		let frame = id3v2_tag.get("COMM").unwrap();
+		let frame = id3v2_tag.get(COMMENT_FRAME_ID).unwrap();
 		assert_eq!(
 			frame.content(),
 			&FrameValue::Comment(LanguageFrame {
@@ -1228,6 +1253,52 @@ mod tests {
 				item_value: ItemValue::Text(String::from("-10.43 dB"))
 			}
 		);
+	}
+
+	#[test]
+	fn comments() {
+		let mut tag = ID3v2Tag::default();
+		let encoding = TextEncoding::Latin1;
+		let flags = FrameFlags::default();
+		let custom_descriptor = "lofty-rs";
+
+		assert!(tag.comment().is_none());
+
+		// Set an empty comment, which is a valid use case.
+		tag.set_comment("".to_owned());
+		assert_eq!(Some(Cow::Borrowed("")), tag.comment());
+
+		// Insert a custom comment frame
+		assert!(tag
+			.frames
+			.iter()
+			.find_map(|frame| filter_comment_frame_by_description(frame, custom_descriptor))
+			.is_none());
+		tag.insert(
+			Frame::new(
+				COMMENT_FRAME_ID,
+				FrameValue::Comment(LanguageFrame {
+					encoding,
+					language: *b"eng",
+					description: custom_descriptor.to_owned(),
+					content: String::from("Qux comment"),
+				}),
+				flags,
+			)
+			.unwrap(),
+		);
+		// Verify that the regular comment still exists
+		assert_eq!(Some(Cow::Borrowed("")), tag.comment());
+
+		tag.remove_comment();
+		assert!(tag.comment().is_none());
+
+		// Verify that the comment with the custom descriptor still exists
+		assert!(tag
+			.frames
+			.iter()
+			.find_map(|frame| filter_comment_frame_by_description(frame, custom_descriptor))
+			.is_some());
 	}
 
 	#[test]


### PR DESCRIPTION
Plain comments are supposed to have an empty description aka *content descriptor*. Only those must appear as `ItemKey::Comment`, otherwise this would cause confusion and inconsistencies during the read/write round trip.

### TODO
- [x] How to filter the COMM frames such that only those with an empty content descriptor appear under `ItemKey::Comment`?
- [x] ~~Test that unsupported frames with a non-empty content descriptor are preserved during a read/write round trip.~~ Out of scope, nothing to do here. Conversions from `ID3v2Tag` to `Tag` are expected to be lossy and applications are responsible for preserving unmapped MP3 metadata frames. All operations directly on `ID3v2Tag` are unaffected by the changes.