### PR TITLE
OGG: Use rounded division to calculate durations

### DIFF
--- a/src/ogg/opus/properties.rs
+++ b/src/ogg/opus/properties.rs
@@ -1,6 +1,7 @@
 use super::find_last_page;
 use crate::error::Result;
 use crate::macros::decode_err;
+use crate::math::RoundedDivision;
 use crate::properties::FileProperties;
 
 use std::io::{Read, Seek, SeekFrom};
@@ -118,7 +119,7 @@ where
 			.saturating_sub(u64::from(pre_skip));
 		if total_samples > 0 {
 			// Best case scenario
-			let length = total_samples as f64 * 1000.0 / 48000.0;
+			let length = (total_samples * 1000).div_round(48000);
 
 			// Get the stream length by subtracting the length of the header packets
 
@@ -128,9 +129,9 @@ where
 
 			let stream_len = file_length - header_size as u64;
 
-			properties.duration = Duration::from_millis(length as u64);
-			properties.overall_bitrate = ((file_length as f64) * 8.0 / length) as u32;
-			properties.audio_bitrate = ((stream_len as f64) * 8.0 / length) as u32;
+			properties.duration = Duration::from_millis(length);
+			properties.overall_bitrate = ((file_length * 8) / length) as u32;
+			properties.audio_bitrate = ((stream_len * 8) / length) as u32;
 		} else {
 			log::debug!("Opus: The file contains invalid PCM values, unable to calculate length");
 		}

--- a/src/ogg/speex/properties.rs
+++ b/src/ogg/speex/properties.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use crate::macros::decode_err;
+use crate::math::RoundedDivision;
 use crate::ogg::find_last_page;
 use crate::properties::FileProperties;
 
@@ -150,7 +151,7 @@ where
 
 			// Best case scenario
 			if total_samples > 0 {
-				length = total_samples * 1000 / u64::from(properties.sample_rate);
+				length = (total_samples * 1000).div_round(u64::from(properties.sample_rate));
 				properties.duration = Duration::from_millis(length);
 			} else {
 				log::debug!(

--- a/src/ogg/vorbis/properties.rs
+++ b/src/ogg/vorbis/properties.rs
@@ -1,5 +1,6 @@
 use super::find_last_page;
 use crate::error::Result;
+use crate::math::RoundedDivision;
 use crate::properties::FileProperties;
 
 use std::io::{Read, Seek, SeekFrom};
@@ -124,7 +125,7 @@ where
 
 			// Best case scenario
 			if total_samples > 0 {
-				length = total_samples * 1000 / u64::from(properties.sample_rate);
+				length = (total_samples * 1000).div_round(u64::from(properties.sample_rate));
 				properties.duration = Duration::from_millis(length);
 			} else {
 				log::debug!(

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -367,7 +367,7 @@ mod tests {
 	};
 
 	const VORBIS_PROPERTIES: VorbisProperties = VorbisProperties {
-		duration: Duration::from_millis(1450),
+		duration: Duration::from_millis(1451),
 		overall_bitrate: 96,
 		audio_bitrate: 112,
 		sample_rate: 48000,


### PR DESCRIPTION
This brings us to parity with FFmpeg durations.