### PR TITLE
picture: add `into_data()`

### DIFF
--- a/src/picture.rs
+++ b/src/picture.rs
@@ -535,9 +535,14 @@ impl Picture {
 		self.description = description.map(Cow::from);
 	}
 
-	/// Returns the picture data
+	/// Returns the [`Picture`] data as borrowed bytes.
 	pub fn data(&self) -> &[u8] {
 		&self.data
+	}
+
+	/// Consumes a [`Picture`], returning the data as [`Vec`] without clones or allocation.
+	pub fn into_data(self) -> Vec<u8> {
+		self.data.into_owned()
 	}
 
 	/// Convert a [`Picture`] to a ID3v2 A/PIC byte Vec


### PR DESCRIPTION
This adds some functions that exposes the inner data.

Since the inner `Cow` is `Cow::Owned`, `into_owned()` _should_ be a cheap no-clone/no-allocation call.

Also, most libraries seem use `bytes()` or `as_bytes()` instead of `data()` but that'll break everyone's code, so, maybe not worth it.