### PR TITLE
MP4: Correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MP4**:
   - `Ilst::remove` will now return all of the removed atoms
   - `Ilst::insert_picture` will now combine all pictures into a single `covr` atom
+  - `Ilst::insert` will now merge atoms with the same identifier into a single atom
 
 ## [0.15.0] - 2023-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - **ID3v2**: Support for "RVA2", "OWNE", "ETCO", and "PRIV" frames through
              `id3::v2::{RelativeVolumeAdjustmentFrame, OwnershipFrame, EventTimingCodesFrame, PrivateFrame}`
+- **MP4**:
+  - `Atom::into_data`
+  - `Atom::merge`
 
 ## Changed
 - **ID3v2**:
@@ -16,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     in a tag once and remove them. Those frames are: "MCDI", "ETCO", "MLLT", "SYTC", "RVRB", "PCNT", "RBUF", "POSS", "OWNE", "SEEK", and "ASPI".
   - `Id3v2Tag::remove` will now take a `FrameId` rather than `&str`
   - `FrameId` now implements `Into<Cow<'_, str>>`, making it possible to use it in `Frame::new`
+- **MP4**:
+  - `Ilst::remove` will now return all of the removed atoms
+  - `Ilst::insert_picture` will now combine all pictures into a single `covr` atom
 
 ## [0.15.0] - 2023-07-11
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,8 @@ pub enum ErrorKind {
 
 	/// Arises when an atom contains invalid data
 	BadAtom(&'static str),
+	/// Arises when attempting to use [`Atom::merge`](crate::mp4::Atom::merge) with mismatching identifiers
+	AtomMismatch,
 
 	// Conversions for external errors
 	/// Errors that arise while parsing OGG pages
@@ -520,6 +522,10 @@ impl Display for LoftyError {
 			ErrorKind::TextDecode(message) => write!(f, "Text decoding: {message}"),
 			ErrorKind::Id3v2(ref id3v2_err) => write!(f, "{id3v2_err}"),
 			ErrorKind::BadAtom(message) => write!(f, "MP4 Atom: {message}"),
+			ErrorKind::AtomMismatch => write!(
+				f,
+				"MP4 Atom: Attempted to use `Atom::merge()` with mismatching identifiers"
+			),
 
 			// Files
 			ErrorKind::TooMuchData => write!(

--- a/src/mp4/ilst/atom.rs
+++ b/src/mp4/ilst/atom.rs
@@ -144,6 +144,13 @@ impl<'a> Atom<'a> {
 	/// # Examples
 	///
 	/// ```rust
+	/// use lofty::mp4::{Atom, AtomData, AtomIdent};
+	///
+	/// let atom = Atom::new(
+	/// 	AtomIdent::Fourcc(*b"\x49ART"),
+	/// 	AtomData::UTF8(String::from("Foo")),
+	/// );
+	/// assert_eq!(atom.into_data().count(), 1);
 	/// ```
 	pub fn into_data(self) -> impl Iterator<Item = AtomData> {
 		self.data.into_iter()

--- a/src/mp4/ilst/atom.rs
+++ b/src/mp4/ilst/atom.rs
@@ -20,6 +20,13 @@ impl AtomDataStorage {
 			AtomDataStorage::Multiple(data) => data.first_mut().expect("not empty"),
 		}
 	}
+
+	pub(super) fn is_pictures(&self) -> bool {
+		match self {
+			AtomDataStorage::Single(v) => matches!(v, AtomData::Picture(_)),
+			AtomDataStorage::Multiple(v) => v.iter().all(|p| matches!(p, AtomData::Picture(_))),
+		}
+	}
 }
 
 impl Debug for AtomDataStorage {


### PR DESCRIPTION
## Added

* `Ilst::insert_picture` will now combine pictures into a single `covr` atom
* `Atom::merge` for combining the data of two atoms
* `Atom::into_data` to consume an `Atom` and return its data

## Changed

* `Ilst::remove` will now return all removed atoms
* `Ilst::pictures` will now only check for a single `covr` atom
* `Ilst::insert` will now merge with existing atoms
	* Now, when inserting an atom that already exists in a tag, the data is taken from the provided atom and merged with the existing value in the tag. This should ensure that the value that already exists in the tag will remain the dominant one.
