### PR TITLE
Fuzz: Read properties in file read targets

### DIFF
--- a/fuzz/fuzz_targets/aacfile_read_from.rs
+++ b/fuzz/fuzz_targets/aacfile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::aac::AacFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::aac::AacFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/aifffile_read_from.rs
+++ b/fuzz/fuzz_targets/aifffile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::iff::aiff::AiffFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::iff::aiff::AiffFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/apefile_read_from.rs
+++ b/fuzz/fuzz_targets/apefile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::ape::ApeFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::ape::ApeFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/flacfile_read_from.rs
+++ b/fuzz/fuzz_targets/flacfile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::flac::FlacFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::flac::FlacFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/mp4file_read_from.rs
+++ b/fuzz/fuzz_targets/mp4file_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::mp4::Mp4File::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::mp4::Mp4File::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/mpegfile_read_from.rs
+++ b/fuzz/fuzz_targets/mpegfile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::mpeg::MpegFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::mpeg::MpegFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/opusfile_read_from.rs
+++ b/fuzz/fuzz_targets/opusfile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::ogg::OpusFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::ogg::OpusFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/speexfile_read_from.rs
+++ b/fuzz/fuzz_targets/speexfile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::ogg::SpeexFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::ogg::SpeexFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/vorbisfile_read_from.rs
+++ b/fuzz/fuzz_targets/vorbisfile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::ogg::VorbisFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::ogg::VorbisFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/wavfile_read_from.rs
+++ b/fuzz/fuzz_targets/wavfile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::iff::wav::WavFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::iff::wav::WavFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });

--- a/fuzz/fuzz_targets/wavpackfile_read_from.rs
+++ b/fuzz/fuzz_targets/wavpackfile_read_from.rs
@@ -6,8 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use lofty::{AudioFile, ParseOptions};
 
 fuzz_target!(|data: Vec<u8>| {
-	let _ = lofty::wavpack::WavPackFile::read_from(
-		&mut Cursor::new(data),
-		ParseOptions::new().read_properties(false),
-	);
+	let _ = lofty::wavpack::WavPackFile::read_from(&mut Cursor::new(data), ParseOptions::new());
 });


### PR DESCRIPTION
No idea why all of the targets had `read_properties(false)`.