### PR TITLE
ID3v2: Use FrameId for Id3v2Tag getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Added
-- **ID3v2**: Support for "RVA2", "OWNE", "ETCO", and "PRIV" frames through
-             `id3::v2::{RelativeVolumeAdjustmentFrame, OwnershipFrame, EventTimingCodesFrame, PrivateFrame}`
+- **ID3v2**:
+  - Support for "RVA2", "OWNE", "ETCO", and "PRIV" frames through
+               `id3::v2::{RelativeVolumeAdjustmentFrame, OwnershipFrame, EventTimingCodesFrame, PrivateFrame}`
+  - `FrameId` now implements `Display`
 - **MP4**:
   - `Atom::into_data`
   - `Atom::merge`
@@ -20,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     in a tag once and remove them. Those frames are: "MCDI", "ETCO", "MLLT", "SYTC", "RVRB", "PCNT", "RBUF", "POSS", "OWNE", "SEEK", and "ASPI".
   - `Id3v2Tag::remove` will now take a `FrameId` rather than `&str`
   - `FrameId` now implements `Into<Cow<'_, str>>`, making it possible to use it in `Frame::new`
+  - `ID3v2Tag` getters will now use `&FrameId` instead of `&str` for IDs
 - **MP4**:
   - `Ilst::remove` will now return all of the removed atoms
   - `Ilst::insert_picture` will now combine all pictures into a single `covr` atom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Support for "RVA2", "OWNE", "ETCO", and "PRIV" frames through
                `id3::v2::{RelativeVolumeAdjustmentFrame, OwnershipFrame, EventTimingCodesFrame, PrivateFrame}`
   - `FrameId` now implements `Display`
+  - `Id3v2Tag::get_texts` for multi-value text frames
 - **MP4**:
   - `Atom::into_data`
   - `Atom::merge`
@@ -22,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     in a tag once and remove them. Those frames are: "MCDI", "ETCO", "MLLT", "SYTC", "RVRB", "PCNT", "RBUF", "POSS", "OWNE", "SEEK", and "ASPI".
   - `Id3v2Tag::remove` will now take a `FrameId` rather than `&str`
   - `FrameId` now implements `Into<Cow<'_, str>>`, making it possible to use it in `Frame::new`
-  - `ID3v2Tag` getters will now use `&FrameId` instead of `&str` for IDs
+  - `Id3v2Tag` getters will now use `&FrameId` instead of `&str` for IDs
 - **MP4**:
   - `Ilst::remove` will now return all of the removed atoms
   - `Ilst::insert_picture` will now combine all pictures into a single `covr` atom

--- a/src/id3/v2/frame/id.rs
+++ b/src/id3/v2/frame/id.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt::{Display, Formatter};
 
 use crate::error::{Id3v2Error, Id3v2ErrorKind, LoftyError, Result};
 use crate::tag::item::ItemKey;
@@ -89,6 +90,12 @@ impl<'a> FrameId<'a> {
 		match self {
 			FrameId::Valid(v) | FrameId::Outdated(v) => v,
 		}
+	}
+}
+
+impl Display for FrameId<'_> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
 	}
 }
 

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -159,8 +159,6 @@ impl Id3v2Tag {
 
 impl Id3v2Tag {
 	/// Gets a [`Frame`] from an id
-	///
-	/// NOTE: This is *not* case-sensitive
 	pub fn get(&self, id: &FrameId<'_>) -> Option<&Frame<'static>> {
 		self.frames.iter().find(|f| &f.id == id)
 	}
@@ -208,7 +206,7 @@ impl Id3v2Tag {
 	///
 	/// tag.set_title(String::from("Foo\0Bar"));
 	///
-	/// let mut titles = tag.get_texts(&TITLE_ID);
+	/// let mut titles = tag.get_texts(&TITLE_ID).expect("Should exist");
 	///
 	/// assert_eq!(titles.next(), Some("Foo"));
 	/// assert_eq!(titles.next(), Some("Bar"));

--- a/tests/files/mpeg.rs
+++ b/tests/files/mpeg.rs
@@ -1,6 +1,7 @@
 use crate::{set_artist, temp_file, verify_artist};
+use std::borrow::Cow;
 
-use lofty::id3::v2::{Frame, FrameFlags, FrameValue, Id3v2Tag, KeyValueFrame};
+use lofty::id3::v2::{Frame, FrameFlags, FrameId, FrameValue, Id3v2Tag, KeyValueFrame};
 use lofty::mpeg::MpegFile;
 use lofty::{
 	Accessor, AudioFile, FileType, ItemKey, ItemValue, ParseOptions, Probe, Tag, TagExt, TagItem,
@@ -344,7 +345,11 @@ fn read_and_write_tpil_frame() {
 
 	let tag: &Id3v2Tag = mpeg_file.id3v2().unwrap();
 
-	let content = match tag.get("TIPL").unwrap().content() {
+	let content = match tag
+		.get(&FrameId::Valid(Cow::Borrowed("TIPL")))
+		.unwrap()
+		.content()
+	{
 		FrameValue::KeyValue(content) => content,
 		_ => panic!("Wrong Frame Value Type for TIPL"),
 	};

--- a/tests/tags/conversions.rs
+++ b/tests/tags/conversions.rs
@@ -1,7 +1,8 @@
 // Tests for special case conversions
 
-use lofty::id3::v2::{CommentFrame, Frame, FrameFlags, Id3v2Tag, UnsynchronizedTextFrame};
+use lofty::id3::v2::{CommentFrame, Frame, FrameFlags, FrameId, Id3v2Tag, UnsynchronizedTextFrame};
 use lofty::{ItemKey, Tag, TagType, TextEncoding};
+use std::borrow::Cow;
 
 #[test]
 fn tag_to_id3v2_lang_frame() {
@@ -12,7 +13,7 @@ fn tag_to_id3v2_lang_frame() {
 	let id3: Id3v2Tag = tag.into();
 
 	assert_eq!(
-		id3.get("USLT"),
+		id3.get(&FrameId::Valid(Cow::Borrowed("USLT"))),
 		Frame::new(
 			"USLT",
 			UnsynchronizedTextFrame {
@@ -28,7 +29,7 @@ fn tag_to_id3v2_lang_frame() {
 	);
 
 	assert_eq!(
-		id3.get("COMM"),
+		id3.get(&FrameId::Valid(Cow::Borrowed("COMM"))),
 		Frame::new(
 			"COMM",
 			CommentFrame {


### PR DESCRIPTION
For consistency since `&str` is no longer used for frame creation and removal.