### PR TITLE
GitHub CI: Replace actions-rs with dtolnay/rust-toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "weekly"
     labels:
       - "dependency"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,19 +13,18 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
 
       - name: Run benchmark
         env:
-            RUSTFLAGS: "--cfg bench"
-        run: cargo bench --all-features -- --output-format bencher | tee output.txt
+          RUSTFLAGS: '--cfg bench'
+        run: |
+          cargo bench --all-features -- --output-format bencher | tee output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,7 @@ on:
       - 'ogg_pager/**'
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   benchmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,73 +25,74 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Dependencies
+      - uses: actions/checkout@v3
+      - name: Install test dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y ffmpeg # Need ffprobe for issue #37
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg # Need ffprobe for issue #37
           sudo apt-get install -y opus-tools # Need opusinfo for issue #130
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - run: cargo test --all-features --tests
+      - run: |
+          cargo test --all-features --tests
+
   docs:
     strategy:
       matrix:
-        project: [ '.', 'ogg_pager', 'lofty_attr' ]
+        project: ['.', 'ogg_pager', 'lofty_attr']
     defaults:
-        run:
-            working-directory: ${{ matrix.project }}
+      run:
+        working-directory: ${{ matrix.project }}
     name: Docs
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - run: |
           cargo doc --all-features --no-deps
           cargo test --all-features --doc
+
   clippy:
     strategy:
       matrix:
-        project: [ '.', 'ogg_pager', 'lofty_attr' ]
+        project: ['.', 'ogg_pager', 'lofty_attr']
     defaults:
-        run:
-            working-directory: ${{ matrix.project }}
+      run:
+        working-directory: ${{ matrix.project }}
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
+          components: clippy
       - run: |
-          rustup component add clippy
           cargo clippy --all-features -- -Dclippy::all -Dclippy::pedantic
+
   style:
     strategy:
       matrix:
-        project: [ '.', 'ogg_pager', 'lofty_attr' ]
+        project: ['.', 'ogg_pager', 'lofty_attr']
     defaults:
-        run:
-            working-directory: ${{ matrix.project }}
+      run:
+        working-directory: ${{ matrix.project }}
     name: Style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
+          components: rustfmt
       - run: |
-          rustup component add rustfmt
           cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
https://github.com/actions-rs/cargo is unmaintained.