### PR TITLE
Replace base64 with data-encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,18 @@ include     = ["src", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT", "SUPPORTED_
 
 [dependencies]
 # Vorbis comments pictures
-base64     = "0.21.5"
-byteorder  = "1.5.0"
+data-encoding = "2.5.0"
+byteorder     = "1.5.0"
 # ID3 compressed frames
-flate2     = { version = "1.0.28", optional = true }
+flate2        = { version = "1.0.28", optional = true }
 # Proc macros
-lofty_attr = "0.9.0"
+lofty_attr    = "0.9.0"
 # Debug logging
-log        = "0.4.20"
+log           = "0.4.20"
 # OGG Vorbis/Opus
-ogg_pager  = "0.5.0"
+ogg_pager     = "0.5.0"
 # Key maps
-paste      = "1.0.14"
+paste         = "1.0.14"
 
 [features]
 default                   = ["id3v2_compression_support"]

--- a/src/ogg/read.rs
+++ b/src/ogg/read.rs
@@ -9,8 +9,8 @@ use crate::util::text::{utf16_decode, utf8_decode, utf8_decode_str};
 use std::borrow::Cow;
 use std::io::{Read, Seek, SeekFrom};
 
-use base64::Engine;
 use byteorder::{LittleEndian, ReadBytesExt};
+use data_encoding::BASE64;
 use ogg_pager::{Packets, PageHeader};
 
 pub type OGGTags = (Option<VorbisComments>, PageHeader, Packets);
@@ -118,7 +118,7 @@ where
 				// to a `METADATA_BLOCK_PICTURE` for it to be useful.
 				//
 				// <https://wiki.xiph.org/VorbisComment#Conversion_to_METADATA_BLOCK_PICTURE>
-				let picture_data = base64::engine::general_purpose::STANDARD.decode(value);
+				let picture_data = BASE64.decode(value);
 
 				match picture_data {
 					Ok(picture_data) => {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -7,8 +7,8 @@ use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
-use base64::Engine as _;
 use byteorder::{BigEndian, ReadBytesExt};
+use data_encoding::BASE64;
 
 /// Common picture item keys for APE
 pub const APE_PICTURE_TYPES: [&str; 21] = [
@@ -608,9 +608,7 @@ impl Picture {
 		data.extend(pic_data.iter());
 
 		if encode {
-			base64::engine::general_purpose::STANDARD
-				.encode(data)
-				.into_bytes()
+			BASE64.encode(&data).into_bytes()
 		} else {
 			data
 		}
@@ -631,7 +629,7 @@ impl Picture {
 		parse_mode: ParsingMode,
 	) -> Result<(Self, PictureInformation)> {
 		if encoded {
-			let data = base64::engine::general_purpose::STANDARD
+			let data = BASE64
 				.decode(bytes)
 				.map_err(|_| LoftyError::new(ErrorKind::NotAPicture))?;
 			Self::from_flac_bytes_inner(&data, parse_mode)


### PR DESCRIPTION
More versatile, easy to use, smaller, well-maintained.