### PR TITLE
Make all file writes generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 	  Lofty writes tags. These are best used as global user-configurable options, as most options will
 	  not apply to all files. The defaults are set to be as safe as possible,
 	  see [here](https://docs.rs/lofty/latest/lofty/struct.WriteOptions.html#impl-Default-for-WriteOptions).
+- **Generic Writes** ([PR](https://github.com/Serial-ATA/lofty-rs/pull/290)):
+  - ⚠️ Important ⚠️: This update introduces `FileLike`, which is a combination of the `Truncate` + `Length` traits
+    that allows one to write to more than just `File`s. In short, `Cursor<Vec<u8>>` can now be written to.
 - **ChannelMask**
   - `BitAnd` and `BitOr` implementations ([PR](https://github.com/Serial-ATA/lofty-rs/pull/371))
   - Associated constants for common channels, ex. `ChannelMask::FRONT_LEFT` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/371))

--- a/lofty_attr/src/internal.rs
+++ b/lofty_attr/src/internal.rs
@@ -48,16 +48,16 @@ pub(crate) fn init_write_lookup(
 			read_only: false,
 			items: lofty::ape::tag::tagitems_into_ape(tag),
 		}
-		.write_to(data, write_options)
+		.write_to(file, write_options)
 	});
 
 	insert!(map, Id3v1, {
-		Into::<lofty::id3::v1::tag::Id3v1TagRef<'_>>::into(tag).write_to(data, write_options)
+		Into::<lofty::id3::v1::tag::Id3v1TagRef<'_>>::into(tag).write_to(file, write_options)
 	});
 
 	if id3v2_strippable {
 		insert!(map, Id3v2, {
-			lofty::id3::v2::tag::Id3v2TagRef::empty().write_to(data, write_options)
+			lofty::id3::v2::tag::Id3v2TagRef::empty().write_to(file, write_options)
 		});
 	} else {
 		insert!(map, Id3v2, {
@@ -65,7 +65,7 @@ pub(crate) fn init_write_lookup(
 				flags: lofty::id3::v2::Id3v2TagFlags::default(),
 				frames: lofty::id3::v2::tag::tag_frames(tag),
 			}
-			.write_to(data, write_options)
+			.write_to(file, write_options)
 		});
 	}
 
@@ -73,7 +73,7 @@ pub(crate) fn init_write_lookup(
 		lofty::iff::wav::tag::RIFFInfoListRef::new(lofty::iff::wav::tag::tagitems_into_riff(
 			tag.items(),
 		))
-		.write_to(data, write_options)
+		.write_to(file, write_options)
 	});
 
 	insert!(map, AiffText, {
@@ -84,7 +84,7 @@ pub(crate) fn init_write_lookup(
 			annotations: Some(tag.get_strings(&lofty::prelude::ItemKey::Comment)),
 			comments: None,
 		}
-		.write_to(data, write_options)
+		.write_to(file, write_options)
 	});
 
 	map
@@ -112,7 +112,12 @@ pub(crate) fn write_module(
 	quote! {
 		pub(crate) mod write {
 			#[allow(unused_variables)]
-			pub(crate) fn write_to(data: &mut ::std::fs::File, tag: &::lofty::tag::Tag, write_options: ::lofty::config::WriteOptions) -> ::lofty::error::Result<()> {
+			pub(crate) fn write_to<F>(file: &mut F, tag: &::lofty::tag::Tag, write_options: ::lofty::config::WriteOptions) -> ::lofty::error::Result<()>
+			where
+				F: ::lofty::io::FileLike,
+				::lofty::error::LoftyError: ::std::convert::From<<F as ::lofty::io::Truncate>::Error>,
+				::lofty::error::LoftyError: ::std::convert::From<<F as ::lofty::io::Length>::Error>,
+			{
 				match tag.tag_type() {
 					#( #applicable_formats )*
 					_ => crate::macros::err!(UnsupportedTag),

--- a/lofty_attr/src/lofty_file.rs
+++ b/lofty_attr/src/lofty_file.rs
@@ -445,7 +445,12 @@ fn generate_audiofile_impl(file: &LoftyFile) -> syn::Result<proc_macro2::TokenSt
 				#read_fn(reader, parse_options)
 			}
 
-			fn save_to(&self, file: &mut ::std::fs::File, write_options: ::lofty::config::WriteOptions) -> ::lofty::error::Result<()> {
+			fn save_to<F>(&self, file: &mut F, write_options: ::lofty::config::WriteOptions) -> ::lofty::error::Result<()>
+			where
+				F: ::lofty::io::FileLike,
+				::lofty::error::LoftyError: ::std::convert::From<<F as ::lofty::io::Truncate>::Error>,
+				::lofty::error::LoftyError: ::std::convert::From<<F as ::lofty::io::Length>::Error>,
+			{
 				use ::lofty::tag::TagExt as _;
 				use ::std::io::Seek as _;
 				#save_to_body

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,8 @@ pub enum ErrorKind {
 	Io(std::io::Error),
 	/// Failure to allocate enough memory
 	Alloc(TryReserveError),
+	/// This should **never** be encountered
+	Infallible(std::convert::Infallible),
 }
 
 /// The types of errors that can occur while interacting with ID3v2 tags
@@ -499,6 +501,14 @@ impl From<std::collections::TryReserveError> for LoftyError {
 	}
 }
 
+impl From<std::convert::Infallible> for LoftyError {
+	fn from(input: std::convert::Infallible) -> Self {
+		Self {
+			kind: ErrorKind::Infallible(input),
+		}
+	}
+}
+
 impl Display for LoftyError {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
 		match self.kind {
@@ -540,6 +550,8 @@ impl Display for LoftyError {
 			),
 			ErrorKind::FileDecoding(ref file_decode_err) => write!(f, "{file_decode_err}"),
 			ErrorKind::FileEncoding(ref file_encode_err) => write!(f, "{file_encode_err}"),
+
+			ErrorKind::Infallible(_) => write!(f, "A expected condition was not upheld"),
 		}
 	}
 }

--- a/src/file/audio_file.rs
+++ b/src/file/audio_file.rs
@@ -1,9 +1,10 @@
 use super::tagged_file::TaggedFile;
 use crate::config::{ParseOptions, WriteOptions};
-use crate::error::Result;
+use crate::error::{LoftyError, Result};
 use crate::tag::TagType;
 
-use std::fs::{File, OpenOptions};
+use crate::util::io::{FileLike, Length, Truncate};
+use std::fs::OpenOptions;
 use std::io::{Read, Seek};
 use std::path::Path;
 
@@ -77,7 +78,11 @@ pub trait AudioFile: Into<TaggedFile> {
 	/// tagged_file.save_to(&mut file, WriteOptions::default())?;
 	/// # Ok(()) }
 	/// ```
-	fn save_to(&self, file: &mut File, write_options: WriteOptions) -> Result<()>;
+	fn save_to<F>(&self, file: &mut F, write_options: WriteOptions) -> Result<()>
+	where
+		F: FileLike,
+		LoftyError: From<<F as Truncate>::Error>,
+		LoftyError: From<<F as Length>::Error>;
 
 	/// Returns a reference to the file's properties
 	fn properties(&self) -> &Self::Properties;

--- a/src/file/tagged_file.rs
+++ b/src/file/tagged_file.rs
@@ -1,10 +1,11 @@
 use super::audio_file::AudioFile;
 use super::file_type::FileType;
 use crate::config::{ParseOptions, WriteOptions};
-use crate::error::Result;
+use crate::error::{LoftyError, Result};
 use crate::properties::FileProperties;
 use crate::tag::{Tag, TagExt, TagType};
 
+use crate::util::io::{FileLike, Length, Truncate};
 use std::fs::File;
 use std::io::{Read, Seek};
 
@@ -423,7 +424,12 @@ impl AudioFile for TaggedFile {
 			.read()
 	}
 
-	fn save_to(&self, file: &mut File, write_options: WriteOptions) -> Result<()> {
+	fn save_to<F>(&self, file: &mut F, write_options: WriteOptions) -> Result<()>
+	where
+		F: FileLike,
+		LoftyError: From<<F as Truncate>::Error>,
+		LoftyError: From<<F as Length>::Error>,
+	{
 		for tag in &self.tags {
 			// TODO: This is a temporary solution. Ideally we should probe once and use
 			//       the format-specific writing to avoid these rewinds.
@@ -631,7 +637,12 @@ impl AudioFile for BoundTaggedFile {
 		)
 	}
 
-	fn save_to(&self, file: &mut File, write_options: WriteOptions) -> Result<()> {
+	fn save_to<F>(&self, file: &mut F, write_options: WriteOptions) -> Result<()>
+	where
+		F: FileLike,
+		LoftyError: From<<F as Truncate>::Error>,
+		LoftyError: From<<F as Length>::Error>,
+	{
 		self.inner.save_to(file, write_options)
 	}
 

--- a/src/flac/mod.rs
+++ b/src/flac/mod.rs
@@ -17,11 +17,11 @@ use crate::ogg::tag::VorbisCommentsRef;
 use crate::ogg::{OggPictureStorage, VorbisComments};
 use crate::picture::{Picture, PictureInformation};
 use crate::tag::TagExt;
+use crate::util::io::{FileLike, Length, Truncate};
 
 use lofty_attr::LoftyFile;
 
 // Exports
-use crate::util::io::{FileLike, Length, Truncate};
 pub use properties::FlacProperties;
 
 /// A FLAC file

--- a/src/flac/write.rs
+++ b/src/flac/write.rs
@@ -7,10 +7,10 @@ use crate::ogg::tag::VorbisCommentsRef;
 use crate::ogg::write::create_comments;
 use crate::picture::{Picture, PictureInformation};
 use crate::tag::{Tag, TagType};
+use crate::util::io::{FileLike, Length, Truncate};
 
 use std::io::{Cursor, Seek, SeekFrom, Write};
 
-use crate::util::io::{FileLike, Length, Truncate};
 use byteorder::{LittleEndian, WriteBytesExt};
 
 const BLOCK_HEADER_SIZE: usize = 4;

--- a/src/id3/v1/tag.rs
+++ b/src/id3/v1/tag.rs
@@ -2,11 +2,12 @@ use crate::config::WriteOptions;
 use crate::error::{LoftyError, Result};
 use crate::id3::v1::constants::GENRES;
 use crate::tag::{Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType};
+use crate::util::io::{FileLike, Length, Truncate};
+
 use std::borrow::Cow;
 use std::io::Write;
 use std::path::Path;
 
-use crate::util::io::{FileLike, Length, Truncate};
 use lofty_attr::tag;
 
 macro_rules! impl_accessor {

--- a/src/id3/v1/write.rs
+++ b/src/id3/v1/write.rs
@@ -4,10 +4,10 @@ use crate::error::{LoftyError, Result};
 use crate::id3::{find_id3v1, ID3FindResults};
 use crate::macros::err;
 use crate::probe::Probe;
+use crate::util::io::{FileLike, Length, Truncate};
 
 use std::io::{Cursor, Seek, Write};
 
-use crate::util::io::{FileLike, Length, Truncate};
 use byteorder::WriteBytesExt;
 
 #[allow(clippy::shadow_unrelated)]

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -21,13 +21,13 @@ use crate::picture::{Picture, PictureType, TOMBSTONE_PICTURE};
 use crate::tag::{
 	try_parse_year, Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType,
 };
+use crate::util::io::{FileLike, Length, Truncate};
 use crate::util::text::{decode_text, TextDecodeOptions, TextEncoding};
 
 use std::borrow::Cow;
 use std::io::{Cursor, Write};
 use std::ops::Deref;
 
-use crate::util::io::{FileLike, Length, Truncate};
 use lofty_attr::tag;
 
 const USER_DEFINED_TEXT_FRAME_ID: &str = "TXXX";

--- a/src/id3/v2/write/chunk_file.rs
+++ b/src/id3/v2/write/chunk_file.rs
@@ -1,9 +1,10 @@
 use crate::config::WriteOptions;
 use crate::error::{LoftyError, Result};
 use crate::iff::chunk::Chunks;
+use crate::util::io::{FileLike, Length, Truncate};
+
 use std::io::SeekFrom;
 
-use crate::util::io::{FileLike, Length, Truncate};
 use byteorder::{ByteOrder, WriteBytesExt};
 
 const CHUNK_NAME_UPPER: [u8; 4] = [b'I', b'D', b'3', b' '];

--- a/src/id3/v2/write/chunk_file.rs
+++ b/src/id3/v2/write/chunk_file.rs
@@ -1,45 +1,47 @@
 use crate::config::WriteOptions;
-use crate::error::Result;
+use crate::error::{LoftyError, Result};
 use crate::iff::chunk::Chunks;
+use std::io::SeekFrom;
 
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
-
+use crate::util::io::{FileLike, Length, Truncate};
 use byteorder::{ByteOrder, WriteBytesExt};
 
 const CHUNK_NAME_UPPER: [u8; 4] = [b'I', b'D', b'3', b' '];
 const CHUNK_NAME_LOWER: [u8; 4] = [b'i', b'd', b'3', b' '];
 
-pub(in crate::id3::v2) fn write_to_chunk_file<B>(
-	data: &mut File,
+pub(in crate::id3::v2) fn write_to_chunk_file<F, B>(
+	file: &mut F,
 	tag: &[u8],
 	write_options: WriteOptions,
 ) -> Result<()>
 where
+	F: FileLike,
+	LoftyError: From<<F as Truncate>::Error>,
+	LoftyError: From<<F as Length>::Error>,
 	B: ByteOrder,
 {
 	// RIFF....WAVE
-	data.seek(SeekFrom::Current(12))?;
+	file.seek(SeekFrom::Current(12))?;
 
-	let file_len = data.metadata()?.len().saturating_sub(12);
+	let file_len = file.len()?.saturating_sub(12);
 
 	let mut id3v2_chunk = (None, None);
 
 	let mut chunks = Chunks::<B>::new(file_len);
 
-	while chunks.next(data).is_ok() {
+	while chunks.next(file).is_ok() {
 		if chunks.fourcc == CHUNK_NAME_UPPER || chunks.fourcc == CHUNK_NAME_LOWER {
-			id3v2_chunk = (Some(data.stream_position()? - 8), Some(chunks.size));
+			id3v2_chunk = (Some(file.stream_position()? - 8), Some(chunks.size));
 			break;
 		}
 
-		data.seek(SeekFrom::Current(i64::from(chunks.size)))?;
+		file.seek(SeekFrom::Current(i64::from(chunks.size)))?;
 
-		chunks.correct_position(data)?;
+		chunks.correct_position(file)?;
 	}
 
 	if let (Some(chunk_start), Some(mut chunk_size)) = id3v2_chunk {
-		data.rewind()?;
+		file.rewind()?;
 
 		// We need to remove the padding byte if it exists
 		if chunk_size % 2 != 0 {
@@ -47,41 +49,41 @@ where
 		}
 
 		let mut file_bytes = Vec::new();
-		data.read_to_end(&mut file_bytes)?;
+		file.read_to_end(&mut file_bytes)?;
 
 		file_bytes.splice(
 			chunk_start as usize..(chunk_start + u64::from(chunk_size) + 8) as usize,
 			[],
 		);
 
-		data.rewind()?;
-		data.set_len(0)?;
-		data.write_all(&file_bytes)?;
+		file.rewind()?;
+		file.truncate(0)?;
+		file.write_all(&file_bytes)?;
 	}
 
 	if !tag.is_empty() {
-		data.seek(SeekFrom::End(0))?;
+		file.seek(SeekFrom::End(0))?;
 
 		if write_options.uppercase_id3v2_chunk {
-			data.write_all(&CHUNK_NAME_UPPER)?;
+			file.write_all(&CHUNK_NAME_UPPER)?;
 		} else {
-			data.write_all(&CHUNK_NAME_LOWER)?;
+			file.write_all(&CHUNK_NAME_LOWER)?;
 		}
 
-		data.write_u32::<B>(tag.len() as u32)?;
-		data.write_all(tag)?;
+		file.write_u32::<B>(tag.len() as u32)?;
+		file.write_all(tag)?;
 
 		// It is required an odd length chunk be padded with a 0
 		// The 0 isn't included in the chunk size, however
 		if tag.len() % 2 != 0 {
-			data.write_u8(0)?;
+			file.write_u8(0)?;
 		}
 
-		let total_size = data.stream_position()? - 8;
+		let total_size = file.stream_position()? - 8;
 
-		data.seek(SeekFrom::Start(4))?;
+		file.seek(SeekFrom::Start(4))?;
 
-		data.write_u32::<B>(total_size as u32)?;
+		file.write_u32::<B>(total_size as u32)?;
 	}
 
 	Ok(())

--- a/src/id3/v2/write/mod.rs
+++ b/src/id3/v2/write/mod.rs
@@ -12,12 +12,12 @@ use crate::id3::v2::Id3v2Tag;
 use crate::id3::{find_id3v2, FindId3v2Config};
 use crate::macros::{err, try_vec};
 use crate::probe::Probe;
+use crate::util::io::{FileLike, Length, Truncate};
 
 use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::ops::Not;
 use std::sync::OnceLock;
 
-use crate::util::io::{FileLike, Length, Truncate};
 use byteorder::{BigEndian, LittleEndian, WriteBytesExt};
 
 // In the very rare chance someone wants to write a CRC in their extended header

--- a/src/iff/aiff/tag.rs
+++ b/src/iff/aiff/tag.rs
@@ -3,12 +3,12 @@ use crate::error::{LoftyError, Result};
 use crate::iff::chunk::Chunks;
 use crate::macros::err;
 use crate::tag::{Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType};
+use crate::util::io::{FileLike, Length, Truncate};
 
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::io::{SeekFrom, Write};
 
-use crate::util::io::{FileLike, Length, Truncate};
 use byteorder::BigEndian;
 use lofty_attr::tag;
 

--- a/src/iff/wav/tag/mod.rs
+++ b/src/iff/wav/tag/mod.rs
@@ -6,11 +6,11 @@ use crate::error::{LoftyError, Result};
 use crate::tag::{
 	try_parse_year, Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType,
 };
+use crate::util::io::{FileLike, Length, Truncate};
 
 use std::borrow::Cow;
 use std::io::Write;
 
-use crate::util::io::{FileLike, Length, Truncate};
 use lofty_attr::tag;
 
 macro_rules! impl_accessor {

--- a/src/iff/wav/tag/write.rs
+++ b/src/iff/wav/tag/write.rs
@@ -4,10 +4,10 @@ use crate::error::{LoftyError, Result};
 use crate::iff::chunk::Chunks;
 use crate::iff::wav::read::verify_wav;
 use crate::macros::err;
+use crate::util::io::{FileLike, Length, Truncate};
 
 use std::io::{Read, Seek, SeekFrom};
 
-use crate::util::io::{FileLike, Length, Truncate};
 use byteorder::{LittleEndian, WriteBytesExt};
 
 pub(in crate::iff::wav) fn write_riff_info<'a, F, I>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,8 @@ pub use util::text::TextEncoding;
 
 pub use lofty_attr::LoftyFile;
 
+pub use util::io;
+
 pub mod prelude {
 	//! A prelude for commonly used items in the library.
 	//!

--- a/src/mp4/ilst/mod.rs
+++ b/src/mp4/ilst/mod.rs
@@ -12,13 +12,13 @@ use crate::picture::{Picture, PictureType, TOMBSTONE_PICTURE};
 use crate::tag::{
 	try_parse_year, Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType,
 };
+use crate::util::io::{FileLike, Length, Truncate};
 use atom::{AdvisoryRating, Atom, AtomData};
 
 use std::borrow::Cow;
 use std::io::Write;
 use std::ops::Deref;
 
-use crate::util::io::{FileLike, Length, Truncate};
 use lofty_attr::tag;
 
 const ARTIST: AtomIdent<'_> = AtomIdent::Fourcc(*b"\xa9ART");

--- a/src/mp4/ilst/ref.rs
+++ b/src/mp4/ilst/ref.rs
@@ -3,10 +3,10 @@
 // *********************
 
 use crate::config::WriteOptions;
-use crate::error::Result;
+use crate::error::{LoftyError, Result};
 use crate::mp4::{Atom, AtomData, AtomIdent, Ilst};
 
-use std::fs::File;
+use crate::util::io::{FileLike, Length, Truncate};
 use std::io::Write;
 
 impl Ilst {
@@ -25,7 +25,12 @@ impl<'a, I: 'a> IlstRef<'a, I>
 where
 	I: IntoIterator<Item = &'a AtomData>,
 {
-	pub(crate) fn write_to(&mut self, file: &mut File, write_options: WriteOptions) -> Result<()> {
+	pub(crate) fn write_to<F>(&mut self, file: &mut F, write_options: WriteOptions) -> Result<()>
+	where
+		F: FileLike,
+		LoftyError: From<<F as Truncate>::Error>,
+		LoftyError: From<<F as Length>::Error>,
+	{
 		super::write::write_to(file, self, write_options)
 	}
 

--- a/src/mp4/ilst/ref.rs
+++ b/src/mp4/ilst/ref.rs
@@ -5,8 +5,8 @@
 use crate::config::WriteOptions;
 use crate::error::{LoftyError, Result};
 use crate::mp4::{Atom, AtomData, AtomIdent, Ilst};
-
 use crate::util::io::{FileLike, Length, Truncate};
+
 use std::io::Write;
 
 impl Ilst {

--- a/src/mp4/ilst/write.rs
+++ b/src/mp4/ilst/write.rs
@@ -9,9 +9,10 @@ use crate::mp4::read::{atom_tree, meta_is_full, nested_atom, verify_mp4, AtomRea
 use crate::mp4::write::{AtomWriter, AtomWriterCompanion, ContextualAtom};
 use crate::mp4::AtomData;
 use crate::picture::{MimeType, Picture};
+use crate::util::io::{FileLike, Length, Truncate};
+
 use std::io::{Cursor, Seek, SeekFrom, Write};
 
-use crate::util::io::{FileLike, Length, Truncate};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 // A "full" atom is a traditional length + identifier, followed by a version (1) and flags (3)

--- a/src/tag/mod.rs
+++ b/src/tag/mod.rs
@@ -565,7 +565,7 @@ impl TagExt for Tag {
 	/// # Errors
 	///
 	/// * A [`FileType`](crate::file::FileType) couldn't be determined from the File
-	/// * Attempting to write a tag to a format that does not support it. See [`FileType::supports_tag_type`](crate::FileType::supports_tag_type)
+	/// * Attempting to write a tag to a format that does not support it. See [`FileType::supports_tag_type`](crate::file::FileType::supports_tag_type)
 	fn save_to<F>(
 		&self,
 		file: &mut F,
@@ -603,7 +603,7 @@ impl TagExt for Tag {
 		self.tag_type.remove_from_path(path)
 	}
 
-	/// Remove a tag from a [`FileLike`](crate::FileLike)
+	/// Remove a tag from a [`FileLike`]
 	///
 	/// # Errors
 	///

--- a/src/tag/mod.rs
+++ b/src/tag/mod.rs
@@ -12,13 +12,13 @@ use crate::error::{LoftyError, Result};
 use crate::macros::err;
 use crate::picture::{Picture, PictureType};
 use crate::probe::Probe;
+use crate::util::io::{FileLike, Length, Truncate};
 
 use std::borrow::Cow;
 use std::io::Write;
 use std::path::Path;
 
 // Exports
-use crate::util::io::{FileLike, Length, Truncate};
 pub use accessor::Accessor;
 pub use item::{ItemKey, ItemValue, TagItem};
 pub use split_merge_tag::{MergeTag, SplitTag};

--- a/src/tag/tag_ext.rs
+++ b/src/tag/tag_ext.rs
@@ -93,7 +93,7 @@ pub trait TagExt: Accessor + Into<Tag> + Sized {
 		)
 	}
 
-	/// Save the tag to a [`File`]
+	/// Save the tag to a [`FileLike`]
 	///
 	/// # Errors
 	///
@@ -128,7 +128,7 @@ pub trait TagExt: Accessor + Into<Tag> + Sized {
 		self.tag_type().remove_from_path(path).map_err(Into::into)
 	}
 
-	/// Remove a tag from a [`File`]
+	/// Remove a tag from a [`FileLike`]
 	///
 	/// # Errors
 	///

--- a/src/tag/tag_type.rs
+++ b/src/tag/tag_type.rs
@@ -41,7 +41,7 @@ impl TagType {
 	}
 
 	#[allow(clippy::shadow_unrelated)]
-	/// Remove a tag from a [`File`]
+	/// Remove a tag from a [`FileLike`]
 	///
 	/// # Errors
 	///

--- a/src/tag/tag_type.rs
+++ b/src/tag/tag_type.rs
@@ -1,11 +1,11 @@
 use super::{utils, Tag};
 use crate::config::WriteOptions;
+use crate::error::LoftyError;
 use crate::file::FileType;
+use crate::io::{FileLike, Length, Truncate};
 use crate::macros::err;
 use crate::probe::Probe;
 
-use crate::error::LoftyError;
-use crate::io::{FileLike, Length, Truncate};
 use std::fs::OpenOptions;
 use std::path::Path;
 

--- a/src/tag/tag_type.rs
+++ b/src/tag/tag_type.rs
@@ -4,7 +4,9 @@ use crate::file::FileType;
 use crate::macros::err;
 use crate::probe::Probe;
 
-use std::fs::{File, OpenOptions};
+use crate::error::LoftyError;
+use crate::io::{FileLike, Length, Truncate};
+use std::fs::OpenOptions;
 use std::path::Path;
 
 /// The tag's format
@@ -46,7 +48,12 @@ impl TagType {
 	/// * It is unable to guess the file format
 	/// * The format doesn't support the tag
 	/// * It is unable to write to the file
-	pub fn remove_from(&self, file: &mut File) -> crate::error::Result<()> {
+	pub fn remove_from<F>(&self, file: &mut F) -> crate::error::Result<()>
+	where
+		F: FileLike,
+		LoftyError: From<<F as Truncate>::Error>,
+		LoftyError: From<<F as Length>::Error>,
+	{
 		let probe = Probe::new(file).guess_file_type()?;
 		let Some(file_type) = probe.file_type() else {
 			err!(UnknownFormat);

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -1,5 +1,5 @@
 use crate::config::WriteOptions;
-use crate::error::Result;
+use crate::error::{LoftyError, Result};
 use crate::file::FileType;
 use crate::macros::err;
 use crate::tag::{Tag, TagType};
@@ -14,16 +14,21 @@ use ape::tag::ApeTagRef;
 use iff::aiff::tag::AiffTextChunksRef;
 use iff::wav::tag::RIFFInfoListRef;
 
-use std::fs::File;
+use crate::util::io::{FileLike, Length, Truncate};
 use std::io::Write;
 
 #[allow(unreachable_patterns)]
-pub(crate) fn write_tag(
+pub(crate) fn write_tag<F>(
 	tag: &Tag,
-	file: &mut File,
+	file: &mut F,
 	file_type: FileType,
 	write_options: WriteOptions,
-) -> Result<()> {
+) -> Result<()>
+where
+	F: FileLike,
+	LoftyError: From<<F as Truncate>::Error>,
+	LoftyError: From<<F as Length>::Error>,
+{
 	match file_type {
 		FileType::Aac => aac::write::write_to(file, tag, write_options),
 		FileType::Aiff => iff::aiff::write::write_to(file, tag, write_options),

--- a/src/tag/utils.rs
+++ b/src/tag/utils.rs
@@ -3,6 +3,7 @@ use crate::error::{LoftyError, Result};
 use crate::file::FileType;
 use crate::macros::err;
 use crate::tag::{Tag, TagType};
+use crate::util::io::{FileLike, Length, Truncate};
 use crate::{aac, ape, flac, iff, mpeg, musepack, wavpack};
 
 use crate::id3::v1::tag::Id3v1TagRef;
@@ -14,7 +15,6 @@ use ape::tag::ApeTagRef;
 use iff::aiff::tag::AiffTextChunksRef;
 use iff::wav::tag::RIFFInfoListRef;
 
-use crate::util::io::{FileLike, Length, Truncate};
 use std::io::Write;
 
 #[allow(unreachable_patterns)]

--- a/src/util/io.rs
+++ b/src/util/io.rs
@@ -1,3 +1,10 @@
+//! Various traits for reading and writing to file-like objects
+
+use crate::error::LoftyError;
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{Cursor, Read, Seek, Write};
+
 // TODO: https://github.com/rust-lang/rust/issues/59359
 pub(crate) trait SeekStreamLen: std::io::Seek {
 	fn stream_len_hack(&mut self) -> crate::error::Result<u64> {
@@ -13,3 +20,245 @@ pub(crate) trait SeekStreamLen: std::io::Seek {
 }
 
 impl<T> SeekStreamLen for T where T: std::io::Seek {}
+
+/// Provides a method to truncate an object to the specified length
+///
+/// This is one component of the [`FileLike`] trait, which is used to provide implementors access to any
+/// file saving methods such as [`crate::AudioFile::save_to`].
+///
+/// Take great care in implementing this for downstream types, as Lofty will assume that the
+/// container has the new length specified. If this assumption were to be broken, files **will** become corrupted.
+pub trait Truncate {
+	/// The error type of the truncation operation
+	type Error: Into<LoftyError>;
+
+	/// Truncate a storage object to the specified length
+	///
+	/// # Errors
+	///
+	/// Errors depend on the object being truncated, which may not always be fallible.
+	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error>;
+}
+
+impl Truncate for File {
+	type Error = std::io::Error;
+
+	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+		self.set_len(new_len)
+	}
+}
+
+impl Truncate for Vec<u8> {
+	type Error = std::convert::Infallible;
+
+	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+		self.truncate(new_len as usize);
+		Ok(())
+	}
+}
+
+impl Truncate for VecDeque<u8> {
+	type Error = std::convert::Infallible;
+
+	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+		self.truncate(new_len as usize);
+		Ok(())
+	}
+}
+
+impl<T> Truncate for Cursor<T>
+where
+	T: Truncate,
+{
+	type Error = <T as Truncate>::Error;
+
+	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+		self.get_mut().truncate(new_len)
+	}
+}
+
+impl<T> Truncate for Box<T>
+where
+	T: Truncate,
+{
+	type Error = <T as Truncate>::Error;
+
+	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+		self.as_mut().truncate(new_len)
+	}
+}
+
+/// Provides a method to get the length of a storage object
+///
+/// This is one component of the [`FileLike`] trait, which is used to provide implementors access to any
+/// file saving methods such as [`crate::AudioFile::save_to`].
+///
+/// Take great care in implementing this for downstream types, as Lofty will assume that the
+/// container has the exact length specified. If this assumption were to be broken, files **may** become corrupted.
+pub trait Length {
+	/// The error type of the length operation
+	type Error: Into<LoftyError>;
+
+	/// Get the length of a storage object
+	///
+	/// # Errors
+	///
+	/// Errors depend on the object being read, which may not always be fallible.
+	fn len(&self) -> std::result::Result<u64, Self::Error>;
+}
+
+impl Length for File {
+	type Error = std::io::Error;
+
+	fn len(&self) -> std::result::Result<u64, Self::Error> {
+		self.metadata().map(|m| m.len())
+	}
+}
+
+impl Length for Vec<u8> {
+	type Error = std::convert::Infallible;
+
+	fn len(&self) -> std::result::Result<u64, Self::Error> {
+		Ok(self.len() as u64)
+	}
+}
+
+impl Length for VecDeque<u8> {
+	type Error = std::convert::Infallible;
+
+	fn len(&self) -> std::result::Result<u64, Self::Error> {
+		Ok(self.len() as u64)
+	}
+}
+
+impl<T> Length for Cursor<T>
+where
+	T: Length,
+{
+	type Error = <T as Length>::Error;
+
+	fn len(&self) -> std::result::Result<u64, Self::Error> {
+		Length::len(self.get_ref())
+	}
+}
+
+impl<T> Length for Box<T>
+where
+	T: Length,
+{
+	type Error = <T as Length>::Error;
+
+	fn len(&self) -> std::result::Result<u64, Self::Error> {
+		Length::len(self.as_ref())
+	}
+}
+
+/// Provides a set of methods to read and write to a file-like object
+///
+/// This is a combination of the [`Read`], [`Write`], [`Seek`], [`Truncate`], and [`Length`] traits.
+/// It is used to provide implementors access to any file saving methods such as [`crate::AudioFile::save_to`].
+///
+/// Take great care in implementing this for downstream types, as Lofty will assume that the
+/// trait implementations are correct. If this assumption were to be broken, files **may** become corrupted.
+pub trait FileLike: Read + Write + Seek + Truncate + Length
+where
+	<Self as Truncate>::Error: Into<LoftyError>,
+	<Self as Length>::Error: Into<LoftyError>,
+{
+}
+
+impl<T> FileLike for T
+where
+	T: Read + Write + Seek + Truncate + Length,
+	<T as Truncate>::Error: Into<LoftyError>,
+	<T as Length>::Error: Into<LoftyError>,
+{
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::config::{ParseOptions, WriteOptions};
+	use crate::file::AudioFile;
+	use crate::mpeg::MpegFile;
+	use crate::tag::Accessor;
+
+	use std::io::{Cursor, Read, Seek, Write};
+
+	const TEST_ASSET: &str = "tests/files/assets/minimal/full_test.mp3";
+
+	fn test_asset_contents() -> Vec<u8> {
+		std::fs::read(TEST_ASSET).unwrap()
+	}
+
+	fn file() -> MpegFile {
+		let file_contents = test_asset_contents();
+		let mut reader = Cursor::new(file_contents);
+		MpegFile::read_from(&mut reader, ParseOptions::new()).unwrap()
+	}
+
+	fn alter_tag(file: &mut MpegFile) {
+		let tag = file.id3v2_mut().unwrap();
+		tag.set_artist(String::from("Bar artist"));
+	}
+
+	fn revert_tag(file: &mut MpegFile) {
+		let tag = file.id3v2_mut().unwrap();
+		tag.set_artist(String::from("Foo artist"));
+	}
+
+	#[test]
+	fn io_save_to_file() {
+		// Read the file and change the artist
+		let mut file = file();
+		alter_tag(&mut file);
+
+		let mut temp_file = tempfile::tempfile().unwrap();
+		let file_content = std::fs::read(TEST_ASSET).unwrap();
+		temp_file.write_all(&file_content).unwrap();
+		temp_file.rewind().unwrap();
+
+		// Save the new artist
+		file.save_to(&mut temp_file, WriteOptions::new().preferred_padding(0))
+			.expect("Failed to save to file");
+
+		// Read the file again and change the artist back
+		temp_file.rewind().unwrap();
+		let mut file = MpegFile::read_from(&mut temp_file, ParseOptions::new()).unwrap();
+		revert_tag(&mut file);
+
+		temp_file.rewind().unwrap();
+		file.save_to(&mut temp_file, WriteOptions::new().preferred_padding(0))
+			.expect("Failed to save to file");
+
+		// The contents should be the same as the original file
+		temp_file.rewind().unwrap();
+		let mut current_file_contents = Vec::new();
+		temp_file.read_to_end(&mut current_file_contents).unwrap();
+
+		assert_eq!(current_file_contents, test_asset_contents());
+	}
+
+	#[test]
+	fn io_save_to_vec() {
+		// Same test as above, but using a Cursor<Vec<u8>> instead of a file
+		let mut file = file();
+		alter_tag(&mut file);
+
+		let file_content = std::fs::read(TEST_ASSET).unwrap();
+
+		let mut reader = Cursor::new(file_content);
+		file.save_to(&mut reader, WriteOptions::new().preferred_padding(0))
+			.expect("Failed to save to vec");
+
+		reader.rewind().unwrap();
+		let mut file = MpegFile::read_from(&mut reader, ParseOptions::new()).unwrap();
+		revert_tag(&mut file);
+
+		reader.rewind().unwrap();
+		file.save_to(&mut reader, WriteOptions::new().preferred_padding(0))
+			.expect("Failed to save to vec");
+
+		let current_file_contents = reader.into_inner();
+		assert_eq!(current_file_contents, test_asset_contents());
+	}
+}

--- a/src/util/io.rs
+++ b/src/util/io.rs
@@ -1,6 +1,7 @@
 //! Various traits for reading and writing to file-like objects
 
 use crate::error::LoftyError;
+
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{Cursor, Read, Seek, Write};

--- a/src/util/io.rs
+++ b/src/util/io.rs
@@ -24,7 +24,7 @@ impl<T> SeekStreamLen for T where T: Seek {}
 /// Provides a method to truncate an object to the specified length
 ///
 /// This is one component of the [`FileLike`] trait, which is used to provide implementors access to any
-/// file saving methods such as [`crate::AudioFile::save_to`].
+/// file saving methods such as [`crate::file::AudioFile::save_to`].
 ///
 /// Take great care in implementing this for downstream types, as Lofty will assume that the
 /// container has the new length specified. If this assumption were to be broken, files **will** become corrupted.
@@ -91,7 +91,7 @@ where
 /// Provides a method to get the length of a storage object
 ///
 /// This is one component of the [`FileLike`] trait, which is used to provide implementors access to any
-/// file saving methods such as [`crate::AudioFile::save_to`].
+/// file saving methods such as [`crate::file::AudioFile::save_to`].
 ///
 /// Take great care in implementing this for downstream types, as Lofty will assume that the
 /// container has the exact length specified. If this assumption were to be broken, files **may** become corrupted.
@@ -156,7 +156,7 @@ where
 /// Provides a set of methods to read and write to a file-like object
 ///
 /// This is a combination of the [`Read`], [`Write`], [`Seek`], [`Truncate`], and [`Length`] traits.
-/// It is used to provide implementors access to any file saving methods such as [`crate::AudioFile::save_to`].
+/// It is used to provide implementors access to any file saving methods such as [`crate::file::AudioFile::save_to`].
 ///
 /// Take great care in implementing this for downstream types, as Lofty will assume that the
 /// trait implementations are correct. If this assumption were to be broken, files **may** become corrupted.

--- a/src/util/io.rs
+++ b/src/util/io.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io::{Cursor, Read, Seek, Write};
 
 // TODO: https://github.com/rust-lang/rust/issues/59359
-pub(crate) trait SeekStreamLen: std::io::Seek {
+pub(crate) trait SeekStreamLen: Seek {
 	fn stream_len_hack(&mut self) -> crate::error::Result<u64> {
 		use std::io::SeekFrom;
 
@@ -19,7 +19,7 @@ pub(crate) trait SeekStreamLen: std::io::Seek {
 	}
 }
 
-impl<T> SeekStreamLen for T where T: std::io::Seek {}
+impl<T> SeekStreamLen for T where T: Seek {}
 
 /// Provides a method to truncate an object to the specified length
 ///
@@ -37,13 +37,13 @@ pub trait Truncate {
 	/// # Errors
 	///
 	/// Errors depend on the object being truncated, which may not always be fallible.
-	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error>;
+	fn truncate(&mut self, new_len: u64) -> Result<(), Self::Error>;
 }
 
 impl Truncate for File {
 	type Error = std::io::Error;
 
-	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+	fn truncate(&mut self, new_len: u64) -> Result<(), Self::Error> {
 		self.set_len(new_len)
 	}
 }
@@ -51,7 +51,7 @@ impl Truncate for File {
 impl Truncate for Vec<u8> {
 	type Error = std::convert::Infallible;
 
-	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+	fn truncate(&mut self, new_len: u64) -> Result<(), Self::Error> {
 		self.truncate(new_len as usize);
 		Ok(())
 	}
@@ -60,7 +60,7 @@ impl Truncate for Vec<u8> {
 impl Truncate for VecDeque<u8> {
 	type Error = std::convert::Infallible;
 
-	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+	fn truncate(&mut self, new_len: u64) -> Result<(), Self::Error> {
 		self.truncate(new_len as usize);
 		Ok(())
 	}
@@ -72,7 +72,7 @@ where
 {
 	type Error = <T as Truncate>::Error;
 
-	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+	fn truncate(&mut self, new_len: u64) -> Result<(), Self::Error> {
 		self.get_mut().truncate(new_len)
 	}
 }
@@ -83,7 +83,7 @@ where
 {
 	type Error = <T as Truncate>::Error;
 
-	fn truncate(&mut self, new_len: u64) -> std::result::Result<(), Self::Error> {
+	fn truncate(&mut self, new_len: u64) -> Result<(), Self::Error> {
 		self.as_mut().truncate(new_len)
 	}
 }
@@ -104,13 +104,13 @@ pub trait Length {
 	/// # Errors
 	///
 	/// Errors depend on the object being read, which may not always be fallible.
-	fn len(&self) -> std::result::Result<u64, Self::Error>;
+	fn len(&self) -> Result<u64, Self::Error>;
 }
 
 impl Length for File {
 	type Error = std::io::Error;
 
-	fn len(&self) -> std::result::Result<u64, Self::Error> {
+	fn len(&self) -> Result<u64, Self::Error> {
 		self.metadata().map(|m| m.len())
 	}
 }
@@ -118,7 +118,7 @@ impl Length for File {
 impl Length for Vec<u8> {
 	type Error = std::convert::Infallible;
 
-	fn len(&self) -> std::result::Result<u64, Self::Error> {
+	fn len(&self) -> Result<u64, Self::Error> {
 		Ok(self.len() as u64)
 	}
 }
@@ -126,7 +126,7 @@ impl Length for Vec<u8> {
 impl Length for VecDeque<u8> {
 	type Error = std::convert::Infallible;
 
-	fn len(&self) -> std::result::Result<u64, Self::Error> {
+	fn len(&self) -> Result<u64, Self::Error> {
 		Ok(self.len() as u64)
 	}
 }
@@ -137,7 +137,7 @@ where
 {
 	type Error = <T as Length>::Error;
 
-	fn len(&self) -> std::result::Result<u64, Self::Error> {
+	fn len(&self) -> Result<u64, Self::Error> {
 		Length::len(self.get_ref())
 	}
 }
@@ -148,7 +148,7 @@ where
 {
 	type Error = <T as Length>::Error;
 
-	fn len(&self) -> std::result::Result<u64, Self::Error> {
+	fn len(&self) -> Result<u64, Self::Error> {
 		Length::len(self.as_ref())
 	}
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,4 @@
 pub(crate) mod alloc;
-pub(crate) mod io;
+pub mod io;
 pub(crate) mod math;
 pub(crate) mod text;


### PR DESCRIPTION
This adds two new traits, `Truncate` and `Length`, which are two operations we needed
that required the use of `File`.

With these two traits, combined with `std::io::Read`, `std::io::Write` and `std::io::Seek`, other types can now be treated as files.

It is now possible to write to a `Cursor<Vec<u8>>`.

TODO: changelog entry