### PR TITLE
probe: Add new default ParsingMode variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ParsingMode**: A new variant, `BestAttempt` will attempt to fill holes in otherwise valid tag items ([PR](https://github.com/Serial-ATA/lofty-rs/pull/205))
+
+### Changed
+- **Probe**: The default `ParsingMode` is now `ParsingMode::BestAttempt` (It was previously `ParsingMode::Strict`)
+
 ### Fixed
 - **MP4**: Fixed potential panic with malformed `plID` atoms ([issue](https://github.com/Serial-ATA/lofty-rs/issues/201)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/202))
 

--- a/src/aac/read.rs
+++ b/src/aac/read.rs
@@ -48,7 +48,7 @@ where
 
 				stream_len -= u64::from(header.size);
 
-				let id3v2 = parse_id3v2(reader, header)?;
+				let id3v2 = parse_id3v2(reader, header, parse_mode)?;
 				if let Some(existing_tag) = &mut file.id3v2_tag {
 					// https://github.com/Serial-ATA/lofty-rs/issues/87
 					// Duplicate tags should have their frames appended to the previous

--- a/src/ape/read.rs
+++ b/src/ape/read.rs
@@ -40,7 +40,7 @@ where
 
 		let reader = &mut &*content;
 
-		let id3v2 = parse_id3v2(reader, header)?;
+		let id3v2 = parse_id3v2(reader, header, parse_options.parsing_mode)?;
 		id3v2_tag = Some(id3v2);
 	}
 

--- a/src/flac/read.rs
+++ b/src/flac/read.rs
@@ -51,7 +51,7 @@ where
 	if let ID3FindResults(Some(header), Some(content)) = find_id3v2(data, true)? {
 		let reader = &mut &*content;
 
-		let id3v2 = parse_id3v2(reader, header)?;
+		let id3v2 = parse_id3v2(reader, header, parse_options.parsing_mode)?;
 		flac_file.id3v2_tag = Some(id3v2);
 	}
 

--- a/src/flac/read.rs
+++ b/src/flac/read.rs
@@ -84,6 +84,7 @@ where
 				&mut &*block.content,
 				block.content.len() as u64,
 				&mut vorbis_comments,
+				parse_options.parsing_mode,
 			)?;
 
 			flac_file.vorbis_comments_tag = Some(vorbis_comments);

--- a/src/id3/v2/frame/content.rs
+++ b/src/id3/v2/frame/content.rs
@@ -6,6 +6,7 @@ use crate::id3::v2::items::{
 };
 use crate::id3::v2::Id3v2Version;
 use crate::macros::err;
+use crate::probe::ParsingMode;
 use crate::util::text::TextEncoding;
 
 use std::io::Read;
@@ -15,6 +16,7 @@ pub(super) fn parse_content<R: Read>(
     reader: &mut R,
     id: &str,
     version: Id3v2Version,
+	parse_mode: ParsingMode,
 ) -> Result<Option<FrameValue>> {
 	Ok(match id {
 		// The ID was previously upgraded, but the content remains unchanged, so version is necessary

--- a/src/id3/v2/frame/content.rs
+++ b/src/id3/v2/frame/content.rs
@@ -28,7 +28,7 @@ pub(super) fn parse_content<R: Read>(
 		"WXXX" => ExtendedUrlFrame::parse(reader, version)?.map(FrameValue::UserUrl),
 		"COMM" => CommentFrame::parse(reader, version)?.map(FrameValue::Comment),
 		"USLT" => UnsynchronizedTextFrame::parse(reader, version)?.map(FrameValue::UnsynchronizedText),
-		"UFID" => UniqueFileIdentifierFrame::parse(reader)?.map(FrameValue::UniqueFileIdentifier),
+		"UFID" => UniqueFileIdentifierFrame::parse(reader, parse_mode)?.map(FrameValue::UniqueFileIdentifier),
 		_ if id.starts_with('T') => TextInformationFrame::parse(reader, version)?.map(FrameValue::Text),
 		// Apple proprietary frames
 		// WFED (Podcast URL), GRP1 (Grouping), MVNM (Movement Name), MVIN (Movement Number)

--- a/src/id3/v2/items/identifier.rs
+++ b/src/id3/v2/items/identifier.rs
@@ -68,3 +68,24 @@ impl Hash for UniqueFileIdentifierFrame {
 		self.owner.hash(state);
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn issue_204_invalid_ufid_parsing_mode_best_attempt() {
+		use crate::id3::v2::UniqueFileIdentifierFrame;
+		use crate::ParsingMode;
+
+		let ufid_no_owner = UniqueFileIdentifierFrame {
+			owner: String::new(),
+			identifier: vec![0],
+		};
+
+		let bytes = ufid_no_owner.as_bytes();
+
+		assert!(UniqueFileIdentifierFrame::parse(&mut &bytes[..], ParsingMode::Strict).is_err());
+		assert!(
+			UniqueFileIdentifierFrame::parse(&mut &bytes[..], ParsingMode::BestAttempt).is_ok()
+		);
+	}
+}

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -1068,6 +1068,7 @@ impl<'a, I: Iterator<Item = FrameRef<'a>> + Clone + 'a> Id3v2TagRef<'a, I> {
 
 #[cfg(test)]
 mod tests {
+	use crate::ParsingMode;
 	use std::borrow::Cow;
 
 	use crate::id3::v2::frame::MUSICBRAINZ_UFID_OWNER;
@@ -1095,7 +1096,7 @@ mod tests {
 		let mut reader = std::io::Cursor::new(&tag_bytes[..]);
 
 		let header = read_id3v2_header(&mut reader).unwrap();
-		crate::id3::v2::read::parse_id3v2(&mut reader, header).unwrap()
+		crate::id3::v2::read::parse_id3v2(&mut reader, header, ParsingMode::Strict).unwrap()
 	}
 
 	#[test]
@@ -1206,7 +1207,9 @@ mod tests {
 		let temp_reader = &mut &*writer;
 
 		let temp_header = read_id3v2_header(temp_reader).unwrap();
-		let temp_parsed_tag = crate::id3::v2::read::parse_id3v2(temp_reader, temp_header).unwrap();
+		let temp_parsed_tag =
+			crate::id3::v2::read::parse_id3v2(temp_reader, temp_header, ParsingMode::Strict)
+				.unwrap();
 
 		assert_eq!(parsed_tag, temp_parsed_tag);
 	}
@@ -1456,7 +1459,7 @@ mod tests {
 		let mut reader = &mut &writer[..];
 
 		let header = read_id3v2_header(&mut reader).unwrap();
-		assert!(crate::id3::v2::read::parse_id3v2(reader, header).is_ok());
+		assert!(crate::id3::v2::read::parse_id3v2(reader, header, ParsingMode::Strict).is_ok());
 
 		assert_eq!(writer[3..10], writer[writer.len() - 7..])
 	}
@@ -1481,7 +1484,7 @@ mod tests {
 		let mut reader = &mut &writer[..];
 
 		let header = read_id3v2_header(&mut reader).unwrap();
-		let tag = crate::id3::v2::read::parse_id3v2(reader, header).unwrap();
+		let tag = crate::id3::v2::read::parse_id3v2(reader, header, ParsingMode::Strict).unwrap();
 
 		assert_eq!(tag.len(), 1);
 		assert_eq!(
@@ -1798,7 +1801,8 @@ mod tests {
 		let mut reader = std::io::Cursor::new(&content[..]);
 
 		let header = read_id3v2_header(&mut reader).unwrap();
-		let reparsed = crate::id3::v2::read::parse_id3v2(&mut reader, header).unwrap();
+		let reparsed =
+			crate::id3::v2::read::parse_id3v2(&mut reader, header, ParsingMode::Strict).unwrap();
 
 		assert_eq!(id3v2, reparsed);
 	}

--- a/src/iff/aiff/read.rs
+++ b/src/iff/aiff/read.rs
@@ -52,7 +52,7 @@ where
 	while chunks.next(data).is_ok() {
 		match &chunks.fourcc {
 			b"ID3 " | b"id3 " => {
-				let tag = chunks.id3_chunk(data)?;
+				let tag = chunks.id3_chunk(data, parse_options.parsing_mode)?;
 				if let Some(existing_tag) = id3v2_tag.as_mut() {
 					// https://github.com/Serial-ATA/lofty-rs/issues/87
 					// Duplicate tags should have their frames appended to the previous

--- a/src/iff/chunk.rs
+++ b/src/iff/chunk.rs
@@ -1,6 +1,7 @@
 use crate::error::Result;
 use crate::id3::v2::tag::Id3v2Tag;
 use crate::macros::{err, try_vec};
+use crate::probe::ParsingMode;
 
 use std::io::{Read, Seek, SeekFrom};
 use std::marker::PhantomData;
@@ -91,7 +92,7 @@ impl<B: ByteOrder> Chunks<B> {
 		Ok(content)
 	}
 
-	pub fn id3_chunk<R>(&mut self, data: &mut R) -> Result<Id3v2Tag>
+	pub fn id3_chunk<R>(&mut self, data: &mut R, parse_mode: ParsingMode) -> Result<Id3v2Tag>
 	where
 		R: Read + Seek,
 	{
@@ -103,7 +104,7 @@ impl<B: ByteOrder> Chunks<B> {
 		let reader = &mut &*content;
 
 		let header = read_id3v2_header(reader)?;
-		let id3v2 = parse_id3v2(reader, header)?;
+		let id3v2 = parse_id3v2(reader, header, parse_mode)?;
 
 		// Skip over the footer
 		if id3v2.flags().footer {

--- a/src/iff/wav/read.rs
+++ b/src/iff/wav/read.rs
@@ -88,7 +88,7 @@ where
 				}
 			},
 			b"ID3 " | b"id3 " => {
-				let tag = chunks.id3_chunk(data)?;
+				let tag = chunks.id3_chunk(data, parse_options.parsing_mode)?;
 				if let Some(existing_tag) = id3v2_tag.as_mut() {
 					// https://github.com/Serial-ATA/lofty-rs/issues/87
 					// Duplicate tags should have their frames appended to the previous

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -72,11 +72,13 @@ macro_rules! parse_mode_choice {
 	(
 		$parse_mode:ident,
 		$(STRICT: $strict_handler:expr,)?
+		$(BESTATTEMPT: $best_attempt_handler:expr,)?
 		$(RELAXED: $relaxed_handler:expr,)?
 		DEFAULT: $default:expr
 	) => {
 		match $parse_mode {
 			$(crate::probe::ParsingMode::Strict => { $strict_handler },)?
+			$(crate::probe::ParsingMode::BestAttempt => { $best_attempt_handler },)?
 			$(crate::probe::ParsingMode::Relaxed => { $relaxed_handler },)?
 			_ => { $default }
 		}
@@ -84,10 +86,12 @@ macro_rules! parse_mode_choice {
 	(
 		$parse_mode:ident,
 		$(STRICT: $strict_handler:expr,)?
+		$(BESTATTEMPT: $best_attempt_handler:expr,)?
 		$(RELAXED: $relaxed_handler:expr $(,)?)?
 	) => {
 		match $parse_mode {
 			$(crate::probe::ParsingMode::Strict => { $strict_handler },)?
+			$(crate::probe::ParsingMode::BestAttempt => { $best_attempt_handler },)?
 			$(crate::probe::ParsingMode::Relaxed => { $relaxed_handler },)?
 			#[allow(unreachable_patterns)]
 			_ => {}

--- a/src/mpeg/read.rs
+++ b/src/mpeg/read.rs
@@ -41,7 +41,7 @@ where
 				let header = read_id3v2_header(reader)?;
 				let skip_footer = header.flags.footer;
 
-				let id3v2 = parse_id3v2(reader, header)?;
+				let id3v2 = parse_id3v2(reader, header, parse_options.parsing_mode)?;
 				if let Some(existing_tag) = &mut file.id3v2_tag {
 					// https://github.com/Serial-ATA/lofty-rs/issues/87
 					// Duplicate tags should have their frames appended to the previous

--- a/src/ogg/opus/mod.rs
+++ b/src/ogg/opus/mod.rs
@@ -29,7 +29,8 @@ impl OpusFile {
 	where
 		R: Read + Seek,
 	{
-		let file_information = super::read::read_from(reader, OPUSHEAD, OPUSTAGS, 2)?;
+		let file_information =
+			super::read::read_from(reader, OPUSHEAD, OPUSTAGS, 2, parse_options.parsing_mode)?;
 
 		Ok(Self {
 			properties: if parse_options.read_properties {

--- a/src/ogg/speex/mod.rs
+++ b/src/ogg/speex/mod.rs
@@ -28,7 +28,8 @@ impl SpeexFile {
 	where
 		R: Read + Seek,
 	{
-		let file_information = super::read::read_from(reader, SPEEXHEADER, &[], 2)?;
+		let file_information =
+			super::read::read_from(reader, SPEEXHEADER, &[], 2, parse_options.parsing_mode)?;
 
 		Ok(Self {
 			properties: if parse_options.read_properties {

--- a/src/ogg/tag.rs
+++ b/src/ogg/tag.rs
@@ -566,14 +566,21 @@ pub(crate) fn create_vorbis_comments_ref(
 mod tests {
 	use crate::ogg::{OggPictureStorage, VorbisComments};
 	use crate::{
-		ItemKey, ItemValue, MergeTag as _, SplitTag as _, Tag, TagExt as _, TagItem, TagType,
+		ItemKey, ItemValue, MergeTag as _, ParsingMode, SplitTag as _, Tag, TagExt as _, TagItem,
+		TagType,
 	};
 
 	fn read_tag(tag: &[u8]) -> VorbisComments {
 		let mut reader = std::io::Cursor::new(tag);
 		let mut parsed_tag = VorbisComments::default();
 
-		crate::ogg::read::read_comments(&mut reader, tag.len() as u64, &mut parsed_tag).unwrap();
+		crate::ogg::read::read_comments(
+			&mut reader,
+			tag.len() as u64,
+			&mut parsed_tag,
+			ParsingMode::Strict,
+		)
+		.unwrap();
 		parsed_tag
 	}
 

--- a/src/ogg/vorbis/mod.rs
+++ b/src/ogg/vorbis/mod.rs
@@ -29,8 +29,13 @@ impl VorbisFile {
 	where
 		R: Read + Seek,
 	{
-		let file_information =
-			super::read::read_from(reader, VORBIS_IDENT_HEAD, VORBIS_COMMENT_HEAD, 3)?;
+		let file_information = super::read::read_from(
+			reader,
+			VORBIS_IDENT_HEAD,
+			VORBIS_COMMENT_HEAD,
+			3,
+			parse_options.parsing_mode,
+		)?;
 
 		Ok(Self {
 			properties: if parse_options.read_properties {

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -115,6 +115,20 @@ impl ParseOptions {
 }
 
 /// The parsing strictness mode
+///
+/// This can be set with [`Probe::options`].
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use lofty::{ParseOptions, ParsingMode, Probe};
+///
+/// # fn main() -> lofty::Result<()> {
+/// // We only want to read spec-compliant inputs
+/// let parsing_options = ParseOptions::new().parsing_mode(ParsingMode::Strict);
+/// let tagged_file = Probe::open("foo.mp3")?.options(parsing_options).read()?;
+/// # Ok(()) }
+/// ```
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Default)]
 #[non_exhaustive]
 pub enum ParsingMode {

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -135,19 +135,34 @@ pub enum ParsingMode {
 	/// Will eagerly error on invalid input
 	///
 	/// This mode will eagerly error on any non spec-compliant input.
+	///
+	/// ## Examples of behavior
+	///
+	/// * Unable to decode text - The parser will error and the entire input is discarded
+	/// * Unable to determine the sample rate - The parser will error and the entire input is discarded
 	Strict,
 	/// Default mode, less eager to error on recoverably malformed input
 	///
 	/// This mode will attempt to fill in any holes where possible in otherwise valid, spec-compliant input.
 	///
 	/// NOTE: A readable input does *not* necessarily make it writeable.
+	///
+	/// ## Examples of behavior
+	///
+	/// * Unable to decode text - If valid otherwise, the field will be replaced by an empty string and the parser moves on
+	/// * Unable to determine the sample rate - The sample rate will be 0
 	#[default]
 	BestAttempt,
-	/// Least eager to error, may produce invalid output
+	/// Least eager to error, may produce invalid/partial output
 	///
 	/// This mode will discard any invalid fields, and ignore the majority of non-fatal errors.
 	///
-	/// Tags and properties read using this mode may come out missing items if the input is malformed.
+	/// If the input is malformed, the resulting tags may be incomplete, and the properties zeroed.
+	///
+	/// ## Examples of behavior
+	///
+	/// * Unable to decode text - The entire item is discarded and the parser moves on
+	/// * Unable to determine the sample rate - The sample rate will be 0
 	Relaxed,
 }
 


### PR DESCRIPTION
The new `BestAttempt` variant will be less eager to error than the previous default, `ParsingMode::Strict`. This comes with the consequence that the input may not be *entirely* spec-compliant.

This implements `BestAttempt` for `UniqueFileIdentifierFrame::parse` and adds `Strict` checks for `VorbisComments` parsing. More checks will come in the future.

closes #204