### PR TITLE
misc: Add allocation limit to `try_vec!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Probe**: The default `ParsingMode` is now `ParsingMode::BestAttempt` (It was previously `ParsingMode::Strict`)
+- **Alloc**:
+  - ⚠️ Important ⚠️: The allocation limit for any single tag item is now **8MB** ([PR](https://github.com/Serial-ATA/lofty-rs/pull/207)).
+                   This is not configurable yet ([issue](https://github.com/Serial-ATA/lofty-rs/issues/208)).
 
 ### Fixed
 - **MP4**: Fixed potential panic with malformed `plID` atoms ([issue](https://github.com/Serial-ATA/lofty-rs/issues/201)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/202))

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,10 +1,6 @@
 macro_rules! try_vec {
 	($elem:expr; $size:expr) => {{
-		let mut v = Vec::new();
-		v.try_reserve_exact($size)?;
-		v.resize($size, $elem);
-
-		v
+		$crate::util::alloc::fallible_vec_from_element($elem, $size)?
 	}};
 }
 

--- a/src/util/alloc.rs
+++ b/src/util/alloc.rs
@@ -1,0 +1,77 @@
+use crate::error::Result;
+use crate::macros::err;
+
+// We have an allocation limit of 8MB for any one item
+const ALLOCATION_LIMIT: usize = 1024 * 1024 * 8;
+
+/// Provides the `fallible_repeat` method on `Vec`
+///
+/// It is intended to be used in [`try_vec!`](crate::macros::try_vec).
+trait VecFallibleRepeat<T>: Sized {
+	fn fallible_repeat(self, element: T, expected_size: usize) -> Result<Self>
+	where
+		T: Clone;
+}
+
+impl<T> VecFallibleRepeat<T> for Vec<T> {
+	fn fallible_repeat(mut self, element: T, expected_size: usize) -> Result<Self>
+	where
+		T: Clone,
+	{
+		if expected_size == 0 {
+			return Ok(self);
+		}
+
+		if expected_size > ALLOCATION_LIMIT {
+			err!(TooMuchData);
+		}
+
+		self.try_reserve(expected_size)?;
+
+		let ptr = self.as_mut_ptr();
+		let mut current_length = self.len();
+		while current_length != expected_size {
+			unsafe {
+				ptr.add(current_length).write(element.clone());
+			}
+			current_length += 1;
+		}
+
+		unsafe {
+			self.set_len(current_length);
+		}
+
+		Ok(self)
+	}
+}
+
+/// **DO NOT USE DIRECTLY**
+///
+/// Creates a `Vec` of the specified length, containing copies of `element`.
+///
+/// This should be used through [`try_vec!`](crate::macros::try_vec)
+pub(crate) fn fallible_vec_from_element<T>(element: T, expected_size: usize) -> Result<Vec<T>>
+where
+	T: Clone,
+{
+	Vec::new().fallible_repeat(element, expected_size)
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::util::alloc::fallible_vec_from_element;
+
+	#[test]
+	fn vec_fallible_repeat() {
+		let u8_vec_len_20 = fallible_vec_from_element(0u8, 20).unwrap();
+		assert_eq!(u8_vec_len_20.len(), 20);
+		assert!(u8_vec_len_20.iter().all(|e| *e == 0));
+
+		let u64_vec_len_89 = fallible_vec_from_element(0u64, 89).unwrap();
+		assert_eq!(u64_vec_len_89.len(), 89);
+		assert!(u64_vec_len_89.iter().all(|e| *e == 0));
+
+		let u8_large_vec = fallible_vec_from_element(0u8, u32::MAX as usize);
+		assert!(u8_large_vec.is_err());
+	}
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod alloc;
 pub(crate) mod text;


### PR DESCRIPTION
This adds an arbitrary allocation limit of 8MB for any one item, which should be more than enough in any case.

This was changed to stop the fuzz tests from failing with OOM errors.