### PR TITLE
ID3v2: Report bad or unsupported frame IDs

### DIFF
--- a/src/id3/v2/frame/header.rs
+++ b/src/id3/v2/frame/header.rs
@@ -24,8 +24,9 @@ where
 		return Ok(None);
 	}
 
-	let id_str = std::str::from_utf8(&frame_header[..3])
-		.map_err(|_| Id3v2Error::new(Id3v2ErrorKind::BadFrameId))?;
+	let frame_id = &frame_header[..3];
+	let id_str = std::str::from_utf8(frame_id)
+		.map_err(|_| Id3v2Error::new(Id3v2ErrorKind::BadFrameId(frame_id.to_vec())))?;
 	let id = upgrade_v2(id_str).map_or_else(|| Cow::Owned(id_str.to_owned()), Cow::Borrowed);
 
 	let frame_id = FrameId::new_cow(id)?;
@@ -63,8 +64,9 @@ where
 		frame_id_end = 3;
 	}
 
+	let frame_id = &frame_header[..frame_id_end];
 	let id_str = std::str::from_utf8(&frame_header[..frame_id_end])
-		.map_err(|_| Id3v2Error::new(Id3v2ErrorKind::BadFrameId))?;
+		.map_err(|_| Id3v2Error::new(Id3v2ErrorKind::BadFrameId(frame_id.to_vec())))?;
 
 	let mut size = u32::from_be_bytes([
 		frame_header[4],

--- a/src/id3/v2/frame/id.rs
+++ b/src/id3/v2/frame/id.rs
@@ -38,7 +38,9 @@ impl<'a> FrameId<'a> {
 		match id.len() {
 			3 => Ok(FrameId::Outdated(id)),
 			4 => Ok(FrameId::Valid(id)),
-			_ => Err(Id3v2Error::new(Id3v2ErrorKind::BadFrameId).into()),
+			_ => Err(
+				Id3v2Error::new(Id3v2ErrorKind::BadFrameId(id.into_owned().into_bytes())).into(),
+			),
 		}
 	}
 
@@ -52,7 +54,10 @@ impl<'a> FrameId<'a> {
 	pub(super) fn verify_id(id_str: &str) -> Result<()> {
 		for c in id_str.chars() {
 			if !c.is_ascii_uppercase() && !c.is_ascii_digit() {
-				return Err(Id3v2Error::new(Id3v2ErrorKind::BadFrameId).into());
+				return Err(Id3v2Error::new(Id3v2ErrorKind::BadFrameId(
+					id_str.as_bytes().to_vec(),
+				))
+				.into());
 			}
 		}
 
@@ -93,7 +98,7 @@ impl<'a> TryFrom<&'a ItemKey> for FrameId<'a> {
 					}
 				}
 
-				Err(Id3v2Error::new(Id3v2ErrorKind::BadFrameId).into())
+				Err(Id3v2Error::new(Id3v2ErrorKind::UnsupportedFrameId(k.clone())).into())
 			},
 		}
 	}

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -533,7 +533,9 @@ impl Accessor for Id3v2Tag {
 	fn set_comment(&mut self, value: String) {
 		let mut value = Some(value);
 		self.frames.retain_mut(|frame| {
-			let Some(CommentFrame { content, .. }) = filter_comment_frame_by_description_mut(frame, &EMPTY_CONTENT_DESCRIPTOR) else {
+			let Some(CommentFrame { content, .. }) =
+				filter_comment_frame_by_description_mut(frame, &EMPTY_CONTENT_DESCRIPTOR)
+			else {
 				return true;
 			};
 			if let Some(value) = value.take() {
@@ -759,7 +761,9 @@ impl SplitTag for Id3v2Tag {
 				) => {
 					if owner == MUSICBRAINZ_UFID_OWNER {
 						let mut identifier = Cursor::new(identifier);
-						let Ok(recording_id) = decode_text(&mut identifier, TextEncoding::Latin1, false) else {
+						let Ok(recording_id) =
+							decode_text(&mut identifier, TextEncoding::Latin1, false)
+						else {
 							return true; // Keep frame
 						};
 						tag.items.push(TagItem::new(

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -533,9 +533,7 @@ impl Accessor for Id3v2Tag {
 	fn set_comment(&mut self, value: String) {
 		let mut value = Some(value);
 		self.frames.retain_mut(|frame| {
-			let Some(CommentFrame { content, .. }) =
-				filter_comment_frame_by_description_mut(frame, &EMPTY_CONTENT_DESCRIPTOR)
-			else {
+			let Some(CommentFrame { content, .. }) = filter_comment_frame_by_description_mut(frame, &EMPTY_CONTENT_DESCRIPTOR) else {
 				return true;
 			};
 			if let Some(value) = value.take() {
@@ -761,9 +759,7 @@ impl SplitTag for Id3v2Tag {
 				) => {
 					if owner == MUSICBRAINZ_UFID_OWNER {
 						let mut identifier = Cursor::new(identifier);
-						let Ok(recording_id) =
-							decode_text(&mut identifier, TextEncoding::Latin1, false)
-						else {
+						let Ok(recording_id) = decode_text(&mut identifier, TextEncoding::Latin1, false) else {
 							return true; // Keep frame
 						};
 						tag.items.push(TagItem::new(


### PR DESCRIPTION
This is the first step to reveal information about malformed/unsupported tags.

Those frames should be skipped when parsing in `Relaxed` mode.

Note: The `BadFrameId` error was used for different purposes, not only for parsing as the message suggests.