### PR TITLE
ID3v2: Fix about number pair of track and disk

### DIFF
--- a/src/id3/v2/frame/mod.rs
+++ b/src/id3/v2/frame/mod.rs
@@ -361,6 +361,7 @@ impl From<TagItem> for Option<Frame<'static>> {
 	}
 }
 
+#[derive(Clone)]
 pub(crate) struct FrameRef<'a> {
 	pub id: FrameID<'a>,
 	pub value: Cow<'a, FrameValue>,

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -27,7 +27,7 @@ const V4_MULTI_VALUE_SEPARATOR: char = '\0';
 const NUMBER_PAIR_SEPARATOR: char = '/';
 
 // This is used as the default number of track and disk.
-const DEFAULT_NUMBER_IN_PAIR: u32 = 1;
+const DEFAULT_NUMBER_IN_PAIR: u32 = 0;
 
 // These keys have the part of the number pair.
 const NUMBER_PAIR_KEYS: &[ItemKey] = &[

--- a/tests/files/mpeg.rs
+++ b/tests/files/mpeg.rs
@@ -240,9 +240,9 @@ fn save_total_of_track_and_disk_to_id3v2() {
 
 	let tag = tagged_file.tag(TagType::ID3v2).unwrap();
 
-	assert_eq!(tag.track().unwrap(), 1);
+	assert_eq!(tag.track().unwrap(), 0);
 	assert_eq!(tag.track_total().unwrap(), track_total);
-	assert_eq!(tag.disk().unwrap(), 1);
+	assert_eq!(tag.disk().unwrap(), 0);
 	assert_eq!(tag.disk_total().unwrap(), disk_total);
 }
 


### PR DESCRIPTION
This PR fixes #145.

TODOs

- [x] Rebase to the main branch for conflict.
- [x] Fix id3::v2::tag::tag_frames() that called from tag::Tag::save_to().
- [x] Add tests about frame values.
- [x] Improve parsing number pair.