### PR TITLE
APE: Properly convert track/disk number pairs when writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- **APE**: The default track/disk number is now `0` to line up with ID3v2.
+           This is only used when `set_{track, disk}_total` is used without a corresponding `set_{track, disk}`.
+
+## Fixed
+- **APE**: Track/Disk number pairs are properly converted when writing ([issue](https://github.com/Serial-ATA/lofty-rs/issues/159)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/216))
+
 ## [0.14.0] - 2023-06-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ byteorder  = "1.4.3"
 # ID3 compressed frames
 flate2     = { version = "1.0.26", optional = true }
 # Proc macros
-lofty_attr = "0.8.0"
+lofty_attr = { path = "lofty_attr" }
 # Debug logging
 log        = "0.4.18"
 # OGG Vorbis/Opus

--- a/lofty_attr/src/internal.rs
+++ b/lofty_attr/src/internal.rs
@@ -46,7 +46,7 @@ pub(crate) fn init_write_lookup(
 	insert!(map, Ape, {
 		lofty::ape::tag::ApeTagRef {
 			read_only: false,
-			items: lofty::ape::tag::tagitems_into_ape(tag.items()),
+			items: lofty::ape::tag::tagitems_into_ape(tag),
 		}
 		.write_to(data)
 	});

--- a/src/ape/tag/write.rs
+++ b/src/ape/tag/write.rs
@@ -145,7 +145,7 @@ where
 
 				(1_u32 << 1, value)
 			},
-			ItemValueRef::Text(value) => {
+			ItemValueRef::Text(ref value) => {
 				tag_write.write_u32::<LittleEndian>(value.len() as u32)?;
 
 				(0_u32, value.as_bytes())

--- a/src/id3/v2/util/mod.rs
+++ b/src/id3/v2/util/mod.rs
@@ -1,4 +1,5 @@
 //! Utilities for working with ID3v2 tags
 
+pub(crate) mod pairs;
 pub mod synchsafe;
 pub mod upgrade;

--- a/src/id3/v2/util/pairs.rs
+++ b/src/id3/v2/util/pairs.rs
@@ -1,4 +1,5 @@
-/// Contains utilities for ID3v2 style number pairs
+//! Contains utilities for ID3v2 style number pairs
+
 use crate::tag::item::{ItemKey, TagItem};
 
 use std::fmt::Display;

--- a/src/id3/v2/util/pairs.rs
+++ b/src/id3/v2/util/pairs.rs
@@ -35,18 +35,15 @@ where
 
 /// Attempts to convert a `TagItem` to a number, passing it to `setter`
 pub(crate) fn set_number<F: FnMut(u32)>(item: &TagItem, mut setter: F) {
-	let text = item.value().text().map(str::trim);
+	let text = item.value().text();
 
-	let trimmed;
-	match text {
-		None | Some("") => {
-			log::warn!("Value does not have text in {:?}", item.key());
-			return;
-		},
-		Some(trimmed_text) => trimmed = trimmed_text,
+	let trimmed_text = text.unwrap_or_default().trim();
+	if trimmed_text.is_empty() {
+		log::warn!("Value does not have text in {:?}", item.key());
+		return;
 	}
 
-	match trimmed.parse::<u32>() {
+	match trimmed_text.parse::<u32>() {
 		Ok(number) => setter(number),
 		Err(parse_error) => {
 			log::warn!(

--- a/src/id3/v2/util/pairs.rs
+++ b/src/id3/v2/util/pairs.rs
@@ -1,0 +1,53 @@
+/// Contains utilities for ID3v2 style number pairs
+use crate::tag::item::{ItemKey, TagItem};
+
+use std::fmt::Display;
+
+pub(crate) const NUMBER_PAIR_SEPARATOR: char = '/';
+
+// This is used as the default number of track and disk.
+pub(crate) const DEFAULT_NUMBER_IN_PAIR: u32 = 0;
+
+// These keys have the part of the number pair.
+pub(crate) const NUMBER_PAIR_KEYS: &[ItemKey] = &[
+	ItemKey::TrackNumber,
+	ItemKey::TrackTotal,
+	ItemKey::DiscNumber,
+	ItemKey::DiscTotal,
+];
+
+/// Creates an ID3v2 style number pair
+pub(crate) fn format_number_pair<N, T>(number: Option<N>, total: Option<T>) -> Option<String>
+where
+	N: Display,
+	T: Display,
+{
+	match (number, total) {
+		(Some(number), None) => Some(number.to_string()),
+		(None, Some(total)) => Some(format!(
+			"{DEFAULT_NUMBER_IN_PAIR}{NUMBER_PAIR_SEPARATOR}{total}"
+		)),
+		(Some(number), Some(total)) => Some(format!("{number}{NUMBER_PAIR_SEPARATOR}{total}")),
+		(None, None) => None,
+	}
+}
+
+/// Attempts to convert a `TagItem` to a number, passing it to `setter`
+pub(crate) fn set_number<F: FnMut(u32)>(item: &TagItem, mut setter: F) {
+	let text = item.value().text();
+	let number = text.map(str::parse::<u32>);
+
+	match number {
+		Some(Ok(number)) => setter(number),
+		Some(Err(parse_error)) => {
+			log::warn!(
+				"\"{}\" cannot be parsed as number in {:?}: {parse_error}",
+				text.unwrap(),
+				item.key()
+			)
+		},
+		None => {
+			log::warn!("Value does not have text in {:?}", item.key())
+		},
+	}
+}

--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -1,5 +1,6 @@
 use crate::tag::TagType;
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 macro_rules! first_key {
@@ -694,7 +695,7 @@ impl ItemValue {
 }
 
 pub(crate) enum ItemValueRef<'a> {
-	Text(&'a str),
+	Text(Cow<'a, str>),
 	Locator(&'a str),
 	Binary(&'a [u8]),
 }
@@ -702,7 +703,7 @@ pub(crate) enum ItemValueRef<'a> {
 impl<'a> Into<ItemValueRef<'a>> for &'a ItemValue {
 	fn into(self) -> ItemValueRef<'a> {
 		match self {
-			ItemValue::Text(text) => ItemValueRef::Text(text),
+			ItemValue::Text(text) => ItemValueRef::Text(Cow::Borrowed(text)),
 			ItemValue::Locator(locator) => ItemValueRef::Locator(locator),
 			ItemValue::Binary(binary) => ItemValueRef::Binary(binary),
 		}

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -42,7 +42,7 @@ pub(crate) fn dump_tag<W: Write>(tag: &Tag, writer: &mut W) -> Result<()> {
 	match tag.tag_type() {
 		TagType::Ape => ApeTagRef {
 			read_only: false,
-			items: ape::tag::tagitems_into_ape(tag.items()),
+			items: ape::tag::tagitems_into_ape(tag),
 		}
 		.dump_to(writer),
 		TagType::Id3v1 => Into::<Id3v1TagRef<'_>>::into(tag).dump_to(writer),


### PR DESCRIPTION
This also changes the default track/disk number to `DEFAULT_NUMBER_IN_PAIR`.

closes #159