### PR TITLE
MP4: Attempt to detect invalid atom identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- **MP4**: Verify atom identifiers fall within a subset of characters ([PR](https://github.com/Serial-ATA/lofty-rs/pull/267))
+  - For a multitude of reasons, garbage data can be left at the end of an atom, resulting in Lofty attempting to
+    parse it as another atom definition. As the specification is broad, there is no way for us to say *with certainty*
+    that an identifier is invalid. Now we unfortunately have to guess the validity based on the commonly known atoms.
+    For this, we follow [TagLib]'s [checks](https://github.com/taglib/taglib/blob/b40b834b1bdbd74593c5619e969e793d4d4886d9/taglib/mp4/mp4atom.cpp#L89).
+
 ## [0.16.1] - 2023-10-15
 
+## Fixed
 - **MP4**: Skip unexpected or empty data atoms in ilst ([PR](https://github.com/Serial-ATA/lofty-rs/pull/261))
   - It is possible for an `ilst` item to have both empty `data` atoms and unexpected (likely vendor-specific) atoms other than `data`.
     These are both cases we can safely ignore unless using `ParsingMode::Strict`.
@@ -591,3 +599,5 @@ See [ogg_pager's changelog](ogg_pager/CHANGELOG.md).
 [0.5.2]: https://github.com/Serial-ATA/lofty-rs/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/Serial-ATA/lofty-rs/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/Serial-ATA/lofty-rs/compare/64f0eff...0.5.0
+
+[TagLib]: https://github.com/taglib/taglib

--- a/src/mp4/ilst/mod.rs
+++ b/src/mp4/ilst/mod.rs
@@ -780,7 +780,7 @@ mod tests {
 		let len = tag.len();
 
 		let cursor = Cursor::new(tag);
-		let mut reader = AtomReader::new(cursor).unwrap();
+		let mut reader = AtomReader::new(cursor, crate::ParsingMode::Strict).unwrap();
 
 		super::read::parse_ilst(&mut reader, crate::ParsingMode::Strict, len as u64).unwrap()
 	}
@@ -848,7 +848,7 @@ mod tests {
 		let len = tag.len();
 
 		let cursor = Cursor::new(tag);
-		let mut reader = AtomReader::new(cursor).unwrap();
+		let mut reader = AtomReader::new(cursor, crate::ParsingMode::Strict).unwrap();
 
 		let parsed_tag =
 			super::read::parse_ilst(&mut reader, crate::ParsingMode::Strict, len as u64).unwrap();
@@ -864,7 +864,7 @@ mod tests {
 		parsed_tag.dump_to(&mut writer).unwrap();
 
 		let cursor = Cursor::new(&writer[8..]);
-		let mut reader = AtomReader::new(cursor).unwrap();
+		let mut reader = AtomReader::new(cursor, crate::ParsingMode::Strict).unwrap();
 
 		// Remove the ilst identifier and size
 		let temp_parsed_tag = super::read::parse_ilst(
@@ -883,7 +883,7 @@ mod tests {
 		let len = tag.len();
 
 		let cursor = Cursor::new(tag);
-		let mut reader = AtomReader::new(cursor).unwrap();
+		let mut reader = AtomReader::new(cursor, crate::ParsingMode::Strict).unwrap();
 
 		let ilst =
 			super::read::parse_ilst(&mut reader, crate::ParsingMode::Strict, len as u64).unwrap();
@@ -1003,7 +1003,7 @@ mod tests {
 			assert_eq!(old_free_size, PADDING_SIZE as u32);
 
 			let cursor = Cursor::new(ilst_bytes);
-			let mut reader = AtomReader::new(cursor).unwrap();
+			let mut reader = AtomReader::new(cursor, crate::ParsingMode::Strict).unwrap();
 
 			ilst = super::read::parse_ilst(
 				&mut reader,

--- a/src/mp4/ilst/read.rs
+++ b/src/mp4/ilst/read.rs
@@ -28,11 +28,11 @@ where
 
 	let mut cursor = Cursor::new(contents);
 
-	let mut ilst_reader = AtomReader::new(&mut cursor)?;
+	let mut ilst_reader = AtomReader::new(&mut cursor, parsing_mode)?;
 
 	let mut tag = Ilst::default();
 
-	while let Ok(atom) = ilst_reader.next() {
+	while let Ok(Some(atom)) = ilst_reader.next() {
 		if let AtomIdent::Fourcc(ref fourcc) = atom.ident {
 			match fourcc {
 				b"free" | b"skip" => {
@@ -189,7 +189,9 @@ where
 	let to_read = (atom_info.start + atom_info.len) - reader.stream_position()?;
 	let mut pos = 0;
 	while pos < to_read {
-		let next_atom = reader.next()?;
+		let Some(next_atom) = reader.next()? else {
+			break;
+		};
 
 		// We don't care about the version
 		let _version = reader.read_u8()?;
@@ -227,6 +229,7 @@ where
 				},
 			},
 		}
+
 		pos += next_atom.len;
 	}
 


### PR DESCRIPTION
This follows the checks of TagLib: <https://github.com/taglib/taglib/blob/b40b834b1bdbd74593c5619e969e793d4d4886d9/taglib/mp4/mp4atom.cpp#L89>.

@uklotzde This fixes the parsing of the file you sent.

Still need to add a test for this, I'll make one tomorrow.