### PR TITLE
id3v2/mp4/ogg: Add tests for multi-valued item conversion

### DIFF
--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -734,12 +734,9 @@ impl SplitAndMergeTag for ID3v2Tag {
 			}
 		}
 
-		let comment_frame_id = ItemKey::Comment
-			.map_key(TagType::ID3v2, false)
-			.expect("valid frame id");
 		if let Some(text) = join_text_items(&mut tag, &ItemKey::Comment) {
 			let frame = Frame {
-				id: FrameID::Valid(Cow::Borrowed(comment_frame_id)),
+				id: FrameID::Valid(Cow::Borrowed(COMMENT_FRAME_ID)),
 				value: FrameValue::Comment(LanguageFrame {
 					encoding: TextEncoding::UTF8,
 					language: UNKNOWN_LANGUAGE,
@@ -751,7 +748,7 @@ impl SplitAndMergeTag for ID3v2Tag {
 			let replaced_frame = self.insert(frame);
 			debug_assert!(replaced_frame.is_none());
 		} else {
-			self.remove(comment_frame_id);
+			self.remove_comment();
 		};
 
 		for item in tag.items {

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -735,18 +735,9 @@ impl SplitAndMergeTag for ID3v2Tag {
 		}
 
 		if let Some(text) = join_text_items(&mut tag, &ItemKey::Comment) {
-			let frame = Frame {
-				id: FrameID::Valid(Cow::Borrowed(COMMENT_FRAME_ID)),
-				value: FrameValue::Comment(LanguageFrame {
-					encoding: TextEncoding::UTF8,
-					language: UNKNOWN_LANGUAGE,
-					description: EMPTY_CONTENT_DESCRIPTOR,
-					content: text,
-				}),
-				flags: FrameFlags::default(),
-			};
-			let replaced_frame = self.insert(frame);
-			debug_assert!(replaced_frame.is_none());
+			// The first comment frame is either replaced or added.
+			debug_assert!(self.comments().count() <= 1);
+			self.set_comment(text);
 		} else {
 			self.remove_comment();
 		};

--- a/src/mp4/ilst/mod.rs
+++ b/src/mp4/ilst/mod.rs
@@ -550,8 +550,11 @@ mod tests {
 	use crate::mp4::{AdvisoryRating, Atom, AtomData, AtomIdent, Ilst, Mp4File};
 	use crate::tag::utils::test_utils;
 	use crate::tag::utils::test_utils::read_path;
-	use crate::{Accessor, AudioFile, ItemKey, ParseOptions, Tag, TagExt, TagType};
-	use std::io::{Cursor, Read, Seek, Write};
+	use crate::{
+		Accessor as _, AudioFile, ItemKey, ItemValue, ParseOptions, SplitAndMergeTag as _, Tag,
+		TagExt as _, TagItem, TagType,
+	};
+	use std::io::{Cursor, Read as _, Seek as _, Write as _};
 
 	fn read_ilst(path: &str) -> Ilst {
 		let tag = crate::tag::utils::test_utils::read_path(path);
@@ -872,6 +875,69 @@ mod tests {
 			*b"\xa9gen",
 			&AtomData::UTF8(String::from("Classical")),
 		);
+	}
+
+	#[test]
+	fn multi_value_roundtrip() {
+		let mut tag = Tag::new(TagType::MP4ilst);
+		tag.insert_text(ItemKey::TrackArtist, "TrackArtist 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::TrackArtist,
+			ItemValue::Text("TrackArtist 2".to_owned()),
+		));
+		tag.insert_text(ItemKey::AlbumArtist, "AlbumArtist 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::AlbumArtist,
+			ItemValue::Text("AlbumArtist 2".to_owned()),
+		));
+		tag.insert_text(ItemKey::TrackTitle, "TrackTitle 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::TrackTitle,
+			ItemValue::Text("TrackTitle 2".to_owned()),
+		));
+		tag.insert_text(ItemKey::AlbumTitle, "AlbumTitle 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::AlbumTitle,
+			ItemValue::Text("AlbumTitle 2".to_owned()),
+		));
+		tag.insert_text(ItemKey::Comment, "Comment 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::Comment,
+			ItemValue::Text("Comment 2".to_owned()),
+		));
+		tag.insert_text(ItemKey::ContentGroup, "ContentGroup 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::ContentGroup,
+			ItemValue::Text("ContentGroup 2".to_owned()),
+		));
+		tag.insert_text(ItemKey::Genre, "Genre 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::Genre,
+			ItemValue::Text("Genre 2".to_owned()),
+		));
+		tag.insert_text(ItemKey::Mood, "Mood 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::Mood,
+			ItemValue::Text("Mood 2".to_owned()),
+		));
+		tag.insert_text(ItemKey::Composer, "Composer 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::Composer,
+			ItemValue::Text("Composer 2".to_owned()),
+		));
+		tag.insert_text(ItemKey::Conductor, "Conductor 1".to_owned());
+		tag.push_item(TagItem::new(
+			ItemKey::Conductor,
+			ItemValue::Text("Conductor 2".to_owned()),
+		));
+		assert_eq!(20, tag.len());
+
+		let mut ilst = Ilst::from(tag.clone());
+		let split_tag = ilst.split_tag();
+
+		assert_eq!(0, ilst.len());
+		assert_eq!(tag.len(), split_tag.len());
+		assert_eq!(tag.items, split_tag.items);
 	}
 
 	#[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -290,9 +290,12 @@ pub trait SplitAndMergeTag {
 	/// Restores the original representation merged with the contents of
 	/// `tag` for further processing, e.g. writing back into a file.
 	///
+	/// Multi-valued items in `tag` with identical keys might get lost
+	/// depending on the support for multi-valued fields in `self`.
+	///
 	/// This method must only be called once and after [`Self::split_tag`]!
-	/// Otherwise the behavior is undefined and may result in redundancies
-	/// or inconsistencies.
+	/// None of the items in `tag` must be present in `self`. Otherwise the
+	/// behavior is undefined and may result in redundancies or inconsistencies.
 	fn merge_tag(&mut self, tag: Tag);
 }
 


### PR DESCRIPTION
The support for multi-valued items in ID3v2 tags was very limited as I noticed while fixing an issue in the context of #103:

- Extend support for multi-valued field in ID3v2 tags, i.e. not only `TrackArtist`.
- Warn when replacing and dropping multi-valued items in ID3v2 tags unintentionally.
- Add tests for conversion round trips with multi-valued items.

This is probably not the most elegant solution, but at least a start accompanied by tests.