### PR TITLE
ID3v2: Remove unnecessary allocations

### DIFF
--- a/src/id3/v2/frame/mod.rs
+++ b/src/id3/v2/frame/mod.rs
@@ -362,7 +362,7 @@ impl From<TagItem> for Option<Frame<'static>> {
 						})
 					},
 					(FrameId::Valid(ref s), ItemValue::Binary(text)) if s == "POPM" => {
-						FrameValue::Popularimeter(Popularimeter::parse(&text).ok()?)
+						FrameValue::Popularimeter(Popularimeter::parse(&mut &text[..]).ok()?)
 					},
 					(_, item_value) => {
 						let Ok(value) = item_value.try_into() else {
@@ -496,7 +496,7 @@ impl<'a> TryFrom<&'a TagItem> for FrameRef<'a> {
 						})
 					},
 					("POPM", ItemValue::Binary(contents)) => {
-						FrameValue::Popularimeter(Popularimeter::parse(contents)?)
+						FrameValue::Popularimeter(Popularimeter::parse(&mut &contents[..])?)
 					},
 					(_, value) => value.try_into()?,
 				};

--- a/src/id3/v2/items/extended_text_frame.rs
+++ b/src/id3/v2/items/extended_text_frame.rs
@@ -4,7 +4,7 @@ use crate::id3::v2::ID3v2Version;
 use crate::util::text::{decode_text, encode_text, read_to_terminator, utf16_decode, TextEncoding};
 
 use std::hash::{Hash, Hasher};
-use std::io::{Cursor, Read};
+use std::io::Read;
 
 use byteorder::ReadBytesExt;
 
@@ -48,53 +48,58 @@ impl ExtendedTextFrame {
 	/// ID3v2.2:
 	///
 	/// * The encoding is not [`TextEncoding::Latin1`] or [`TextEncoding::UTF16`]
-	pub fn parse(content: &[u8], version: ID3v2Version) -> Result<Option<Self>> {
-		if content.len() < 2 {
+	pub fn parse<R>(reader: &mut R, version: ID3v2Version) -> Result<Option<Self>>
+	where
+		R: Read,
+	{
+		let Ok(encoding_byte) = reader.read_u8() else {
 			return Ok(None);
-		}
+		};
 
-		let mut content = &mut &content[..];
-		let encoding = verify_encoding(content.read_u8()?, version)?;
-
-		let mut endianness: fn([u8; 2]) -> u16 = u16::from_le_bytes;
-		if encoding == TextEncoding::UTF16 {
-			let mut cursor = Cursor::new(content);
-			let mut bom = [0; 2];
-			cursor.read_exact(&mut bom)?;
-
-			match [bom[0], bom[1]] {
-				[0xFF, 0xFE] => endianness = u16::from_le_bytes,
-				[0xFE, 0xFF] => endianness = u16::from_be_bytes,
-				// We'll catch an invalid BOM below
-				_ => {},
-			};
-
-			content = cursor.into_inner();
-		}
-
-		let description = decode_text(content, encoding, true)?.content;
+		let encoding = verify_encoding(encoding_byte, version)?;
+		let description = decode_text(reader, encoding, true)?;
 
 		let frame_content;
+		if encoding != TextEncoding::UTF16 {
+			frame_content = decode_text(reader, encoding, false)?.content;
+
+			return Ok(Some(ExtendedTextFrame {
+				encoding,
+				description: description.content,
+				content: frame_content,
+			}));
+		}
+
 		// It's possible for the description to be the only string with a BOM
-		if encoding == TextEncoding::UTF16 {
-			if content.len() >= 2 && (content[..2] == [0xFF, 0xFE] || content[..2] == [0xFE, 0xFF])
-			{
-				frame_content = decode_text(content, encoding, false)?.content;
-			} else {
-				frame_content = match read_to_terminator(content, TextEncoding::UTF16) {
-					Some(raw_text) => utf16_decode(&raw_text, endianness).map_err(|_| {
-						Into::<LoftyError>::into(Id3v2Error::new(Id3v2ErrorKind::BadSyncText))
-					})?,
-					None => String::new(),
-				}
+		'utf16: {
+			let bom = description.bom;
+			let Some(raw_text) = read_to_terminator(reader, TextEncoding::UTF16) else {
+				// Nothing left to do
+				frame_content = String::new();
+				break 'utf16;
+			};
+
+			if raw_text.starts_with(&[0xFF, 0xFE]) || raw_text.starts_with(&[0xFE, 0xFF]) {
+				frame_content =
+					decode_text(&mut &raw_text[..], TextEncoding::UTF16, false)?.content;
+				break 'utf16;
 			}
-		} else {
-			frame_content = decode_text(content, encoding, false)?.content;
+
+			let endianness = match bom {
+				[0xFF, 0xFE] => u16::from_le_bytes,
+				[0xFE, 0xFF] => u16::from_be_bytes,
+				// Handled in description decoding
+				_ => unreachable!(),
+			};
+
+			frame_content = utf16_decode(&raw_text, endianness).map_err(|_| {
+				Into::<LoftyError>::into(Id3v2Error::new(Id3v2ErrorKind::BadSyncText))
+			})?;
 		}
 
 		Ok(Some(ExtendedTextFrame {
 			encoding,
-			description,
+			description: description.content,
 			content: frame_content,
 		}))
 	}

--- a/src/id3/v2/items/url_link_frame.rs
+++ b/src/id3/v2/items/url_link_frame.rs
@@ -1,6 +1,8 @@
 use crate::error::Result;
 use crate::util::text::{decode_text, encode_text, TextEncoding};
 
+use std::io::Read;
+
 /// An `ID3v2` URL frame
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct UrlLinkFrame(pub(crate) String);
@@ -13,14 +15,16 @@ impl UrlLinkFrame {
 	/// # Errors
 	///
 	/// * Unable to decode the text as [`TextEncoding::Latin1`]
-	pub fn parse(content: &[u8]) -> Result<Option<Self>> {
-		if content.is_empty() {
+	pub fn parse<R>(reader: &mut R) -> Result<Option<Self>>
+	where
+		R: Read,
+	{
+		let url = decode_text(reader, TextEncoding::Latin1, true)?;
+		if url.bytes_read == 0 {
 			return Ok(None);
 		}
 
-		let url = decode_text(&mut &content[..], TextEncoding::Latin1, true)?.content;
-
-		Ok(Some(UrlLinkFrame(url)))
+		Ok(Some(UrlLinkFrame(url.content)))
 	}
 
 	/// Convert an [`UrlLinkFrame`] to a byte vec

--- a/src/id3/v2/mod.rs
+++ b/src/id3/v2/mod.rs
@@ -51,7 +51,7 @@ pub enum ID3v2Version {
 	V4,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct ID3v2Header {
 	pub version: ID3v2Version,
 	pub flags: ID3v2TagFlags,

--- a/tests/picture/format_parsers.rs
+++ b/tests/picture/format_parsers.rs
@@ -28,7 +28,7 @@ fn create_original_picture() -> Picture {
 fn id3v24_apic() {
 	let buf = get_buf("tests/picture/assets/png_640x628.apic");
 
-	let apic = AttachedPictureFrame::parse(&buf, ID3v2Version::V4).unwrap();
+	let apic = AttachedPictureFrame::parse(&mut &buf[..], ID3v2Version::V4).unwrap();
 
 	assert_eq!(create_original_picture(), apic.picture);
 }
@@ -52,7 +52,7 @@ fn as_apic_bytes() {
 fn id3v22_pic() {
 	let buf = get_buf("tests/picture/assets/png_640x628.pic");
 
-	let pic = AttachedPictureFrame::parse(&buf, ID3v2Version::V2).unwrap();
+	let pic = AttachedPictureFrame::parse(&mut &buf[..], ID3v2Version::V2).unwrap();
 
 	assert_eq!(create_original_picture(), pic.picture);
 }


### PR DESCRIPTION
Previously, we would immediately read the entire tag into memory as well as each frame's content. Now, we only allocate when necessary, reusing the original reader.