### PR TITLE
tag: Check for and remove empty item values

### DIFF
--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -657,6 +657,15 @@ impl ItemValue {
 			_ => None,
 		}
 	}
+
+	/// Check for emptiness
+	pub fn is_empty(&self) -> bool {
+		match self {
+			Self::Binary(binary) => binary.is_empty(),
+			Self::Locator(locator) => locator.is_empty(),
+			Self::Text(text) => text.is_empty(),
+		}
+	}
 }
 
 pub(crate) enum ItemValueRef<'a> {

--- a/src/tag/mod.rs
+++ b/src/tag/mod.rs
@@ -426,6 +426,11 @@ impl Tag {
 		self.items.retain(f)
 	}
 
+	/// Remove all items with empty values
+	pub fn remove_empty(&mut self) {
+		self.items.retain(|item| !item.value().is_empty());
+	}
+
 	/// Returns the stored [`Picture`]s as a slice
 	pub fn pictures(&self) -> &[Picture] {
 		&self.pictures


### PR DESCRIPTION
Successor for #180. The method `Tag::remove_empty()` is not strictly necessary, but probably convenient.