### PR TITLE
WavPack: Fix multichannel detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `FrameValue::KeyValue` for TIPL/TMCL frames ([PR](https://github.com/Serial-ATA/lofty-rs/pull/214))
 - **ParseOptions**: `ParseOptions::max_junk_bytes`, allowing the parser to sift through junk bytes to find required information, rather than
                     immediately declare a file invalid. ([discussion](https://github.com/Serial-ATA/lofty-rs/discussions/219)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/227))
+- **WavPack**: `WavPackProperties` now contains the channel mask, accessible through `WavPackProperties::channel_mask()` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/230))
 
 ## Changed
 - **ID3v2**:
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - **APE**: Track/Disk number pairs are properly converted when writing ([issue](https://github.com/Serial-ATA/lofty-rs/issues/159)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/216))
 - **ID3v2**: TIPL/TMCL frames will no longer be read as a single terminated string ([issue](https://github.com/Serial-ATA/lofty-rs/pull/213)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/214))
+- **WavPack**: Multichannel files will no longer be marked as mono, supporting up to 4095 channels ([PR](https://github.com/Serial-ATA/lofty-rs/pull/230))
 
 ## [0.14.0] - 2023-06-08
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -94,7 +94,7 @@ impl FileProperties {
 /// * CAF channel bitmap: <https://developer.apple.com/library/archive/documentation/MusicAudio/Reference/CAFSpec/CAF_spec/CAF_spec.html#//apple_ref/doc/uid/TP40001862-CH210-BCGBHHHI>
 /// * WAV default channel ordering: <https://learn.microsoft.com/en-us/previous-versions/windows/hardware/design/dn653308(v=vs.85)?redirectedfrom=MSDN#default-channel-ordering>
 /// * FFmpeg: <https://ffmpeg.org/doxygen/trunk/group__channel__masks.html>
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 #[repr(transparent)]
 pub struct ChannelMask(pub(crate) u32);
 
@@ -136,7 +136,7 @@ mod tests {
 	};
 	use crate::probe::ParseOptions;
 	use crate::wavpack::{WavPackFile, WavPackProperties};
-	use crate::{AudioFile, FileProperties};
+	use crate::{AudioFile, ChannelMask, FileProperties};
 
 	use std::fs::File;
 	use std::time::Duration;
@@ -392,6 +392,7 @@ mod tests {
 		audio_bitrate: 597,
 		sample_rate: 48000,
 		channels: 2,
+		channel_mask: ChannelMask::stereo(),
 		bit_depth: 16,
 		lossless: true,
 	};

--- a/src/wavpack/properties.rs
+++ b/src/wavpack/properties.rs
@@ -343,7 +343,7 @@ fn get_extended_meta_info(
 					decode_err!(@BAIL WavPack, "Unable to extract channel information");
 				}
 
-				properties.channels = block_content[index] as u16;
+				properties.channels = u16::from(block_content[index]);
 				index += 1;
 
 				let reader = &mut &block_content[index..];
@@ -353,11 +353,11 @@ fn get_extended_meta_info(
 				match s {
 					0 => {
 						let channel_mask = reader.read_u8()?;
-						properties.channel_mask = ChannelMask(channel_mask as u32);
+						properties.channel_mask = ChannelMask(u32::from(channel_mask));
 					},
 					1 => {
 						let channel_mask = reader.read_u16::<LittleEndian>()?;
-						properties.channel_mask = ChannelMask(channel_mask as u32);
+						properties.channel_mask = ChannelMask(u32::from(channel_mask));
 					},
 					2 => {
 						let channel_mask = reader.read_u24::<LittleEndian>()?;
@@ -368,14 +368,14 @@ fn get_extended_meta_info(
 						properties.channel_mask = ChannelMask(channel_mask);
 					},
 					4 => {
-						properties.channels |= ((reader.read_u8()? & 0xF) as u16) << 8;
+						properties.channels |= u16::from(reader.read_u8()? & 0xF) << 8;
 						properties.channels += 1;
 
 						let channel_mask = reader.read_u24::<LittleEndian>()?;
 						properties.channel_mask = ChannelMask(channel_mask);
 					},
 					5 => {
-						properties.channels |= ((reader.read_u8()? & 0xF) as u16) << 8;
+						properties.channels |= u16::from(reader.read_u8()? & 0xF) << 8;
 						properties.channels += 1;
 
 						let channel_mask = reader.read_u32::<LittleEndian>()?;

--- a/src/wavpack/properties.rs
+++ b/src/wavpack/properties.rs
@@ -127,6 +127,39 @@ where
 		}
 
 		let flags = block_header.flags;
+		let sample_rate_idx = ((flags >> 23) & 0xF) as usize;
+
+		// In the case of non-standard sample rates and DSD audio, we need to actually read the
+		// block to get the sample rate
+		if properties.sample_rate == 0 || flags & FLAG_DSD == FLAG_DSD {
+			let mut block_contents = try_vec![0; (block_header.block_size - 24) as usize];
+			if reader.read_exact(&mut block_contents).is_err() {
+				parse_mode_choice!(
+						parse_mode,
+						STRICT: decode_err!(@BAIL WavPack, "Block size mismatch"),
+						DEFAULT: break
+					);
+			}
+
+			if let Err(e) = get_extended_meta_info(parse_mode, &block_contents, &mut properties)
+			{
+				parse_mode_choice!(
+					parse_mode,
+					STRICT: return Err(e),
+					DEFAULT: break
+				);
+			}
+
+			// A sample rate index of 15 indicates a custom sample rate, which should have been found
+			// when we just parsed the metadata blocks
+			if sample_rate_idx == 15 && properties.sample_rate == 0 {
+				parse_mode_choice!(
+					parse_mode,
+					STRICT: decode_err!(@BAIL WavPack, "Expected custom sample rate"),
+					DEFAULT: break
+				)
+			}
+		}
 
 		if flags & FLAG_INITIAL_BLOCK == FLAG_INITIAL_BLOCK {
 			if block_header.version < MIN_STREAM_VERSION
@@ -142,46 +175,22 @@ where
 			total_samples = block_header.total_samples;
 			properties.bit_depth = ((((flags & BYTES_PER_SAMPLE_MASK) + 1) * 8) - ((flags & BIT_DEPTH_SHIFT_MASK) >> BIT_DEPTH_SHL)) as u8;
 
-			let sample_rate_idx = ((flags >> 23) & 0xF) as usize;
 			let sample_rate = SAMPLE_RATES[sample_rate_idx];
 			properties.sample_rate = sample_rate;
 
 			properties.version = block_header.version;
 			properties.lossless = flags & FLAG_HYBRID_COMPRESSION == 0;
 
-			let is_mono = flags & FLAG_MONO > 0;
-			properties.channels = if is_mono { 1 } else { 2 };
 
-			// In the case of non-standard sample rates and DSD audio, we need to actually read the
-			// block to get the sample rate
-			if sample_rate == 0 || flags & FLAG_DSD == FLAG_DSD {
-				let mut block_contents = try_vec![0; (block_header.block_size - 24) as usize];
-				if reader.read_exact(&mut block_contents).is_err() {
-					parse_mode_choice!(
-						parse_mode,
-						STRICT: decode_err!(@BAIL WavPack, "Block size mismatch"),
-						DEFAULT: break
-					);
-				}
-
-				if let Err(e) = get_extended_meta_info(parse_mode, &block_contents, &mut properties)
-				{
-					parse_mode_choice!(
-						parse_mode,
-						STRICT: return Err(e),
-						DEFAULT: break
-					);
-				}
-			}
-
-			// A sample rate index of 15 indicates a custom sample rate, which should have been found
-			// when we just parsed the metadata blocks
-			if sample_rate_idx == 15 && properties.sample_rate == 0 {
-				parse_mode_choice!(
-					parse_mode,
-					STRICT: decode_err!(@BAIL WavPack, "Expected custom sample rate"),
-					DEFAULT: break
-				)
+			// https://web.archive.org/web/20150424062034/https://www.wavpack.com/file_format.txt:
+			//
+			// A flag in the header indicates whether the block is the first or the last in the
+			// sequence (for simple mono or stereo files both of these would always be set).
+			//
+			// We already checked if `FLAG_INITIAL_BLOCK` is set
+			if flags & FLAG_FINAL_BLOCK > 0 {
+				let is_mono = flags & FLAG_MONO > 0;
+				properties.channels = if is_mono { 1 } else { 2 };
 			}
 		}
 


### PR DESCRIPTION
This also fixes metadata sub block reading as a result.

Also took the opportunity to read the channel mask out of the `MULTICHANNEL` metadata sub block, which was previously skipped.