### PR TITLE
v0.12.0: Separate SplitAndMergeTag into SplitTag/MergeTag for compile-time safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **APE**/**ID3v1**/**ID3v2**/**Tag**:
   - Allow empty strings as values instead of removing the corresponding item when empty ([PR](https://github.com/Serial-ATA/lofty-rs/pull/134))
+  - Separated the trait `SplitAndMergeTag` into `SplitTag` and `MergeTag` to prevent any unexpected or undefined behavior at runtime ([#143](https://github.com/Serial-ATA/lofty-rs/pull/143))
 
 ### Fixed
 - **ID3v2**:

--- a/src/iff/aiff/tag.rs
+++ b/src/iff/aiff/tag.rs
@@ -3,7 +3,7 @@ use crate::iff::chunk::Chunks;
 use crate::macros::err;
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{Tag, TagType};
-use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
+use crate::traits::{Accessor, MergeTag, SplitTag, TagExt};
 
 use std::borrow::Cow;
 use std::convert::TryFrom;
@@ -216,13 +216,22 @@ impl TagExt for AIFFTextChunks {
 	}
 }
 
-impl SplitAndMergeTag for AIFFTextChunks {
-	fn split_tag(&mut self) -> Tag {
-		std::mem::take(self).into()
-	}
+#[derive(Debug, Clone, Default)]
+pub struct SplitTagRemainder;
 
-	fn merge_tag(&mut self, tag: Tag) {
-		*self = tag.into();
+impl SplitTag for AIFFTextChunks {
+	type Remainder = SplitTagRemainder;
+
+	fn split_tag(self) -> (Self::Remainder, Tag) {
+		(SplitTagRemainder, self.into())
+	}
+}
+
+impl MergeTag for SplitTagRemainder {
+	type Merged = AIFFTextChunks;
+
+	fn merge_tag(self, tag: Tag) -> Self::Merged {
+		tag.into()
 	}
 }
 

--- a/src/iff/wav/tag/mod.rs
+++ b/src/iff/wav/tag/mod.rs
@@ -4,7 +4,7 @@ mod write;
 use crate::error::{LoftyError, Result};
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{try_parse_year, Tag, TagType};
-use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
+use crate::traits::{Accessor, MergeTag, SplitTag, TagExt};
 
 use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
@@ -211,13 +211,22 @@ impl TagExt for RIFFInfoList {
 	}
 }
 
-impl SplitAndMergeTag for RIFFInfoList {
-	fn split_tag(&mut self) -> Tag {
-		std::mem::take(self).into()
-	}
+#[derive(Debug, Clone, Default)]
+pub struct SplitTagRemainder;
 
-	fn merge_tag(&mut self, tag: Tag) {
-		*self = tag.into();
+impl SplitTag for RIFFInfoList {
+	type Remainder = SplitTagRemainder;
+
+	fn split_tag(self) -> (Self::Remainder, Tag) {
+		(SplitTagRemainder, self.into())
+	}
+}
+
+impl MergeTag for SplitTagRemainder {
+	type Merged = RIFFInfoList;
+
+	fn merge_tag(self, tag: Tag) -> Self::Merged {
+		tag.into()
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub use crate::tag::{Tag, TagType};
 pub use tag::item::{ItemKey, ItemValue, TagItem};
 pub use util::text::TextEncoding;
 
-pub use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
+pub use crate::traits::{Accessor, MergeTag, SplitTag, TagExt};
 
 pub use picture::PictureInformation;
 

--- a/src/tag/mod.rs
+++ b/src/tag/mod.rs
@@ -6,7 +6,7 @@ use crate::file::FileType;
 use crate::macros::err;
 use crate::picture::{Picture, PictureType};
 use crate::probe::Probe;
-use crate::traits::{Accessor, SplitAndMergeTag, TagExt};
+use crate::traits::{Accessor, MergeTag, SplitTag, TagExt};
 use item::{ItemKey, ItemValue, TagItem};
 
 use std::borrow::Cow;
@@ -592,13 +592,22 @@ impl TagExt for Tag {
 	}
 }
 
-impl SplitAndMergeTag for Tag {
-	fn split_tag(&mut self) -> Self {
-		std::mem::replace(self, Self::new(self.tag_type))
-	}
+#[derive(Debug, Clone, Default)]
+pub struct SplitTagRemainder;
 
-	fn merge_tag(&mut self, tag: Self) {
-		*self = tag;
+impl SplitTag for Tag {
+	type Remainder = SplitTagRemainder;
+
+	fn split_tag(self) -> (Self::Remainder, Self) {
+		(SplitTagRemainder, self)
+	}
+}
+
+impl MergeTag for SplitTagRemainder {
+	type Merged = Tag;
+
+	fn merge_tag(self, tag: Tag) -> Self::Merged {
+		tag
 	}
 }
 


### PR DESCRIPTION
This is the follow-up for #137 to avoid unexpected/undefined behavior at runtime.

Finally, the typestate pattern is in place. Separation into 2 traits was the missing link.