### PR TITLE
ID3v2: Support UTF-16 TIPL frames with single BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **MP4**: The `dfLa` atom for FLAC streams will now be found, providing better properties ([PR](https://github.com/Serial-ATA/lofty-rs/pull/298))
+- **ID3v2**: Support UTF-16 encoded TIPL frames with a single BOM ([issue](https://github.com/Serial-ATA/lofty-rs/issues/306)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/307))
 
 ### Removed
 - **ItemKey**: `ItemKey::InvolvedPeople`

--- a/src/id3/v2/items/audio_text_frame.rs
+++ b/src/id3/v2/items/audio_text_frame.rs
@@ -1,5 +1,5 @@
 use crate::error::{ErrorKind, Id3v2Error, Id3v2ErrorKind, LoftyError, Result};
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::hash::{Hash, Hasher};
 
@@ -96,11 +96,21 @@ impl AudioTextFrame {
 		let encoding = TextEncoding::from_u8(content.read_u8()?)
 			.ok_or_else(|| LoftyError::new(ErrorKind::TextDecode("Found invalid encoding")))?;
 
-		let mime_type = decode_text(content, TextEncoding::Latin1, true)?.content;
+		let mime_type = decode_text(
+			content,
+			TextDecodeOptions::new()
+				.encoding(TextEncoding::Latin1)
+				.terminated(true),
+		)?
+		.content;
 
 		let flags = AudioTextFrameFlags::from_u8(content.read_u8()?);
 
-		let equivalent_text = decode_text(content, encoding, true)?.content;
+		let equivalent_text = decode_text(
+			content,
+			TextDecodeOptions::new().encoding(encoding).terminated(true),
+		)?
+		.content;
 
 		Ok(Self {
 			encoding,

--- a/src/id3/v2/items/encapsulated_object.rs
+++ b/src/id3/v2/items/encapsulated_object.rs
@@ -1,5 +1,5 @@
 use crate::error::{ErrorKind, Id3v2Error, Id3v2ErrorKind, LoftyError, Result};
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::io::{Cursor, Read};
 
@@ -36,9 +36,17 @@ impl GeneralEncapsulatedObject {
 
 		let mut cursor = Cursor::new(&data[1..]);
 
-		let mime_type = decode_text(&mut cursor, TextEncoding::Latin1, true)?;
-		let file_name = decode_text(&mut cursor, encoding, true)?;
-		let descriptor = decode_text(&mut cursor, encoding, true)?;
+		let mime_type = decode_text(
+			&mut cursor,
+			TextDecodeOptions::new()
+				.encoding(TextEncoding::Latin1)
+				.terminated(true),
+		)?;
+
+		let text_decode_options = TextDecodeOptions::new().encoding(encoding).terminated(true);
+
+		let file_name = decode_text(&mut cursor, text_decode_options)?;
+		let descriptor = decode_text(&mut cursor, text_decode_options)?;
 
 		let mut data = Vec::new();
 		cursor.read_to_end(&mut data)?;

--- a/src/id3/v2/items/extended_text_frame.rs
+++ b/src/id3/v2/items/extended_text_frame.rs
@@ -1,7 +1,9 @@
 use crate::error::{Id3v2Error, Id3v2ErrorKind, LoftyError, Result};
 use crate::id3::v2::frame::content::verify_encoding;
 use crate::id3::v2::header::Id3v2Version;
-use crate::util::text::{decode_text, encode_text, utf16_decode_bytes, TextEncoding};
+use crate::util::text::{
+	decode_text, encode_text, utf16_decode_bytes, TextDecodeOptions, TextEncoding,
+};
 
 use std::hash::{Hash, Hasher};
 use std::io::Read;
@@ -57,11 +59,15 @@ impl ExtendedTextFrame {
 		};
 
 		let encoding = verify_encoding(encoding_byte, version)?;
-		let description = decode_text(reader, encoding, true)?;
+		let description = decode_text(
+			reader,
+			TextDecodeOptions::new().encoding(encoding).terminated(true),
+		)?;
 
 		let frame_content;
 		if encoding != TextEncoding::UTF16 {
-			frame_content = decode_text(reader, encoding, false)?.content;
+			frame_content =
+				decode_text(reader, TextDecodeOptions::new().encoding(encoding))?.content;
 
 			return Ok(Some(ExtendedTextFrame {
 				encoding,

--- a/src/id3/v2/items/extended_url_frame.rs
+++ b/src/id3/v2/items/extended_url_frame.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::id3::v2::frame::content::verify_encoding;
 use crate::id3::v2::header::Id3v2Version;
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::hash::{Hash, Hasher};
 use std::io::Read;
@@ -57,8 +57,16 @@ impl ExtendedUrlFrame {
 		};
 
 		let encoding = verify_encoding(encoding_byte, version)?;
-		let description = decode_text(reader, encoding, true)?.content;
-		let content = decode_text(reader, TextEncoding::Latin1, false)?.content;
+		let description = decode_text(
+			reader,
+			TextDecodeOptions::new().encoding(encoding).terminated(true),
+		)?
+		.content;
+		let content = decode_text(
+			reader,
+			TextDecodeOptions::new().encoding(TextEncoding::Latin1),
+		)?
+		.content;
 
 		Ok(Some(ExtendedUrlFrame {
 			encoding,

--- a/src/id3/v2/items/language_frame.rs
+++ b/src/id3/v2/items/language_frame.rs
@@ -1,7 +1,7 @@
 use crate::error::{Id3v2Error, Id3v2ErrorKind, Result};
 use crate::id3::v2::frame::content::verify_encoding;
 use crate::id3::v2::header::Id3v2Version;
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::hash::{Hash, Hasher};
 use std::io::Read;
@@ -32,8 +32,12 @@ impl LanguageFrame {
 		let mut language = [0; 3];
 		reader.read_exact(&mut language)?;
 
-		let description = decode_text(reader, encoding, true)?.content;
-		let content = decode_text(reader, encoding, false)?.content;
+		let description = decode_text(
+			reader,
+			TextDecodeOptions::new().encoding(encoding).terminated(true),
+		)?
+		.content;
+		let content = decode_text(reader, TextDecodeOptions::new().encoding(encoding))?.content;
 
 		Ok(Some(Self {
 			encoding,

--- a/src/id3/v2/items/popularimeter.rs
+++ b/src/id3/v2/items/popularimeter.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::hash::{Hash, Hasher};
 use std::io::Read;
@@ -36,7 +36,12 @@ impl Popularimeter {
 	where
 		R: Read,
 	{
-		let email = decode_text(reader, TextEncoding::Latin1, true)?;
+		let email = decode_text(
+			reader,
+			TextDecodeOptions::new()
+				.encoding(TextEncoding::Latin1)
+				.terminated(true),
+		)?;
 		let rating = reader.read_u8()?;
 
 		let mut counter_content = Vec::new();

--- a/src/id3/v2/items/private_frame.rs
+++ b/src/id3/v2/items/private_frame.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::io::Read;
 
@@ -28,7 +28,12 @@ impl PrivateFrame {
 	where
 		R: Read,
 	{
-		let Ok(owner) = decode_text(reader, TextEncoding::Latin1, true) else {
+		let Ok(owner) = decode_text(
+			reader,
+			TextDecodeOptions::new()
+				.encoding(TextEncoding::Latin1)
+				.terminated(true),
+		) else {
 			return Ok(None);
 		};
 

--- a/src/id3/v2/items/relative_volume_adjustment_frame.rs
+++ b/src/id3/v2/items/relative_volume_adjustment_frame.rs
@@ -1,7 +1,7 @@
 use crate::error::{Id3v2Error, Id3v2ErrorKind, Result};
 use crate::macros::try_vec;
 use crate::probe::ParsingMode;
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -110,7 +110,13 @@ impl RelativeVolumeAdjustmentFrame {
 	where
 		R: Read,
 	{
-		let identification = decode_text(reader, TextEncoding::Latin1, true)?.content;
+		let identification = decode_text(
+			reader,
+			TextDecodeOptions::new()
+				.encoding(TextEncoding::Latin1)
+				.terminated(true),
+		)?
+		.content;
 
 		let mut channels = HashMap::new();
 		while let Ok(channel_type_byte) = reader.read_u8() {

--- a/src/id3/v2/items/text_information_frame.rs
+++ b/src/id3/v2/items/text_information_frame.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::id3::v2::frame::content::verify_encoding;
 use crate::id3::v2::header::Id3v2Version;
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use byteorder::ReadBytesExt;
 
@@ -37,7 +37,7 @@ impl TextInformationFrame {
 		};
 
 		let encoding = verify_encoding(encoding_byte, version)?;
-		let value = decode_text(reader, encoding, false)?.content;
+		let value = decode_text(reader, TextDecodeOptions::new().encoding(encoding))?.content;
 
 		Ok(Some(TextInformationFrame { encoding, value }))
 	}

--- a/src/id3/v2/items/unique_file_identifier.rs
+++ b/src/id3/v2/items/unique_file_identifier.rs
@@ -1,7 +1,7 @@
 use crate::error::{Id3v2Error, Id3v2ErrorKind, Result};
 use crate::macros::parse_mode_choice;
 use crate::probe::ParsingMode;
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::hash::{Hash, Hasher};
 use std::io::Read;
@@ -25,7 +25,12 @@ impl UniqueFileIdentifierFrame {
 	where
 		R: Read,
 	{
-		let owner_decode_result = decode_text(reader, TextEncoding::Latin1, true)?;
+		let owner_decode_result = decode_text(
+			reader,
+			TextDecodeOptions::new()
+				.encoding(TextEncoding::Latin1)
+				.terminated(true),
+		)?;
 
 		let owner;
 		match owner_decode_result.text_or_none() {

--- a/src/id3/v2/items/url_link_frame.rs
+++ b/src/id3/v2/items/url_link_frame.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::util::text::{decode_text, encode_text, TextEncoding};
+use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::io::Read;
 
@@ -19,7 +19,12 @@ impl UrlLinkFrame {
 	where
 		R: Read,
 	{
-		let url = decode_text(reader, TextEncoding::Latin1, true)?;
+		let url = decode_text(
+			reader,
+			TextDecodeOptions::new()
+				.encoding(TextEncoding::Latin1)
+				.terminated(true),
+		)?;
 		if url.bytes_read == 0 {
 			return Ok(None);
 		}

--- a/src/id3/v2/tag.rs
+++ b/src/id3/v2/tag.rs
@@ -17,7 +17,7 @@ use crate::picture::{Picture, PictureType, TOMBSTONE_PICTURE};
 use crate::tag::item::{ItemKey, ItemValue, TagItem};
 use crate::tag::{try_parse_year, Tag, TagType};
 use crate::traits::{Accessor, MergeTag, SplitTag, TagExt};
-use crate::util::text::{decode_text, TextEncoding};
+use crate::util::text::{decode_text, TextDecodeOptions, TextEncoding};
 
 use std::borrow::Cow;
 use std::convert::TryInto;
@@ -1084,9 +1084,10 @@ impl SplitTag for Id3v2Tag {
 				) => {
 					if owner == MUSICBRAINZ_UFID_OWNER {
 						let mut identifier = Cursor::new(identifier);
-						let Ok(recording_id) =
-							decode_text(&mut identifier, TextEncoding::Latin1, false)
-						else {
+						let Ok(recording_id) = decode_text(
+							&mut identifier,
+							TextDecodeOptions::new().encoding(TextEncoding::Latin1),
+						) else {
 							return true; // Keep frame
 						};
 						tag.items.push(TagItem::new(

--- a/src/util/text.rs
+++ b/src/util/text.rs
@@ -60,6 +60,13 @@ const EMPTY_DECODED_TEXT: DecodeTextResult = DecodeTextResult {
 	bom: [0, 0],
 };
 
+/// Specify how to decode the provided text
+///
+/// By default, this will:
+///
+/// * Use [`TextEncoding::UTF8`] as the encoding
+/// * Not expect the text to be null terminated
+/// * Have no byte order mark
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct TextDecodeOptions {
 	pub encoding: TextEncoding,


### PR DESCRIPTION
This changes the signature of `decode_text` to take the new `TextDecodeOptions`. This allows us to specify a UTF-16 BOM ahead of time.

closes https://github.com/Serial-ATA/lofty-rs/issues/306