### PR TITLE
OGG: Support reading COVERART fields/Make FLAC pictures less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MP4**:
   - `Atom::into_data`
   - `Atom::merge`
+- **OGG**: Support for reading "COVERART" fields, an old deprecated image storage format.
 
 ## Changed
 - **ID3v2**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Ilst::remove` will now return all of the removed atoms
   - `Ilst::insert_picture` will now combine all pictures into a single `covr` atom
   - `Ilst::insert` will now merge atoms with the same identifier into a single atom
-- **FLAC**: Allow multiple Vorbis Comment blocks when not using `ParsingMode::Strict`
-  - This is not allowed [by spec](https://xiph.org/flac/format.html#def_VORBIS_COMMENT), but is still possible
-    to encounter in the wild. Now we will just tag whichever tag happens to be latest in the stream and
-    use it, they **will not be merged**.
+- **FLAC**:
+  - Allow multiple Vorbis Comment blocks when not using `ParsingMode::Strict`
+    - This is not allowed [by spec](https://xiph.org/flac/format.html#def_VORBIS_COMMENT), but is still possible
+      to encounter in the wild. Now we will just tag whichever tag happens to be latest in the stream and
+      use it, they **will not be merged**.
+  - Allow picture types greater than 255 when not using `ParsingMode::Strict`
+    - This is not allowed [by spec](https://xiph.org/flac/format.html#metadata_block_picture), but has been encountered
+      in the wild. Now we will just cap the picture type at 255.
 
 ## Fixed
 - **WavPack**: Custom sample rates will no longer be overwritten

--- a/fuzz/fuzz_targets/picture_from_flac_bytes.rs
+++ b/fuzz/fuzz_targets/picture_from_flac_bytes.rs
@@ -1,7 +1,9 @@
 #![no_main]
+use lofty::ParsingMode;
+
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = lofty::Picture::from_flac_bytes(data, true);
-    let _ = lofty::Picture::from_flac_bytes(data, false);
+	let _ = lofty::Picture::from_flac_bytes(data, true, ParsingMode::Relaxed);
+	let _ = lofty::Picture::from_flac_bytes(data, false, ParsingMode::Relaxed);
 });

--- a/src/flac/read.rs
+++ b/src/flac/read.rs
@@ -100,9 +100,17 @@ where
 		}
 
 		if block.ty == BLOCK_ID_PICTURE {
-			flac_file
-				.pictures
-				.push(Picture::from_flac_bytes(&block.content, false)?)
+			match Picture::from_flac_bytes(&block.content, false, parse_options.parsing_mode) {
+				Ok(picture) => flac_file.pictures.push(picture),
+				Err(e) => {
+					if parse_options.parsing_mode == ParsingMode::Strict {
+						return Err(e);
+					}
+
+					log::warn!("Unable to read FLAC picture block, discarding");
+					continue;
+				},
+			}
 		}
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,9 @@
 	clippy::from_iter_instead_of_collect,
 	clippy::no_effect_underscore_binding,
 	clippy::used_underscore_binding,
+	clippy::ignored_unit_patterns, /* Not a fan of this lint, doesn't make anything clearer as it claims */
+	clippy::needless_return, /* Explicit returns are needed from time to time for clarity */
+	clippy::redundant_guards, /* Currently broken for some cases, might enable later*/
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 

--- a/src/ogg/read.rs
+++ b/src/ogg/read.rs
@@ -94,7 +94,7 @@ where
 
 		match key {
 			k if k.eq_ignore_ascii_case(b"METADATA_BLOCK_PICTURE") => {
-				match Picture::from_flac_bytes(value, true) {
+				match Picture::from_flac_bytes(value, true, parse_mode) {
 					Ok(picture) => tag.pictures.push(picture),
 					Err(e) => {
 						if parse_mode == ParsingMode::Strict {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -784,7 +784,7 @@ impl Picture {
 		})
 	}
 
-	fn mimetype_from_bin(bytes: &[u8]) -> Result<MimeType> {
+	pub(crate) fn mimetype_from_bin(bytes: &[u8]) -> Result<MimeType> {
 		match bytes[..8] {
 			[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A] => Ok(MimeType::Png),
 			[0xFF, 0xD8, ..] => Ok(MimeType::Jpeg),

--- a/tests/picture/format_parsers.rs
+++ b/tests/picture/format_parsers.rs
@@ -1,5 +1,5 @@
 use lofty::id3::v2::{AttachedPictureFrame, Id3v2Version};
-use lofty::{Picture, PictureInformation, PictureType, TextEncoding};
+use lofty::{ParsingMode, Picture, PictureInformation, PictureType, TextEncoding};
 
 use std::fs::File;
 use std::io::Read;
@@ -96,7 +96,7 @@ fn as_ape_bytes() {
 fn flac_metadata_block_picture() {
 	let buf = get_buf("tests/picture/assets/png_640x628.vorbis");
 
-	let (pic, _) = Picture::from_flac_bytes(&buf, true).unwrap();
+	let (pic, _) = Picture::from_flac_bytes(&buf, true, ParsingMode::Strict).unwrap();
 
 	assert_eq!(create_original_picture(), pic);
 }


### PR DESCRIPTION
* We now support reading COVERART fields, which will be upgraded to METADATA_BLOCK_PICTURE on write.
* FLAC picture blocks can have any picture type now, and it will simply max out at 255.

closes #253 