### PR TITLE
Replace base64 with data-encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include     = ["src", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT", "benches", 
 
 [dependencies]
 # Vorbis comments pictures
-base64     = "0.21.4"
+data-encoding = "2.4.0"
 byteorder  = "1.4.3"
 # ID3 compressed frames
 flate2     = { version = "1.0.27", optional = true }

--- a/src/ogg/read.rs
+++ b/src/ogg/read.rs
@@ -8,8 +8,8 @@ use crate::probe::ParsingMode;
 use std::borrow::Cow;
 use std::io::{Read, Seek, SeekFrom};
 
-use base64::Engine;
 use byteorder::{LittleEndian, ReadBytesExt};
+use data_encoding::BASE64;
 use ogg_pager::{Packets, PageHeader};
 
 pub type OGGTags = (Option<VorbisComments>, PageHeader, Packets);
@@ -111,7 +111,7 @@ where
 				// to a `METADATA_BLOCK_PICTURE` for it to be useful.
 				//
 				// <https://wiki.xiph.org/VorbisComment#Conversion_to_METADATA_BLOCK_PICTURE>
-				let picture_data = base64::engine::general_purpose::STANDARD.decode(value);
+				let picture_data = BASE64.decode(value);
 
 				match picture_data {
 					Ok(picture_data) => {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -6,8 +6,8 @@ use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
-use base64::Engine as _;
 use byteorder::{BigEndian, ReadBytesExt};
+use data_encoding::BASE64;
 
 /// Common picture item keys for APE
 pub const APE_PICTURE_TYPES: [&str; 21] = [
@@ -609,9 +609,7 @@ impl Picture {
 		data.extend(pic_data.iter());
 
 		if encode {
-			base64::engine::general_purpose::STANDARD
-				.encode(data)
-				.into_bytes()
+			BASE64.encode(&data).into_bytes()
 		} else {
 			data
 		}
@@ -632,7 +630,7 @@ impl Picture {
 		parse_mode: ParsingMode,
 	) -> Result<(Self, PictureInformation)> {
 		if encoded {
-			let data = base64::engine::general_purpose::STANDARD
+			let data = BASE64
 				.decode(bytes)
 				.map_err(|_| LoftyError::new(ErrorKind::NotAPicture))?;
 			Self::from_flac_bytes_inner(&data, parse_mode)


### PR DESCRIPTION
Just stumbled over this discussion: https://github.com/marshallpierce/rust-base64/issues/213

There is also `base64-simd`, but I don't trust it (yet).