### PR TITLE
MP4: Check if audio streams are DRM protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **MP4**: Check if audio streams are DRM protected, exposed as `Mp4Properties::is_drm_protected()` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/297))
+
 ### Changed
 - **ID3v1**: Renamed `GENRES[14]` to `"R&B"` (Previously `"Rhythm & Blues"`) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/296))
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -241,6 +241,7 @@ mod tests {
 		sample_rate: 48000,
 		bit_depth: None,
 		channels: 2,
+		drm_protected: false,
 	};
 
 	const MP4_ALAC_PROPERTIES: Mp4Properties = Mp4Properties {
@@ -252,6 +253,7 @@ mod tests {
 		sample_rate: 48000,
 		bit_depth: Some(16),
 		channels: 2,
+		drm_protected: false,
 	};
 
 	const MP4_ALS_PROPERTIES: Mp4Properties = Mp4Properties {
@@ -263,6 +265,7 @@ mod tests {
 		sample_rate: 48000,
 		bit_depth: None,
 		channels: 2,
+		drm_protected: false,
 	};
 
 	const MP4_FLAC_PROPERTIES: Mp4Properties = Mp4Properties {
@@ -274,6 +277,7 @@ mod tests {
 		sample_rate: 48000,
 		bit_depth: Some(16),
 		channels: 2,
+		drm_protected: false,
 	};
 
 	const MPC_SV5_PROPERTIES: MpcSv4to6Properties = MpcSv4to6Properties {


### PR DESCRIPTION
This also has the side effect of making us now read every sample entry, which means we can now skip unknown entries to potentially find a suitable one.

Credit to `Lukáš Lalinský` for finding the location of the undocumented `drms` atom.
Source: <https://mail.kde.org/pipermail/taglib-devel/2011-March/001886.html>