### PR TITLE
MP4: Remove duplicate track/disc methods on `Ilst`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     that an identifier is invalid. Now we unfortunately have to guess the validity based on the commonly known atoms.
     For this, we follow [TagLib]'s [checks](https://github.com/taglib/taglib/blob/b40b834b1bdbd74593c5619e969e793d4d4886d9/taglib/mp4/mp4atom.cpp#L89).
 
+## Removed
+- **MP4**: `Ilst::{track_total, disc_number, disc_total}` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/269))
+  - These existed prior to the methods on `Accessor`. There is no need to keep them around, as they behave the same.
+
 ## [0.16.1] - 2023-10-15
 
 ## Fixed

--- a/src/mp4/ilst/mod.rs
+++ b/src/mp4/ilst/mod.rs
@@ -366,21 +366,6 @@ impl Ilst {
 		})
 	}
 
-	/// Returns the total number of tracks
-	pub fn track_total(&self) -> Option<u16> {
-		self.extract_number(*b"trkn", 6)
-	}
-
-	/// Returns the disc number
-	pub fn disc_number(&self) -> Option<u16> {
-		self.extract_number(*b"disk", 4)
-	}
-
-	/// Returns the total number of discs
-	pub fn disc_total(&self) -> Option<u16> {
-		self.extract_number(*b"disk", 6)
-	}
-
 	// Extracts a u16 from an integer pair
 	fn extract_number(&self, fourcc: [u8; 4], expected_size: usize) -> Option<u16> {
 		if let Some(atom) = self.get(&AtomIdent::Fourcc(fourcc)) {


### PR DESCRIPTION
These came awhile before the `Accessor` methods, and managed to stick around for almost a year and a half after the fact. :smile: 