### PR TITLE
Remove `None` variants on multiple enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - **ItemKey**: `ItemKey::InvolvedPeople`
+- **MimeType**: `MimeType::None`, `Picture` now stores an `Option<MimeType>`.
+- **ID3v2**: `TextSizeRestrictions::None` and `ImageSizeRestrictions::None`
+	- `TagRestrictions` now stores an `Option<TextSizeRestrictions>` and `Option<ImageSizeRestrictions>`.
+- **MPEG**: `Emphasis::None`, `MpegProperties` now stores an `Option<Emphasis>`.
 
 ## [0.17.1] - 2023-11-26
 

--- a/benches/create_tag.rs
+++ b/benches/create_tag.rs
@@ -47,7 +47,7 @@ fn bench_write(c: &mut Criterion) {
 
 				let picture = Picture::new_unchecked(
 					PictureType::CoverFront,
-					MimeType::Jpeg,
+					Some(MimeType::Jpeg),
 					None,
 					include_bytes!("../benches_assets/cover.jpg").to_vec(),
 				);
@@ -73,7 +73,7 @@ fn bench_write(c: &mut Criterion) {
 
 				let picture = Picture::new_unchecked(
 					PictureType::CoverFront,
-					MimeType::Jpeg,
+					Some(MimeType::Jpeg),
 					None,
 					include_bytes!("../benches_assets/cover.jpg").to_vec(),
 				);
@@ -97,7 +97,7 @@ fn bench_write(c: &mut Criterion) {
 
 				let picture = Picture::new_unchecked(
 					PictureType::CoverFront,
-					MimeType::Jpeg,
+					Some(MimeType::Jpeg),
 					None,
 					include_bytes!("../benches_assets/cover.jpg").to_vec(),
 				);
@@ -116,7 +116,7 @@ fn bench_write(c: &mut Criterion) {
 
 				let picture = Picture::new_unchecked(
 					PictureType::CoverFront,
-					MimeType::Jpeg,
+					Some(MimeType::Jpeg),
 					None,
 					include_bytes!("../benches_assets/cover.jpg").to_vec(),
 				);

--- a/src/id3/v2/restrictions.rs
+++ b/src/id3/v2/restrictions.rs
@@ -14,12 +14,9 @@ pub enum TagSizeRestrictions {
 }
 
 /// Restrictions on text field sizes
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 pub enum TextSizeRestrictions {
-	/// No size restrictions
-	#[default]
-	None,
 	/// No longer than 1024 characters
 	C_1024,
 	/// No longer than 128 characters
@@ -29,12 +26,9 @@ pub enum TextSizeRestrictions {
 }
 
 /// Restrictions on all image sizes
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 pub enum ImageSizeRestrictions {
-	/// No size restrictions
-	#[default]
-	None,
 	/// All images are 256x256 or smaller
 	P_256,
 	/// All images are 64x64 or smaller
@@ -54,14 +48,14 @@ pub struct TagRestrictions {
 	/// `true` - Strings are only encoded with [`TextEncoding::Latin1`](crate::TextEncoding::Latin1) or [`TextEncoding::UTF8`](crate::TextEncoding::UTF8)
 	pub text_encoding: bool,
 	/// Restrictions on all text field sizes. See [`TextSizeRestrictions`]
-	pub text_fields_size: TextSizeRestrictions,
+	pub text_fields_size: Option<TextSizeRestrictions>,
 	/// Image encoding restrictions
 	///
 	/// `false` - No restrictions
 	/// `true` - Images can only be `PNG` or `JPEG`
 	pub image_encoding: bool,
 	/// Restrictions on all image sizes. See [`ImageSizeRestrictions`]
-	pub image_size: ImageSizeRestrictions,
+	pub image_size: Option<ImageSizeRestrictions>,
 }
 
 impl TagRestrictions {
@@ -88,9 +82,9 @@ impl TagRestrictions {
 
 		// 000xx000
 		match restriction_flags & 0x18 {
-			8 => restrictions.text_fields_size = TextSizeRestrictions::C_1024,
-			16 => restrictions.text_fields_size = TextSizeRestrictions::C_128,
-			24 => restrictions.text_fields_size = TextSizeRestrictions::C_30,
+			8 => restrictions.text_fields_size = Some(TextSizeRestrictions::C_1024),
+			16 => restrictions.text_fields_size = Some(TextSizeRestrictions::C_128),
+			24 => restrictions.text_fields_size = Some(TextSizeRestrictions::C_30),
 			_ => {}, // 0, default
 		}
 
@@ -101,9 +95,9 @@ impl TagRestrictions {
 
 		// 000000xx
 		match restriction_flags & 0x03 {
-			1 => restrictions.image_size = ImageSizeRestrictions::P_256,
-			2 => restrictions.image_size = ImageSizeRestrictions::P_64,
-			3 => restrictions.image_size = ImageSizeRestrictions::P_64_64,
+			1 => restrictions.image_size = Some(ImageSizeRestrictions::P_256),
+			2 => restrictions.image_size = Some(ImageSizeRestrictions::P_64),
+			3 => restrictions.image_size = Some(ImageSizeRestrictions::P_64_64),
 			_ => {}, // 0, default
 		}
 
@@ -127,10 +121,10 @@ impl TagRestrictions {
 		}
 
 		match self.text_fields_size {
-			TextSizeRestrictions::None => {},
-			TextSizeRestrictions::C_1024 => byte |= 0x08,
-			TextSizeRestrictions::C_128 => byte |= 0x10,
-			TextSizeRestrictions::C_30 => byte |= 0x18,
+			Some(TextSizeRestrictions::C_1024) => byte |= 0x08,
+			Some(TextSizeRestrictions::C_128) => byte |= 0x10,
+			Some(TextSizeRestrictions::C_30) => byte |= 0x18,
+			_ => {},
 		}
 
 		if self.image_encoding {
@@ -138,10 +132,10 @@ impl TagRestrictions {
 		}
 
 		match self.image_size {
-			ImageSizeRestrictions::None => {},
-			ImageSizeRestrictions::P_256 => byte |= 0x01,
-			ImageSizeRestrictions::P_64 => byte |= 0x02,
-			ImageSizeRestrictions::P_64_64 => byte |= 0x03,
+			Some(ImageSizeRestrictions::P_256) => byte |= 0x01,
+			Some(ImageSizeRestrictions::P_64) => byte |= 0x02,
+			Some(ImageSizeRestrictions::P_64_64) => byte |= 0x03,
+			_ => {},
 		}
 
 		byte

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -1784,7 +1784,7 @@ mod tests {
 				encoding: TextEncoding::Latin1,
 				picture: Picture {
 					pic_type: PictureType::CoverFront,
-					mime_type: MimeType::Png,
+					mime_type: Some(MimeType::Png),
 					description: None,
 					data: read_path("tests/tags/assets/id3v2/test_full_cover.png").into(),
 				},
@@ -1841,7 +1841,7 @@ mod tests {
 
 		let picture = Picture::new_unchecked(
 			PictureType::CoverFront,
-			MimeType::Jpeg,
+			Some(MimeType::Jpeg),
 			Some(String::from("cover")),
 			picture_data,
 		);

--- a/src/mp4/ilst/mod.rs
+++ b/src/mp4/ilst/mod.rs
@@ -257,7 +257,7 @@ impl Ilst {
 	/// // Insert pictures
 	/// ilst.insert_picture(Picture::new_unchecked(
 	/// 	PictureType::Other,
-	/// 	MimeType::Png,
+	/// 	Some(MimeType::Png),
 	/// 	None,
 	/// 	png_data,
 	/// ));
@@ -265,7 +265,7 @@ impl Ilst {
 	/// # let jpeg_data = b"bar".to_vec();
 	/// ilst.insert_picture(Picture::new_unchecked(
 	/// 	PictureType::Other,
-	/// 	MimeType::Jpeg,
+	/// 	Some(MimeType::Jpeg),
 	/// 	None,
 	/// 	jpeg_data,
 	/// ));
@@ -302,7 +302,7 @@ impl Ilst {
 	/// // Insert a single picture
 	/// ilst.insert_picture(Picture::new_unchecked(
 	/// 	PictureType::Other,
-	/// 	MimeType::Png,
+	/// 	Some(MimeType::Png),
 	/// 	None,
 	/// 	png_data,
 	/// ));
@@ -312,7 +312,7 @@ impl Ilst {
 	/// // Insert another picture
 	/// ilst.insert_picture(Picture::new_unchecked(
 	/// 	PictureType::Other,
-	/// 	MimeType::Jpeg,
+	/// 	Some(MimeType::Jpeg),
 	/// 	None,
 	/// 	jpeg_data,
 	/// ));

--- a/src/mp4/ilst/read.rs
+++ b/src/mp4/ilst/read.rs
@@ -294,12 +294,12 @@ where
 		for (flags, value) in atom_data {
 			let mime_type = match flags {
 				// Type 0 is implicit
-				RESERVED => MimeType::None,
+				RESERVED => None,
 				// GIF is deprecated
-				12 => MimeType::Gif,
-				JPEG => MimeType::Jpeg,
-				PNG => MimeType::Png,
-				BMP => MimeType::Bmp,
+				12 => Some(MimeType::Gif),
+				JPEG => Some(MimeType::Jpeg),
+				PNG => Some(MimeType::Png),
+				BMP => Some(MimeType::Bmp),
 				_ => err!(BadAtom("\"covr\" atom has an unknown type")),
 			};
 

--- a/src/mp4/ilst/write.rs
+++ b/src/mp4/ilst/write.rs
@@ -446,12 +446,12 @@ fn write_int(
 fn write_picture(picture: &Picture, writer: &mut Cursor<Vec<u8>>) -> Result<()> {
 	match picture.mime_type {
 		// GIF is deprecated
-		MimeType::Gif => write_data(12, &picture.data, writer),
-		MimeType::Jpeg => write_data(13, &picture.data, writer),
-		MimeType::Png => write_data(14, &picture.data, writer),
-		MimeType::Bmp => write_data(27, &picture.data, writer),
+		Some(MimeType::Gif) => write_data(12, &picture.data, writer),
+		Some(MimeType::Jpeg) => write_data(13, &picture.data, writer),
+		Some(MimeType::Png) => write_data(14, &picture.data, writer),
+		Some(MimeType::Bmp) => write_data(27, &picture.data, writer),
 		// We'll assume implicit (0) was the intended type
-		MimeType::None => write_data(0, &picture.data, writer),
+		None => write_data(0, &picture.data, writer),
 		_ => Err(FileEncodingError::new(
 			FileType::Mp4,
 			"Attempted to write an unsupported picture format",

--- a/src/mpeg/properties.rs
+++ b/src/mpeg/properties.rs
@@ -24,7 +24,7 @@ pub struct MpegProperties {
 	pub(crate) mode_extension: Option<u8>,
 	pub(crate) copyright: bool,
 	pub(crate) original: bool,
-	pub(crate) emphasis: Emphasis,
+	pub(crate) emphasis: Option<Emphasis>,
 }
 
 impl From<MpegProperties> for FileProperties {
@@ -117,7 +117,7 @@ impl MpegProperties {
 	}
 
 	/// See [`Emphasis`]
-	pub fn emphasis(&self) -> Emphasis {
+	pub fn emphasis(&self) -> Option<Emphasis> {
 		self.emphasis
 	}
 }

--- a/src/ogg/picture_storage.rs
+++ b/src/ogg/picture_storage.rs
@@ -74,11 +74,11 @@ pub trait OggPictureStorage: private::Sealed {
 	/// # use lofty::{Picture, PictureInformation, PictureType, MimeType};
 	///
 	/// # fn main() -> lofty::Result<()> {
-	/// # let front_cover = Picture::new_unchecked(PictureType::CoverFront, MimeType::Png, None, Vec::new());
+	/// # let front_cover = Picture::new_unchecked(PictureType::CoverFront, Some(MimeType::Png), None, Vec::new());
 	/// # let front_cover_info = PictureInformation::default();
-	/// # let back_cover = Picture::new_unchecked(PictureType::CoverBack, MimeType::Png, None, Vec::new());
+	/// # let back_cover = Picture::new_unchecked(PictureType::CoverBack, Some(MimeType::Png), None, Vec::new());
 	/// # let back_cover_info = PictureInformation::default();
-	/// # let another_picture = Picture::new_unchecked(PictureType::Band, MimeType::Png, None, Vec::new());
+	/// # let another_picture = Picture::new_unchecked(PictureType::Band, Some(MimeType::Png), None, Vec::new());
 	/// let mut tag = VorbisComments::default();
 	///
 	/// // Add a front cover
@@ -122,7 +122,7 @@ pub trait OggPictureStorage: private::Sealed {
 	/// # use lofty::{Picture, PictureType, MimeType, PictureInformation};
 	///
 	/// # fn main() -> lofty::Result<()> {
-	/// # let front_cover = Picture::new_unchecked(PictureType::CoverFront, MimeType::Png, None, Vec::new());
+	/// # let front_cover = Picture::new_unchecked(PictureType::CoverFront, Some(MimeType::Png), None, Vec::new());
 	/// # let front_cover_info = PictureInformation::default();
 	/// let mut tag = VorbisComments::default();
 	///
@@ -149,9 +149,9 @@ pub trait OggPictureStorage: private::Sealed {
 	/// # use lofty::{Picture, PictureType, MimeType, PictureInformation};
 	///
 	/// # fn main() -> lofty::Result<()> {
-	/// # let front_cover = Picture::new_unchecked(PictureType::CoverFront, MimeType::Png, None, Vec::new());
+	/// # let front_cover = Picture::new_unchecked(PictureType::CoverFront, Some(MimeType::Png), None, Vec::new());
 	/// # let front_cover_info = PictureInformation::default();
-	/// # let back_cover = Picture::new_unchecked(PictureType::CoverBack, MimeType::Png, None, Vec::new());
+	/// # let back_cover = Picture::new_unchecked(PictureType::CoverBack, Some(MimeType::Png), None, Vec::new());
 	/// # let back_cover_info = PictureInformation::default();
 	/// let mut tag = VorbisComments::default();
 	///

--- a/src/ogg/read.rs
+++ b/src/ogg/read.rs
@@ -127,7 +127,7 @@ where
 
 						let picture = Picture {
 							pic_type: PictureType::Other,
-							mime_type,
+							mime_type: Some(mime_type),
 							description: None,
 							data: Cow::from(picture_data),
 						};

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -70,9 +70,6 @@ impl MimeType {
 	#[allow(clippy::should_implement_trait)]
 	/// Get a `MimeType` from a string
 	///
-	/// Empty strings will map to `MimeType::None`, while any unrecognized MIME types will
-	/// map to `MimeType::Unknown`.
-	///
 	/// # Examples
 	///
 	/// ```rust
@@ -93,8 +90,6 @@ impl MimeType {
 	}
 
 	/// Get a &str from a `MimeType`
-	///
-	/// NOTE: `MimeType::None` will return an empty string.
 	///
 	/// # Examples
 	///

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -705,7 +705,7 @@ impl Picture {
 				if mime_type_str.is_empty() {
 					mime_type = None;
 				} else {
-					mime_type = Some(MimeType::from_str(&mime_type_str));
+					mime_type = Some(MimeType::from_str(mime_type_str));
 				}
 
 				return Ok((

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -126,7 +126,7 @@ mod tests {
 	use crate::iff::aiff::{AiffFile, AiffProperties};
 	use crate::iff::wav::{WavFile, WavFormat, WavProperties};
 	use crate::mp4::{AudioObjectType, Mp4Codec, Mp4File, Mp4Properties};
-	use crate::mpeg::{ChannelMode, Emphasis, Layer, MpegFile, MpegProperties, MpegVersion};
+	use crate::mpeg::{ChannelMode, Layer, MpegFile, MpegProperties, MpegVersion};
 	use crate::musepack::sv4to6::MpcSv4to6Properties;
 	use crate::musepack::sv7::{Link, MpcSv7Properties, Profile};
 	use crate::musepack::sv8::{EncoderInfo, MpcSv8Properties, ReplayGain, StreamHeader};
@@ -199,7 +199,7 @@ mod tests {
 		audio_bitrate: 384,
 		sample_rate: 32000,
 		channels: 2,
-		emphasis: Emphasis::None,
+		emphasis: None,
 	};
 
 	const MP2_PROPERTIES: MpegProperties = MpegProperties {
@@ -214,7 +214,7 @@ mod tests {
 		audio_bitrate: 384,
 		sample_rate: 48000,
 		channels: 2,
-		emphasis: Emphasis::None,
+		emphasis: None,
 	};
 
 	const MP3_PROPERTIES: MpegProperties = MpegProperties {
@@ -229,7 +229,7 @@ mod tests {
 		audio_bitrate: 62,
 		sample_rate: 48000,
 		channels: 2,
-		emphasis: Emphasis::None,
+		emphasis: None,
 	};
 
 	const MP4_AAC_PROPERTIES: Mp4Properties = Mp4Properties {

--- a/src/tag/mod.rs
+++ b/src/tag/mod.rs
@@ -464,9 +464,9 @@ impl Tag {
 	/// use lofty::{Picture, Tag, TagType};
 	/// # use lofty::{PictureType, MimeType};
 	///
-	/// # let front_cover = Picture::new_unchecked(PictureType::CoverFront, MimeType::Png, None, Vec::new());
-	/// # let back_cover = Picture::new_unchecked(PictureType::CoverBack, MimeType::Png, None, Vec::new());
-	/// # let another_picture = Picture::new_unchecked(PictureType::Band, MimeType::Png, None, Vec::new());
+	/// # let front_cover = Picture::new_unchecked(PictureType::CoverFront, Some(MimeType::Png), None, Vec::new());
+	/// # let back_cover = Picture::new_unchecked(PictureType::CoverBack, Some(MimeType::Png), None, Vec::new());
+	/// # let another_picture = Picture::new_unchecked(PictureType::Band, Some(MimeType::Png), None, Vec::new());
 	/// let mut tag = Tag::new(TagType::Id3v2);
 	///
 	/// // Add a front cover
@@ -506,7 +506,7 @@ impl Tag {
 	/// use lofty::{Picture, Tag, TagType};
 	/// # use lofty::{PictureType, MimeType};
 	///
-	/// # let picture = Picture::new_unchecked(PictureType::CoverFront, MimeType::Png, None, Vec::new());
+	/// # let picture = Picture::new_unchecked(PictureType::CoverFront, Some(MimeType::Png), None, Vec::new());
 	/// let mut tag = Tag::new(TagType::Id3v2);
 	/// tag.push_picture(picture);
 	///

--- a/tests/picture/from_reader.rs
+++ b/tests/picture/from_reader.rs
@@ -16,7 +16,7 @@ fn get_buf(path: &str) -> Vec<u8> {
 fn picture_from_reader_png() {
 	let pic = Picture::from_reader(&mut &*get_buf("tests/picture/assets/png_640x628.png")).unwrap();
 
-	assert_eq!(pic.mime_type(), &MimeType::Png);
+	assert_eq!(pic.mime_type(), Some(&MimeType::Png));
 }
 
 #[test]
@@ -24,21 +24,21 @@ fn picture_from_reader_jpeg() {
 	let pic =
 		Picture::from_reader(&mut &*get_buf("tests/picture/assets/jpeg_640x628.jpg")).unwrap();
 
-	assert_eq!(pic.mime_type(), &MimeType::Jpeg);
+	assert_eq!(pic.mime_type(), Some(&MimeType::Jpeg));
 }
 
 #[test]
 fn picture_from_reader_bmp() {
 	let pic = Picture::from_reader(&mut &*get_buf("tests/picture/assets/bmp_640x628.bmp")).unwrap();
 
-	assert_eq!(pic.mime_type(), &MimeType::Bmp);
+	assert_eq!(pic.mime_type(), Some(&MimeType::Bmp));
 }
 
 #[test]
 fn picture_from_reader_gif() {
 	let pic = Picture::from_reader(&mut &*get_buf("tests/picture/assets/gif_640x628.gif")).unwrap();
 
-	assert_eq!(pic.mime_type(), &MimeType::Gif);
+	assert_eq!(pic.mime_type(), Some(&MimeType::Gif));
 }
 
 #[test]
@@ -46,5 +46,5 @@ fn picture_from_reader_tiff() {
 	let pic =
 		Picture::from_reader(&mut &*get_buf("tests/picture/assets/tiff_640x628.tiff")).unwrap();
 
-	assert_eq!(pic.mime_type(), &MimeType::Tiff);
+	assert_eq!(pic.mime_type(), Some(&MimeType::Tiff));
 }


### PR DESCRIPTION
This removes:

* `MimeType::None`
* `TextSizeRestrictions::None`
* `ImageSizeRestrictions::None`
* `Emphasis::None`

Instead of `X::None`, it's clearer to just store an `Option<X>`.