### PR TITLE
OGG: Cleanup and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bad frame IDs will no longer error when using `ParsingMode::{Relaxed, BestAttempt}`. The parser will now just move on to the next frame. ([PR](https://github.com/Serial-ATA/lofty-rs/pull/214))
 - **APE**: The default track/disk number is now `0` to line up with ID3v2.
            This is only used when `set_{track, disk}_total` is used without a corresponding `set_{track, disk}`.
+- **VorbisComments**: When writing, items larger than `u32::MAX` will throw `ErrorKind::TooMuchData`, rather than be silently discarded.
 
 ## Fixed
 - **APE**: Track/Disk number pairs are properly converted when writing ([issue](https://github.com/Serial-ATA/lofty-rs/issues/159)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/216))

--- a/src/flac/read.rs
+++ b/src/flac/read.rs
@@ -10,7 +10,6 @@ use crate::id3::v2::read::parse_id3v2;
 use crate::id3::{find_id3v2, ID3FindResults};
 use crate::macros::decode_err;
 use crate::ogg::read::read_comments;
-use crate::ogg::tag::VorbisComments;
 use crate::picture::Picture;
 use crate::probe::ParseOptions;
 
@@ -79,11 +78,9 @@ where
 				decode_err!(@BAIL Flac, "Streams are only allowed one Vorbis Comments block per stream");
 			}
 
-			let mut vorbis_comments = VorbisComments::new();
-			read_comments(
+			let vorbis_comments = read_comments(
 				&mut &*block.content,
 				block.content.len() as u64,
-				&mut vorbis_comments,
 				parse_options.parsing_mode,
 			)?;
 

--- a/src/ogg/tag.rs
+++ b/src/ogg/tag.rs
@@ -573,10 +573,7 @@ mod tests {
 	fn read_tag(tag: &[u8]) -> VorbisComments {
 		let mut reader = std::io::Cursor::new(tag);
 
-		let parsed_tag =
-			crate::ogg::read::read_comments(&mut reader, tag.len() as u64, ParsingMode::Strict)
-				.unwrap();
-		parsed_tag
+		crate::ogg::read::read_comments(&mut reader, tag.len() as u64, ParsingMode::Strict).unwrap()
 	}
 
 	#[test]

--- a/src/ogg/tag.rs
+++ b/src/ogg/tag.rs
@@ -572,15 +572,10 @@ mod tests {
 
 	fn read_tag(tag: &[u8]) -> VorbisComments {
 		let mut reader = std::io::Cursor::new(tag);
-		let mut parsed_tag = VorbisComments::default();
 
-		crate::ogg::read::read_comments(
-			&mut reader,
-			tag.len() as u64,
-			&mut parsed_tag,
-			ParsingMode::Strict,
-		)
-		.unwrap();
+		let parsed_tag =
+			crate::ogg::read::read_comments(&mut reader, tag.len() as u64, ParsingMode::Strict)
+				.unwrap();
 		parsed_tag
 	}
 

--- a/src/ogg/write.rs
+++ b/src/ogg/write.rs
@@ -22,8 +22,7 @@ pub(crate) enum OGGFormat {
 }
 
 impl OGGFormat {
-	#[allow(clippy::trivially_copy_pass_by_ref)]
-	pub(crate) fn comment_signature(&self) -> Option<&[u8]> {
+	pub(crate) fn comment_signature(self) -> Option<&'static [u8]> {
 		match self {
 			OGGFormat::Opus => Some(OPUSTAGS),
 			OGGFormat::Vorbis => Some(VORBIS_COMMENT_HEAD),


### PR DESCRIPTION
* Stop ignoring fields whose size fails the `u32` -> `usize` conversion, now throwing `TooMuchData`
* Stop requiring `&mut VorbisComments` to be passed to `read_comments`
* Remove intermediary String creation in `read_comments` (Now only allocating once, until all information is verified)
* Start logging more warnings when data is being discarded