### PR TITLE
APE: Fix property reading on old stream versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WavPack**: Custom sample rates will no longer be overwritten
   - When a custom sample rate (or multiplier) was encountered, it would accidentally be overwritten with 0, causing
     incorrect duration and bitrate values.
+- **APE**: Reading properties on older files will no longer error
+  - Older APE stream versions were not properly handled, leading to incorrect properties and errors.
 
 ## [0.15.0] - 2023-07-11
 

--- a/src/ape/read.rs
+++ b/src/ape/read.rs
@@ -125,7 +125,12 @@ where
 		id3v2_tag,
 		ape_tag,
 		properties: if parse_options.read_properties {
-			super::properties::read_properties(data, stream_len, file_length)?
+			super::properties::read_properties(
+				data,
+				stream_len,
+				file_length,
+				parse_options.parsing_mode,
+			)?
 		} else {
 			ApeProperties::default()
 		},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,9 @@
 	clippy::field_reassign_with_default,
 	clippy::manual_range_patterns, /* This is not at all clearer as it suggests */
 	clippy::explicit_iter_loop,
-	clippy::from_iter_instead_of_collect
+	clippy::from_iter_instead_of_collect,
+	clippy::no_effect_underscore_binding,
+	clippy::used_underscore_binding,
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
@@ -183,15 +185,3 @@ pub use crate::traits::{Accessor, MergeTag, SplitTag, TagExt};
 pub use picture::PictureInformation;
 
 pub use lofty_attr::LoftyFile;
-
-// TODO: https://github.com/rust-lang/rust/issues/88581
-#[inline]
-pub(crate) const fn div_ceil(dividend: u64, divisor: u64) -> u64 {
-	let d = dividend / divisor;
-	let r = dividend % divisor;
-	if r > 0 && divisor > 0 {
-		d + 1
-	} else {
-		d
-	}
-}

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -171,7 +171,7 @@ mod tests {
 		version: 3990,
 		duration: Duration::from_millis(1428),
 		overall_bitrate: 361,
-		audio_bitrate: 361,
+		audio_bitrate: 360,
 		sample_rate: 48000,
 		bit_depth: 16,
 		channels: 2,

--- a/tests/files/zero_sized.rs
+++ b/tests/files/zero_sized.rs
@@ -4,11 +4,13 @@ use lofty::iff::aiff::AiffFile;
 use lofty::iff::wav::WavFile;
 use lofty::mp4::Mp4File;
 use lofty::mpeg::MpegFile;
-use lofty::{AudioFile, ParseOptions};
+use lofty::{AudioFile, ParseOptions, ParsingMode};
 
 fn read_file_with_properties<A: AudioFile>(path: &str) -> bool {
-	let res =
-		<A as AudioFile>::read_from(&mut std::fs::File::open(path).unwrap(), ParseOptions::new());
+	let res = <A as AudioFile>::read_from(
+		&mut std::fs::File::open(path).unwrap(),
+		ParseOptions::new().parsing_mode(ParsingMode::Strict),
+	);
 	res.is_ok()
 }
 


### PR DESCRIPTION
This also makes property reading take `ParsingMode` into account.