### PR TITLE
MP4: Fix parsing of plID atoms with incorrect codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **MP4**: Fixed potential panic with malformed `plID` atoms ([issue](https://github.com/Serial-ATA/lofty-rs/issues/201)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/202))
+
 ## [0.13.0] - 2023-05-08
 
 ### Added

--- a/src/mp4/ilst/read.rs
+++ b/src/mp4/ilst/read.rs
@@ -1,6 +1,5 @@
 use super::constants::{
-	BE_64BIT_SIGNED_INTEGER, BE_SIGNED_INTEGER, BE_UNSIGNED_INTEGER, BMP, JPEG, PNG, RESERVED,
-	UTF16, UTF8,
+	BE_SIGNED_INTEGER, BE_UNSIGNED_INTEGER, BMP, JPEG, PNG, RESERVED, UTF16, UTF8,
 };
 use super::{Atom, AtomData, AtomIdent, Ilst};
 use crate::error::Result;
@@ -75,9 +74,7 @@ where
 						let mut data = Vec::new();
 
 						for (code, content) in atom_data {
-							if (code == BE_SIGNED_INTEGER || code == BE_64BIT_SIGNED_INTEGER)
-								&& content.len() == 8
-							{
+							if content.len() == 8 {
 								data.push(AtomData::Unknown {
 									code,
 									data: content,
@@ -85,10 +82,17 @@ where
 							}
 						}
 
-						tag.atoms.push(Atom {
-							ident: AtomIdent::Fourcc(*b"plID"),
-							data: AtomDataStorage::Multiple(data),
-						})
+						if !data.is_empty() {
+							let storage = match data.len() {
+								1 => AtomDataStorage::Single(data.remove(0)),
+								_ => AtomDataStorage::Multiple(data),
+							};
+
+							tag.atoms.push(Atom {
+								ident: AtomIdent::Fourcc(*b"plID"),
+								data: storage,
+							})
+						}
 					}
 
 					continue;


### PR DESCRIPTION
In the event that the `plID` atom has the wrong code (which seems to be the case quite often), we wouldn't populate the atom data properly. This would lead to a panic when converting to `Tag`.

This removes the code check entirely, since we can no longer trust that to be correct. We also now verify that there's *something* present.

closes #201