### PR TITLE
Split and rejoin tags for read/modify/write round trips

### DIFF
--- a/src/ape/tag/mod.rs
+++ b/src/ape/tag/mod.rs
@@ -6,7 +6,7 @@ use crate::ape::tag::item::{ApeItem, ApeItemRef};
 use crate::error::{LoftyError, Result};
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
+use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
 
 use std::borrow::Cow;
 use std::convert::TryInto;
@@ -289,7 +289,7 @@ impl TagExt for ApeTag {
 	}
 }
 
-impl SplitAndRejoinTag for ApeTag {
+impl SplitAndMergeTag for ApeTag {
 	fn split_tag(&mut self) -> Tag {
 		fn split_pair(
 			content: &str,
@@ -349,7 +349,7 @@ impl SplitAndRejoinTag for ApeTag {
 		tag
 	}
 
-	fn rejoin_tag(&mut self, tag: Tag) {
+	fn merge_tag(&mut self, tag: Tag) {
 		for item in tag.items {
 			if let Ok(ape_item) = item.try_into() {
 				self.insert(ape_item)
@@ -377,7 +377,7 @@ impl From<ApeTag> for Tag {
 impl From<Tag> for ApeTag {
 	fn from(input: Tag) -> Self {
 		let mut ape_tag = Self::default();
-		ape_tag.rejoin_tag(input);
+		ape_tag.merge_tag(input);
 		ape_tag
 	}
 }

--- a/src/id3/v1/tag.rs
+++ b/src/id3/v1/tag.rs
@@ -2,7 +2,7 @@ use crate::error::{LoftyError, Result};
 use crate::id3::v1::constants::GENRES;
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
+use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
 
 use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
@@ -238,7 +238,7 @@ impl TagExt for ID3v1Tag {
 	}
 }
 
-impl SplitAndRejoinTag for ID3v1Tag {
+impl SplitAndMergeTag for ID3v1Tag {
 	fn split_tag(&mut self) -> Tag {
 		let mut tag = Tag::new(TagType::ID3v1);
 
@@ -272,7 +272,7 @@ impl SplitAndRejoinTag for ID3v1Tag {
 		tag
 	}
 
-	fn rejoin_tag(&mut self, tag: Tag) {
+	fn merge_tag(&mut self, tag: Tag) {
 		*self = tag.into();
 	}
 }

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -9,7 +9,7 @@ use crate::id3::v2::items::language_frame::LanguageFrame;
 use crate::picture::{Picture, PictureType, TOMBSTONE_PICTURE};
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
+use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
 use crate::util::text::TextEncoding;
 
 use std::borrow::Cow;
@@ -533,7 +533,7 @@ impl TagExt for ID3v2Tag {
 	}
 }
 
-impl SplitAndRejoinTag for ID3v2Tag {
+impl SplitAndMergeTag for ID3v2Tag {
 	fn split_tag(&mut self) -> Tag {
 		fn split_pair(
 			content: &str,
@@ -693,7 +693,7 @@ impl SplitAndRejoinTag for ID3v2Tag {
 		tag
 	}
 
-	fn rejoin_tag(&mut self, mut tag: Tag) {
+	fn merge_tag(&mut self, mut tag: Tag) {
 		fn join_items(tag: &mut Tag, key: &ItemKey) -> String {
 			let mut iter = tag.take_strings(key);
 
@@ -748,7 +748,7 @@ impl From<ID3v2Tag> for Tag {
 impl From<Tag> for ID3v2Tag {
 	fn from(input: Tag) -> Self {
 		let mut id3v2_tag = ID3v2Tag::default();
-		id3v2_tag.rejoin_tag(input);
+		id3v2_tag.merge_tag(input);
 		id3v2_tag
 	}
 }

--- a/src/iff/aiff/tag.rs
+++ b/src/iff/aiff/tag.rs
@@ -3,7 +3,7 @@ use crate::iff::chunk::Chunks;
 use crate::macros::err;
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, TagExt};
+use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
 
 use std::borrow::Cow;
 use std::convert::TryFrom;
@@ -216,9 +216,19 @@ impl TagExt for AIFFTextChunks {
 	}
 }
 
+impl SplitAndRejoinTag for AIFFTextChunks {
+	fn split_tag(&mut self) -> Tag {
+		std::mem::take(self).into()
+	}
+
+	fn rejoin_tag(&mut self, tag: Tag) {
+		*self = tag.into();
+	}
+}
+
 impl From<AIFFTextChunks> for Tag {
 	fn from(input: AIFFTextChunks) -> Self {
-		let mut tag = Tag::new(TagType::AIFFText);
+		let mut tag = Self::new(TagType::AIFFText);
 
 		let push_item = |field: Option<String>, item_key: ItemKey, tag: &mut Tag| {
 			if let Some(text) = field {

--- a/src/iff/aiff/tag.rs
+++ b/src/iff/aiff/tag.rs
@@ -3,7 +3,7 @@ use crate::iff::chunk::Chunks;
 use crate::macros::err;
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
+use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
 
 use std::borrow::Cow;
 use std::convert::TryFrom;
@@ -216,12 +216,12 @@ impl TagExt for AIFFTextChunks {
 	}
 }
 
-impl SplitAndRejoinTag for AIFFTextChunks {
+impl SplitAndMergeTag for AIFFTextChunks {
 	fn split_tag(&mut self) -> Tag {
 		std::mem::take(self).into()
 	}
 
-	fn rejoin_tag(&mut self, tag: Tag) {
+	fn merge_tag(&mut self, tag: Tag) {
 		*self = tag.into();
 	}
 }

--- a/src/iff/wav/tag/mod.rs
+++ b/src/iff/wav/tag/mod.rs
@@ -4,7 +4,7 @@ mod write;
 use crate::error::{LoftyError, Result};
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
+use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
 
 use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
@@ -211,12 +211,12 @@ impl TagExt for RIFFInfoList {
 	}
 }
 
-impl SplitAndRejoinTag for RIFFInfoList {
+impl SplitAndMergeTag for RIFFInfoList {
 	fn split_tag(&mut self) -> Tag {
 		std::mem::take(self).into()
 	}
 
-	fn rejoin_tag(&mut self, tag: Tag) {
+	fn merge_tag(&mut self, tag: Tag) {
 		*self = tag.into();
 	}
 }

--- a/src/iff/wav/tag/mod.rs
+++ b/src/iff/wav/tag/mod.rs
@@ -4,7 +4,7 @@ mod write;
 use crate::error::{LoftyError, Result};
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, TagExt};
+use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
 
 use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
@@ -211,9 +211,19 @@ impl TagExt for RIFFInfoList {
 	}
 }
 
+impl SplitAndRejoinTag for RIFFInfoList {
+	fn split_tag(&mut self) -> Tag {
+		std::mem::take(self).into()
+	}
+
+	fn rejoin_tag(&mut self, tag: Tag) {
+		*self = tag.into();
+	}
+}
+
 impl From<RIFFInfoList> for Tag {
 	fn from(input: RIFFInfoList) -> Self {
-		let mut tag = Tag::new(TagType::RIFFInfo);
+		let mut tag = Self::new(TagType::RIFFInfo);
 
 		for (k, v) in input.items {
 			let item_key = ItemKey::from_key(TagType::RIFFInfo, &k);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ pub use crate::tag::{Tag, TagType};
 pub use tag::item::{ItemKey, ItemValue, TagItem};
 pub use util::text::TextEncoding;
 
-pub use crate::traits::{Accessor, TagExt};
+pub use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
 
 pub use picture::PictureInformation;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ pub use crate::tag::{Tag, TagType};
 pub use tag::item::{ItemKey, ItemValue, TagItem};
 pub use util::text::TextEncoding;
 
-pub use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
+pub use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
 
 pub use picture::PictureInformation;
 

--- a/src/mp4/ilst/atom.rs
+++ b/src/mp4/ilst/atom.rs
@@ -12,10 +12,10 @@ pub(super) enum AtomDataStorage {
 }
 
 impl AtomDataStorage {
-	pub(super) fn take_first(self) -> AtomData {
+	pub(super) fn first_mut(&mut self) -> &mut AtomData {
 		match self {
 			AtomDataStorage::Single(val) => val,
-			AtomDataStorage::Multiple(mut data) => data.swap_remove(0),
+			AtomDataStorage::Multiple(data) => data.first_mut().expect("not empty"),
 		}
 	}
 }

--- a/src/mp4/ilst/mod.rs
+++ b/src/mp4/ilst/mod.rs
@@ -10,7 +10,7 @@ use crate::mp4::ilst::atom::AtomDataStorage;
 use crate::picture::{Picture, PictureType, TOMBSTONE_PICTURE};
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
+use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
 use atom::{AdvisoryRating, Atom, AtomData};
 
 use std::borrow::Cow;
@@ -377,7 +377,7 @@ impl TagExt for Ilst {
 	}
 }
 
-impl SplitAndRejoinTag for Ilst {
+impl SplitAndMergeTag for Ilst {
 	fn split_tag(&mut self) -> Tag {
 		let mut tag = Tag::new(TagType::MP4ilst);
 
@@ -446,7 +446,7 @@ impl SplitAndRejoinTag for Ilst {
 		tag
 	}
 
-	fn rejoin_tag(&mut self, tag: Tag) {
+	fn merge_tag(&mut self, tag: Tag) {
 		fn convert_to_uint(space: &mut Option<u16>, cont: &str) {
 			if let Ok(num) = cont.parse::<u16>() {
 				*space = Some(num);
@@ -538,7 +538,7 @@ impl From<Ilst> for Tag {
 impl From<Tag> for Ilst {
 	fn from(input: Tag) -> Self {
 		let mut ilst = Self::default();
-		ilst.rejoin_tag(input);
+		ilst.merge_tag(input);
 		ilst
 	}
 }

--- a/src/ogg/tag.rs
+++ b/src/ogg/tag.rs
@@ -7,7 +7,7 @@ use crate::picture::{Picture, PictureInformation};
 use crate::probe::Probe;
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
+use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
 
 use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
@@ -328,7 +328,7 @@ impl TagExt for VorbisComments {
 	}
 }
 
-impl SplitAndRejoinTag for VorbisComments {
+impl SplitAndMergeTag for VorbisComments {
 	fn split_tag(&mut self) -> Tag {
 		let mut tag = Tag::new(TagType::VorbisComments);
 
@@ -359,7 +359,7 @@ impl SplitAndRejoinTag for VorbisComments {
 		tag
 	}
 
-	fn rejoin_tag(&mut self, mut tag: Tag) {
+	fn merge_tag(&mut self, mut tag: Tag) {
 		if let Some(TagItem {
 			item_value: ItemValue::Text(val),
 			..
@@ -403,7 +403,7 @@ impl From<VorbisComments> for Tag {
 impl From<Tag> for VorbisComments {
 	fn from(input: Tag) -> Self {
 		let mut vorbis_comments = Self::default();
-		vorbis_comments.rejoin_tag(input);
+		vorbis_comments.merge_tag(input);
 		vorbis_comments
 	}
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -502,8 +502,8 @@ impl Picture {
 		Self {
 			pic_type,
 			mime_type,
-			description: description.map(Cow::from),
-			data: Cow::from(data),
+			description: description.map(Cow::Owned),
+			data: Cow::Owned(data),
 		}
 	}
 
@@ -890,3 +890,11 @@ impl Picture {
 		}
 	}
 }
+
+// A placeholder that is needed during conversions.
+pub(crate) const TOMBSTONE_PICTURE: Picture = Picture {
+	pic_type: PictureType::Other,
+	mime_type: MimeType::Unknown(String::new()),
+	description: None,
+	data: Cow::Owned(Vec::new()),
+};

--- a/src/tag/mod.rs
+++ b/src/tag/mod.rs
@@ -6,7 +6,7 @@ use crate::file::FileType;
 use crate::macros::err;
 use crate::picture::{Picture, PictureType};
 use crate::probe::Probe;
-use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
+use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
 use item::{ItemKey, ItemValue, TagItem};
 
 use std::borrow::Cow;
@@ -583,12 +583,12 @@ impl TagExt for Tag {
 	}
 }
 
-impl SplitAndRejoinTag for Tag {
+impl SplitAndMergeTag for Tag {
 	fn split_tag(&mut self) -> Self {
 		std::mem::replace(self, Self::new(self.tag_type))
 	}
 
-	fn rejoin_tag(&mut self, tag: Self) {
+	fn merge_tag(&mut self, tag: Self) {
 		*self = tag;
 	}
 }

--- a/src/tag/mod.rs
+++ b/src/tag/mod.rs
@@ -6,7 +6,7 @@ use crate::file::FileType;
 use crate::macros::err;
 use crate::picture::{Picture, PictureType};
 use crate::probe::Probe;
-use crate::traits::{Accessor, TagExt};
+use crate::traits::{Accessor, SplitAndRejoinTag, TagExt};
 use item::{ItemKey, ItemValue, TagItem};
 
 use std::borrow::Cow;
@@ -580,6 +580,16 @@ impl TagExt for Tag {
 	fn clear(&mut self) {
 		self.items.clear();
 		self.pictures.clear();
+	}
+}
+
+impl SplitAndRejoinTag for Tag {
+	fn split_tag(&mut self) -> Self {
+		std::mem::replace(self, Self::new(self.tag_type))
+	}
+
+	fn rejoin_tag(&mut self, tag: Self) {
+		*self = tag;
 	}
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -233,6 +233,30 @@ pub trait TagExt: Accessor + Into<Tag> + Sized {
 	fn clear(&mut self);
 }
 
+/// Split and rejoin tags.
+///
+/// Useful and required for implementing read/modify/write round trips.
+pub trait SplitAndRejoinTag {
+	/// Extract and split generic contents into a [`Tag`].
+	///
+	/// Leaves the remainder that cannot be represented in the
+	/// resulting tag in `self`. This is useful if the modified [`Tag`]
+	/// is rejoined later using [`SplitAndRejoinTag::rejoin_tag`].
+	// NOTE: Using the "typestate pattern" (http://cliffle.com/blog/rust-typestate/)
+	// to represent the intermediate state turned out as less flexible
+	// and useful than expected.
+	fn split_tag(&mut self) -> Tag;
+
+	/// Rejoin a [`Tag`].
+	///
+	/// Rejoin a tag that has previously been obtained with
+	/// [`SplitAndRejoinTag::split_tag`].
+	///
+	/// Restores the original representation merged with the contents of
+	/// `tag` for further processing, e.g. writing back into a file.
+	fn rejoin_tag(&mut self, tag: Tag);
+}
+
 // TODO: https://github.com/rust-lang/rust/issues/59359
 pub(crate) trait SeekStreamLen: std::io::Seek {
 	fn stream_len(&mut self) -> crate::error::Result<u64> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -233,7 +233,7 @@ pub trait TagExt: Accessor + Into<Tag> + Sized {
 	fn clear(&mut self);
 }
 
-/// Split and rejoin tags.
+/// Split and merge tags.
 ///
 /// Useful and required for implementing lossless read/modify/write round trips.
 ///
@@ -241,7 +241,7 @@ pub trait TagExt: Accessor + Into<Tag> + Sized {
 ///
 /// ```no_run
 /// use lofty::mpeg::MPEGFile;
-/// use lofty::{AudioFile, ItemKey, SplitAndRejoinTag as _};
+/// use lofty::{AudioFile, ItemKey, SplitAndMergeTag as _};
 ///
 /// // Read the tag from a file
 /// # let mut file = std::fs::OpenOptions::new().write(true).open("/path/to/file.mp3")?;
@@ -264,19 +264,19 @@ pub trait TagExt: Accessor + Into<Tag> + Sized {
 /// tag.remove_key(&ItemKey::Composer);
 ///
 /// // ID3v2 <- [`lofty::Tag`]
-/// id3v2.rejoin_tag(tag);
+/// id3v2.merge_tag(tag);
 ///
 /// // Write the changes back into the file
 /// mpeg_file.save_to(&mut file)?;
 ///
 /// # Ok::<(), lofty::LoftyError>(())
 /// ```
-pub trait SplitAndRejoinTag {
+pub trait SplitAndMergeTag {
 	/// Extract and split generic contents into a [`Tag`].
 	///
 	/// Leaves the remainder that cannot be represented in the
 	/// resulting tag in `self`. This is useful if the modified [`Tag`]
-	/// is rejoined later using [`SplitAndRejoinTag::rejoin_tag`].
+	/// is merged later using [`SplitAndMergeTag::merge_tag`].
 	// NOTE: Using the "typestate pattern" (http://cliffle.com/blog/rust-typestate/)
 	// to represent the intermediate state turned out as less flexible
 	// and useful than expected.
@@ -285,11 +285,15 @@ pub trait SplitAndRejoinTag {
 	/// Rejoin a [`Tag`].
 	///
 	/// Rejoin a tag that has previously been obtained with
-	/// [`SplitAndRejoinTag::split_tag`].
+	/// [`SplitAndMergeTag::split_tag`].
 	///
 	/// Restores the original representation merged with the contents of
 	/// `tag` for further processing, e.g. writing back into a file.
-	fn rejoin_tag(&mut self, tag: Tag);
+	///
+	/// This method must only be called once and after [`Self::split_tag`]!
+	/// Otherwise the behavior is undefined and may result in redundancies
+	/// or inconsistencies.
+	fn merge_tag(&mut self, tag: Tag);
 }
 
 // TODO: https://github.com/rust-lang/rust/issues/59359


### PR DESCRIPTION
Adds a new trait `SplitAndRejoinTag` with methods that are needed for safely and efficiently implementing read/modify/write round trips when synchronizing metadata:

- `fn split_tag(&mut self) -> Tag;`
- `fn rejoin_tag(&mut self);`

The central function from my code base that accomplishes the task demonstrates how they are supposed to be used:

```rust
fn split_export_rejoin_track_to_tag<T>(
    tag_repr: &mut T,
    config: &ExportTrackConfig,
    track: &mut Track,
    edit_embedded_artwork_image: Option<EditEmbeddedArtworkImage>,
) where
    T: SplitAndRejoinTag,
{
    // Split the generic tag contents from the underlying representation.
    // The remainder will remain untouched while modifying the generic tag.
    let mut tag = tag_repr.split_tag();
    // Export the metadata of the given track into the generic tag, i.e.
    // add, modify, or delete items and pictures accordingly.
    export_track_to_tag(&mut tag, config, track, edit_embedded_artwork_image);
    // Rejoin the generic tag contents back into the remainder of the underlying
    // representation.
    tag_repr.rejoin_tag(tag);
    // Depending on `T` some post-processing might be required in the outer context
    // to update contents in `tag_repr` that are not (yet) supported by the generic
    // `lofty::Tag` representation.
}
```

~~Ideally the task would be implemented using a type-state-pattern that consumes its arguments to prevent mutating the remainder between split and rejoin. I am considering this alternative, stay tuned...~~ Didn't turn out as helpful. I left a comment in the docs in case anyone has the same idea.