### PR TITLE
Expose channel mask in file properties

### DIFF
--- a/src/aac/properties.rs
+++ b/src/aac/properties.rs
@@ -87,6 +87,7 @@ impl From<AACProperties> for FileProperties {
 			sample_rate: Some(input.sample_rate),
 			bit_depth: None,
 			channels: Some(input.channels),
+			channel_mask: None,
 		}
 	}
 }

--- a/src/ape/properties.rs
+++ b/src/ape/properties.rs
@@ -30,6 +30,7 @@ impl From<ApeProperties> for FileProperties {
 			sample_rate: Some(input.sample_rate),
 			bit_depth: Some(input.bit_depth),
 			channels: Some(input.channels),
+			channel_mask: None,
 		}
 	}
 }

--- a/src/flac/properties.rs
+++ b/src/flac/properties.rs
@@ -28,6 +28,7 @@ impl From<FlacProperties> for FileProperties {
 			sample_rate: Some(input.sample_rate),
 			bit_depth: Some(input.bit_depth),
 			channels: Some(input.channels),
+			channel_mask: None,
 		}
 	}
 }

--- a/src/iff/aiff/properties.rs
+++ b/src/iff/aiff/properties.rs
@@ -69,5 +69,6 @@ pub(super) fn read_properties(
 		sample_rate: Some(sample_rate),
 		bit_depth: Some(sample_size as u8),
 		channels: Some(channels),
+		channel_mask: None,
 	})
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,3 +195,35 @@ pub(crate) const fn div_ceil(dividend: u64, divisor: u64) -> u64 {
 		d
 	}
 }
+
+/// Channel mask
+///
+/// A mask of (at least) 18 bits, one for each channel.
+///
+/// Standard speaker channels: <https://www.wikipedia.org/wiki/Surround_sound>
+/// CAF channel bitmap: <https://developer.apple.com/library/archive/documentation/MusicAudio/Reference/CAFSpec/CAF_spec/CAF_spec.html#//apple_ref/doc/uid/TP40001862-CH210-BCGBHHHI>
+/// WAV default channel ordering: <https://learn.microsoft.com/en-us/previous-versions/windows/hardware/design/dn653308(v=vs.85)?redirectedfrom=MSDN#default-channel-ordering>
+/// FFmpeg: <https://ffmpeg.org/doxygen/trunk/group__channel__masks.html>
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct ChannelMask(pub(crate) u32);
+
+impl ChannelMask {
+	/// A single front center channel
+	#[must_use]
+	pub const fn mono() -> Self {
+		Self(0x4) // front center
+	}
+
+	/// Front left+right channels
+	#[must_use]
+	pub const fn stereo() -> Self {
+		Self(0x3) // front left (0x1) + front right (0x2)
+	}
+
+	/// The bit mask
+	#[must_use]
+	pub const fn bits(self) -> u32 {
+		self.0
+	}
+}

--- a/src/mp4/properties.rs
+++ b/src/mp4/properties.rs
@@ -151,6 +151,7 @@ impl From<Mp4Properties> for FileProperties {
 			sample_rate: Some(input.sample_rate),
 			bit_depth: input.bit_depth,
 			channels: Some(input.channels),
+			channel_mask: None,
 		}
 	}
 }

--- a/src/mpeg/properties.rs
+++ b/src/mpeg/properties.rs
@@ -2,6 +2,7 @@ use super::header::{ChannelMode, Emphasis, Header, Layer, MpegVersion, XingHeade
 use crate::error::Result;
 use crate::mpeg::header::{cmp_header, rev_search_for_frame_sync, HeaderCmpResult, HEADER_MASK};
 use crate::properties::FileProperties;
+use crate::ChannelMask;
 
 use std::io::{Read, Seek, SeekFrom};
 use std::time::Duration;
@@ -28,13 +29,33 @@ pub struct MPEGProperties {
 
 impl From<MPEGProperties> for FileProperties {
 	fn from(input: MPEGProperties) -> Self {
+		let MPEGProperties {
+			duration,
+			overall_bitrate,
+			audio_bitrate,
+			sample_rate,
+			channels,
+			channel_mode,
+			version: _,
+			layer: _,
+			copyright: _,
+			emphasis: _,
+			mode_extension: _,
+			original: _,
+		} = input;
+		let channel_mask = match channel_mode {
+			ChannelMode::SingleChannel => Some(ChannelMask::mono()),
+			ChannelMode::Stereo | ChannelMode::JointStereo => Some(ChannelMask::stereo()),
+			ChannelMode::DualChannel => None, // Cannot be represented by ChannelMask
+		};
 		Self {
-			duration: input.duration,
-			overall_bitrate: Some(input.overall_bitrate),
-			audio_bitrate: Some(input.audio_bitrate),
-			sample_rate: Some(input.sample_rate),
+			duration,
+			overall_bitrate: Some(overall_bitrate),
+			audio_bitrate: Some(audio_bitrate),
+			sample_rate: Some(sample_rate),
 			bit_depth: None,
-			channels: Some(input.channels),
+			channels: Some(channels),
+			channel_mask,
 		}
 	}
 }

--- a/src/ogg/opus/properties.rs
+++ b/src/ogg/opus/properties.rs
@@ -30,6 +30,7 @@ impl From<OpusProperties> for FileProperties {
 			sample_rate: Some(input.input_sample_rate),
 			bit_depth: None,
 			channels: Some(input.channels),
+			channel_mask: None,
 		}
 	}
 }

--- a/src/ogg/speex/properties.rs
+++ b/src/ogg/speex/properties.rs
@@ -33,6 +33,7 @@ impl From<SpeexProperties> for FileProperties {
 			sample_rate: Some(input.sample_rate),
 			bit_depth: None,
 			channels: Some(input.channels),
+			channel_mask: None,
 		}
 	}
 }

--- a/src/ogg/vorbis/properties.rs
+++ b/src/ogg/vorbis/properties.rs
@@ -32,6 +32,7 @@ impl From<VorbisProperties> for FileProperties {
 			sample_rate: Some(input.sample_rate),
 			bit_depth: None,
 			channels: Some(input.channels),
+			channel_mask: None,
 		}
 	}
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use crate::ChannelMask;
+
 /// Various *immutable* audio properties
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
@@ -10,6 +12,7 @@ pub struct FileProperties {
 	pub(crate) sample_rate: Option<u32>,
 	pub(crate) bit_depth: Option<u8>,
 	pub(crate) channels: Option<u8>,
+	pub(crate) channel_mask: Option<ChannelMask>,
 }
 
 impl Default for FileProperties {
@@ -21,6 +24,7 @@ impl Default for FileProperties {
 			sample_rate: None,
 			bit_depth: None,
 			channels: None,
+			channel_mask: None,
 		}
 	}
 }
@@ -35,6 +39,7 @@ impl FileProperties {
 		sample_rate: Option<u32>,
 		bit_depth: Option<u8>,
 		channels: Option<u8>,
+		channel_mask: Option<ChannelMask>,
 	) -> Self {
 		Self {
 			duration,
@@ -43,6 +48,7 @@ impl FileProperties {
 			sample_rate,
 			bit_depth,
 			channels,
+			channel_mask,
 		}
 	}
 
@@ -119,6 +125,7 @@ mod tests {
 		sample_rate: Some(48000),
 		bit_depth: Some(16),
 		channels: Some(2),
+		channel_mask: None,
 	};
 
 	const APE_PROPERTIES: ApeProperties = ApeProperties {
@@ -271,6 +278,7 @@ mod tests {
 		sample_rate: 48000,
 		bit_depth: 16,
 		channels: 2,
+		channel_mask: None,
 	};
 
 	const WAVPACK_PROPERTIES: WavPackProperties = WavPackProperties {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -81,6 +81,11 @@ impl FileProperties {
 	pub fn channels(&self) -> Option<u8> {
 		self.channels
 	}
+
+	/// Channel mask
+	pub fn channel_mask(&self) -> Option<ChannelMask> {
+		self.channel_mask
+	}
 }
 
 #[cfg(test)]

--- a/src/wavpack/properties.rs
+++ b/src/wavpack/properties.rs
@@ -31,6 +31,7 @@ impl From<WavPackProperties> for FileProperties {
 			sample_rate: Some(input.sample_rate),
 			bit_depth: Some(input.bit_depth),
 			channels: Some(input.channels),
+			channel_mask: None,
 		}
 	}
 }


### PR DESCRIPTION
Currently only supported by WAV files.

- The `ChannelMask` newtype cannot be constructed, i.e. read-only. Edit: Only the `mono()` and `stereo()` constructors are public for convenience and also serve as examples.
- Implementation detail: Explicit destructuring of format-specific file properties upon conversion is safer when new fields are added in the future.