### PR TITLE
MP4 property fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **ID3v1**: Renamed `GENRES[14]` to `"R&B"` (Previously `"Rhythm & Blues"`) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/296))
+- **MP4**: Duration milliseconds are now rounded to the nearest whole number ([PR](https://github.com/Serial-ATA/lofty-rs/pull/298))
+
+### Fixed
+- **MP4**: The `dfLa` atom for FLAC streams will now be found, providing better properties ([PR](https://github.com/Serial-ATA/lofty-rs/pull/298))
 
 ## [0.17.1] - 2023-11-26
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,7 @@ pub mod flac;
 pub mod id3;
 pub mod iff;
 pub(crate) mod macros;
+mod math;
 pub mod mp4;
 pub mod mpeg;
 pub mod musepack;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,21 @@
+pub(crate) trait RoundedDivision<Rhs = Self> {
+	type Output;
+
+	fn div_round(self, rhs: Rhs) -> Self::Output;
+}
+
+macro_rules! unsigned_rounded_division {
+	($($t:ty),*) => {
+		$(
+			impl RoundedDivision for $t {
+				type Output = $t;
+
+				fn div_round(self, rhs: Self) -> Self::Output {
+					(self + (rhs >> 1)) / rhs
+				}
+			}
+		)*
+	};
+}
+
+unsigned_rounded_division!(u8, u16, u32, u64, u128, usize);

--- a/src/mp4/properties.rs
+++ b/src/mp4/properties.rs
@@ -2,6 +2,7 @@ use super::atom_info::{AtomIdent, AtomInfo};
 use super::read::{nested_atom, skip_unneeded, AtomReader};
 use crate::error::{LoftyError, Result};
 use crate::macros::{decode_err, err, try_vec};
+use crate::math::RoundedDivision;
 use crate::probe::ParsingMode;
 use crate::properties::FileProperties;
 
@@ -302,7 +303,8 @@ where
 		(timescale, u64::from(duration))
 	};
 
-	let duration = Duration::from_millis(duration * 1000 / u64::from(timescale));
+	let duration_millis = (duration * 1000).div_round(u64::from(timescale));
+	let duration = Duration::from_millis(duration_millis);
 
 	// We create the properties here, since it is possible the other information isn't available
 	let mut properties = Mp4Properties {

--- a/src/mp4/properties.rs
+++ b/src/mp4/properties.rs
@@ -648,7 +648,7 @@ where
 		return Ok(());
 	};
 
-	if dfla.ident != AtomIdent::Fourcc(*b"dfla") {
+	if dfla.ident != AtomIdent::Fourcc(*b"dfLa") {
 		return Ok(());
 	}
 
@@ -670,6 +670,8 @@ where
 	properties.sample_rate = flac_properties.sample_rate;
 	properties.bit_depth = Some(flac_properties.bit_depth);
 	properties.channels = flac_properties.channels;
+
+	// Bitrate values are calculated later...
 
 	Ok(())
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -272,7 +272,7 @@ mod tests {
 		codec: Mp4Codec::FLAC,
 		extended_audio_object_type: None,
 		duration: Duration::from_millis(1428),
-		overall_bitrate: 280, // TODO: FFmpeg reports 279
+		overall_bitrate: 280,
 		audio_bitrate: 275,
 		sample_rate: 48000,
 		bit_depth: Some(16),


### PR DESCRIPTION
* We used to not read the `dfLa` atom containing FLAC stream information, due to the wrong FOURCC being checked
* Duration millisecond counts would sometimes be off by one. We now round, which should be done in other places.