### PR TITLE
ID3v2: Make FrameId less annoying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
              `id3::v2::{RelativeVolumeAdjustmentFrame, OwnershipFrame, EventTimingCodesFrame, PrivateFrame}`
 
 ## Changed
-- **ID3v2**: For spec compliance, `Id3v2Tag::insert` will now check for frames that are only meant to appear
-             in a tag once and remove them. Those frames are: "MCDI", "ETCO", "MLLT", "SYTC", "RVRB", "PCNT", "RBUF", "POSS", "OWNE", "SEEK", and "ASPI".
+- **ID3v2**:
+  - For spec compliance, `Id3v2Tag::insert` will now check for frames that are only meant to appear
+    in a tag once and remove them. Those frames are: "MCDI", "ETCO", "MLLT", "SYTC", "RVRB", "PCNT", "RBUF", "POSS", "OWNE", "SEEK", and "ASPI".
+  - `Id3v2Tag::remove` will now take a `FrameId` rather than `&str`
+  - `FrameId` now implements `Into<Cow<'_, str>>`, making it possible to use it in `Frame::new`
 
 ## [0.15.0] - 2023-07-11
 

--- a/src/id3/v2/frame/id.rs
+++ b/src/id3/v2/frame/id.rs
@@ -5,6 +5,8 @@ use crate::tag::item::ItemKey;
 use crate::tag::TagType;
 
 /// An `ID3v2` frame ID
+///
+/// ⚠ WARNING ⚠: Be very careful when constructing this by hand. It is recommended to use [`FrameId::new`].
 #[derive(PartialEq, Clone, Debug, Eq, Hash)]
 pub enum FrameId<'a> {
 	/// A valid `ID3v2.3/4` frame
@@ -19,6 +21,8 @@ pub enum FrameId<'a> {
 
 impl<'a> FrameId<'a> {
 	/// Attempts to create a `FrameId` from an ID string
+	///
+	/// NOTE: This will not upgrade IDs, for that behavior use [`Frame::new`](crate::id3::v2::Frame::new).
 	///
 	/// # Errors
 	///
@@ -78,6 +82,19 @@ impl<'a> FrameId<'a> {
 			Self::Valid(inner) => FrameId::Valid(Cow::Owned(inner.into_owned())),
 			Self::Outdated(inner) => FrameId::Outdated(Cow::Owned(inner.into_owned())),
 		}
+	}
+
+	/// Consumes the [`FrameId`], returning the inner value
+	pub fn into_inner(self) -> Cow<'a, str> {
+		match self {
+			FrameId::Valid(v) | FrameId::Outdated(v) => v,
+		}
+	}
+}
+
+impl<'a> Into<Cow<'a, str>> for FrameId<'a> {
+	fn into(self) -> Cow<'a, str> {
+		self.into_inner()
 	}
 }
 


### PR DESCRIPTION
This changes two things:

1. `FrameId` now implements `Into<Cow<'_, str>>`

This makes it possible to use `FrameId`s in `Frame::new`. It's now much less annoying to create frames using constant IDs.

2. `Id3v2Tag::remove` now takes a `FrameId`

This makes it more type safe and removes the unnecessary caseless string comparison.