### PR TITLE
ParseOptions: Add `ParseOptions::allocation_limit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **VorbisComments**: When converting from `Tag` to `VorbisComments`, `ItemKey::Unknown`s will be checked for spec compliance. ([PR](https://github.com/Serial-ATA/lofty-rs/pull/272))
 - **Alloc**: The default allocation limit for any single tag item is now **16MB**.
+- **Probe**: `Probe::set_file_type()` will return the `Probe` to allow for builder-style usage.
 
 ### Fixed
 - **MP4**: Verify atom identifiers fall within a subset of characters ([PR](https://github.com/Serial-ATA/lofty-rs/pull/267))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ParseOptions**: `ParseOptions::allocation_limit` to change the default allocation limit.
+
 ### Changed
 - **VorbisComments**: When converting from `Tag` to `VorbisComments`, `ItemKey::Unknown`s will be checked for spec compliance. ([PR](https://github.com/Serial-ATA/lofty-rs/pull/272))
+- **Alloc**: The default allocation limit for any single tag item is now **16MB**.
 
 ### Fixed
 - **MP4**: Verify atom identifiers fall within a subset of characters ([PR](https://github.com/Serial-ATA/lofty-rs/pull/267))

--- a/src/error.rs
+++ b/src/error.rs
@@ -530,7 +530,7 @@ impl Display for LoftyError {
 			// Files
 			ErrorKind::TooMuchData => write!(
 				f,
-				"An abnormally large amount of data was provided, and an overflow occurred"
+				"Attempted to read/write an abnormally large amount of data"
 			),
 			ErrorKind::SizeMismatch => write!(
 				f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@
 	clippy::ignored_unit_patterns, /* Not a fan of this lint, doesn't make anything clearer as it claims */
 	clippy::needless_return, /* Explicit returns are needed from time to time for clarity */
 	clippy::redundant_guards, /* Currently broken for some cases, might enable later*/
+	clippy::into_iter_without_iter, /* This is only going to fire on some internal types, doesn't matter much */
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -151,6 +151,9 @@ impl ParseOptions {
 	/// This is a safety measure to prevent allocating too much memory for a single tag item. If a tag item
 	/// exceeds this limit, the allocator will return [`crate::error::ErrorKind::TooMuchData`].
 	///
+	/// NOTE: This only needs to be set once per thread. The limit will be used for all subsequent
+	///       reads, until a new one is set.
+	///
 	/// # Examples
 	///
 	/// ```rust

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -377,7 +377,7 @@ impl<R: Read> Probe<R> {
 	/// let mut probe = Probe::new(reader);
 	/// assert_eq!(probe.file_type(), None);
 	///
-	/// probe.set_file_type(FileType::Mpeg);
+	/// let probe = probe.set_file_type(FileType::Mpeg);
 	///
 	/// assert_eq!(probe.file_type(), Some(FileType::Mpeg));
 	/// # Ok(()) }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -28,6 +28,7 @@ pub struct ParseOptions {
 	pub(crate) use_custom_resolvers: bool,
 	pub(crate) parsing_mode: ParsingMode,
 	pub(crate) max_junk_bytes: usize,
+	pub(crate) allocation_limit: usize,
 }
 
 impl Default for ParseOptions {
@@ -55,6 +56,9 @@ impl ParseOptions {
 	/// Default number of junk bytes to read
 	pub const DEFAULT_MAX_JUNK_BYTES: usize = 1024;
 
+	/// Default allocation limit for any single tag item
+	pub const DEFAULT_ALLOCATION_LIMIT: usize = 16 * 1024 * 1024;
+
 	/// Creates a new `ParseOptions`, alias for `Default` implementation
 	///
 	/// See also: [`ParseOptions::default`]
@@ -73,6 +77,7 @@ impl ParseOptions {
 			use_custom_resolvers: true,
 			parsing_mode: Self::DEFAULT_PARSING_MODE,
 			max_junk_bytes: Self::DEFAULT_MAX_JUNK_BYTES,
+			allocation_limit: Self::DEFAULT_ALLOCATION_LIMIT,
 		}
 	}
 
@@ -138,6 +143,24 @@ impl ParseOptions {
 	/// ```
 	pub fn max_junk_bytes(&mut self, max_junk_bytes: usize) -> Self {
 		self.max_junk_bytes = max_junk_bytes;
+		*self
+	}
+
+	/// The maximum number of bytes to allocate for any single tag item
+	///
+	/// This is a safety measure to prevent allocating too much memory for a single tag item. If a tag item
+	/// exceeds this limit, the allocator will return [`ErrorKind::TooMuchData`].
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use lofty::ParseOptions;
+	///
+	/// // I have files with gigantic images, I'll double the allocation limit!
+	/// let parsing_options = ParseOptions::new().allocation_limit(32 * 1024 * 1024);
+	/// ```
+	pub fn allocation_limit(&mut self, allocation_limit: usize) -> Self {
+		self.allocation_limit = allocation_limit;
 		*self
 	}
 }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -374,8 +374,9 @@ impl<R: Read> Probe<R> {
 	/// assert_eq!(probe.file_type(), Some(FileType::Mpeg));
 	/// # Ok(()) }
 	/// ```
-	pub fn set_file_type(&mut self, file_type: FileType) {
-		self.f_ty = Some(file_type)
+	pub fn set_file_type(mut self, file_type: FileType) -> Self {
+		self.f_ty = Some(file_type);
+		self
 	}
 
 	/// Set the [`ParseOptions`] for the Probe

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -149,7 +149,7 @@ impl ParseOptions {
 	/// The maximum number of bytes to allocate for any single tag item
 	///
 	/// This is a safety measure to prevent allocating too much memory for a single tag item. If a tag item
-	/// exceeds this limit, the allocator will return [`ErrorKind::TooMuchData`].
+	/// exceeds this limit, the allocator will return [`crate::error::ErrorKind::TooMuchData`].
 	///
 	/// # Examples
 	///

--- a/src/util/alloc.rs
+++ b/src/util/alloc.rs
@@ -1,8 +1,6 @@
 use crate::error::Result;
 use crate::macros::err;
-
-// We have an allocation limit of 16MB for any one item
-const ALLOCATION_LIMIT: usize = 16 * 1024 * 1024;
+use crate::probe::ParseOptions;
 
 /// Provides the `fallible_repeat` method on `Vec`
 ///
@@ -22,7 +20,7 @@ impl<T> VecFallibleRepeat<T> for Vec<T> {
 			return Ok(self);
 		}
 
-		if expected_size > ALLOCATION_LIMIT {
+		if expected_size > ParseOptions::DEFAULT_ALLOCATION_LIMIT {
 			err!(TooMuchData);
 		}
 

--- a/src/util/alloc.rs
+++ b/src/util/alloc.rs
@@ -1,8 +1,8 @@
 use crate::error::Result;
 use crate::macros::err;
 
-// We have an allocation limit of 8MB for any one item
-const ALLOCATION_LIMIT: usize = 1024 * 1024 * 8;
+// We have an allocation limit of 16MB for any one item
+const ALLOCATION_LIMIT: usize = 16 * 1024 * 1024;
 
 /// Provides the `fallible_repeat` method on `Vec`
 ///


### PR DESCRIPTION
What this changes:
* Adds `ParseOptions::allocation_limit`
* Changes the default allocation limit to 16MB (previously 8MB)
* Makes `Probe::set_file_type()` return `Probe` to support using it in a builder pattern
	* This was done to make the test nicer, and should've been the behavior from the start.
* Improves the message for `ErrorKind::TooMuchData`
	* Might be worth adding a new variant specifically for exceeded allocation limits in the future. The other contexts where it is used don't necessarily apply to allocation.

The allocation limit can simply be set once and retained for the rest of the program's runtime.

closes #274, #208