### PR TITLE
ID3v2: Handle genre IDs in TCON frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **ParseOptions**: `ParseOptions::allocation_limit` to change the default allocation limit. ([PR](https://github.com/Serial-ATA/lofty-rs/pull/276))
+- **ID3v2**: `Id3v2Tag::genres` to handle all the ways genres can be stored in `TCON` frames. ([PR](https://github.com/Serial-ATA/lofty-rs/pull/286))
 
 ### Changed
 - **VorbisComments**: When converting from `Tag` to `VorbisComments`, `ItemKey::Unknown`s will be checked for spec compliance. ([PR](https://github.com/Serial-ATA/lofty-rs/pull/272))


### PR DESCRIPTION
I played around with this and came up with an implementation that returns an iterator and avoids allocation. It seemed appropriate to change the genre getter for the `Accessor` impl to use the new method so that numeric IDs will be translated and multiple values joined with '/' as per `get_text`. That's done as a separate commit in case it's a problem.

One question is whether `get_texts` and `get_text` should behave the same as `genres` and `genre` for TCON frames? I think this could be done fairly cleanly by reworking `GenresIter` into a more generic `MultiValueIter` and using it in `get_texts`. I can add another commit to this PR to address that if necessary.

closes #281 