### PR TITLE
MPEG: Find ID3v2 tags buried in junk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ID3v1**: Renamed `GENRES[14]` to `"R&B"` (Previously `"Rhythm & Blues"`) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/296))
 - **MP4**: Duration milliseconds are now rounded to the nearest whole number ([PR](https://github.com/Serial-ATA/lofty-rs/pull/298))
 - **ID3v2**: Stop erroring on empty frames when not using `ParsingMode::Strict` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/299))
+- **resolve**: Custom resolvers will now be checked before the default resolvers ([PR](https://github.com/Serial-ATA/lofty-rs/pull/319))
+- **MPEG**: Up to `max_junk_bytes` will now be searched for tags between the start of the file and the first MPEG frame ([PR](https://github.com/Serial-ATA/lofty-rs/pull/320))
+  - This allows us to read and write ID3v2 tags that are preceeded by junk
 
 ### Fixed
 - **MP4**:

--- a/src/ape/read.rs
+++ b/src/ape/read.rs
@@ -28,7 +28,6 @@ where
 	let mut ape_tag: Option<ApeTag> = None;
 
 	// ID3v2 tags are unsupported in APE files, but still possible
-	#[allow(unused_variables)]
 	if let ID3FindResults(Some(header), Some(content)) = find_id3v2(data, true)? {
 		log::warn!("Encountered an ID3v2 tag. This tag cannot be rewritten to the APE file!");
 

--- a/src/id3/v2/frame/header.rs
+++ b/src/id3/v2/frame/header.rs
@@ -70,6 +70,8 @@ where
 	let mut id_end = 4;
 	let mut invalid_v2_frame = false;
 	if header[3] == 0 && !synchsafe {
+		log::warn!("Found a v2 frame ID in a v3 tag, attempting to upgrade");
+
 		invalid_v2_frame = true;
 		id_end = 3;
 	}

--- a/src/id3/v2/frame/read.rs
+++ b/src/id3/v2/frame/read.rs
@@ -64,6 +64,8 @@ impl<'a> ParsedFrame<'a> {
 
 		// Get the encryption method symbol
 		if let Some(enc) = flags.encryption.as_mut() {
+			log::trace!("Reading encryption method symbol");
+
 			if size < 1 {
 				return Err(Id3v2Error::new(Id3v2ErrorKind::BadFrameLength).into());
 			}
@@ -74,6 +76,8 @@ impl<'a> ParsedFrame<'a> {
 
 		// Get the group identifier
 		if let Some(group) = flags.grouping_identity.as_mut() {
+			log::trace!("Reading group identifier");
+
 			if size < 1 {
 				return Err(Id3v2Error::new(Id3v2ErrorKind::BadFrameLength).into());
 			}
@@ -84,6 +88,8 @@ impl<'a> ParsedFrame<'a> {
 
 		// Get the real data length
 		if flags.data_length_indicator.is_some() || flags.compression {
+			log::trace!("Reading data length indicator");
+
 			if size < 4 {
 				return Err(Id3v2Error::new(Id3v2ErrorKind::BadFrameLength).into());
 			}

--- a/src/id3/v2/write/mod.rs
+++ b/src/id3/v2/write/mod.rs
@@ -48,7 +48,7 @@ pub(crate) fn write_id3v2<'a, I: Iterator<Item = FrameRef<'a>> + Clone + 'a>(
 
 	// Unable to determine a format
 	if file_type.is_none() {
-		err!(UnsupportedTag);
+		err!(UnknownFormat);
 	}
 
 	let file_type = file_type.unwrap();

--- a/src/mpeg/read.rs
+++ b/src/mpeg/read.rs
@@ -4,7 +4,7 @@ use crate::ape::header::read_ape_header;
 use crate::error::Result;
 use crate::id3::v2::header::Id3v2Header;
 use crate::id3::v2::read::parse_id3v2;
-use crate::id3::{find_id3v1, find_id3v2, find_lyrics3v2, ID3FindResults};
+use crate::id3::{find_id3v1, find_lyrics3v2, ID3FindResults};
 use crate::macros::{decode_err, err};
 use crate::mpeg::header::HEADER_MASK;
 use crate::probe::{ParseOptions, ParsingMode};
@@ -27,29 +27,39 @@ where
 
 	reader.seek(SeekFrom::Current(-1))?;
 
-	// Best case scenario, we find an ID3v2 tag at the beginning of the file.
-	// We will check again after finding the frame sync, in case the tag is buried in junk.
-	if let ID3FindResults(Some(header), Some(content)) = find_id3v2(reader, true)? {
-		// Seek back to read the tag in full
-		reader.seek(SeekFrom::Current(-4))?;
-
-		let skip_footer = header.flags.footer;
-
-		let id3v2_reader = &mut &*content;
-		let id3v2 = parse_id3v2(id3v2_reader, header, parse_options.parsing_mode)?;
-
-		// Skip over the footer
-		if skip_footer {
-			reader.seek(SeekFrom::Current(10))?;
-		}
-
-		file.id3v2_tag = Some(id3v2);
-	}
-
 	let mut header = [0; 4];
 
 	while let Ok(()) = reader.read_exact(&mut header) {
 		match header {
+			// [I, D, 3, ver_major, ver_minor, flags, size (4 bytes)]
+			//
+			// Best case scenario, we find an ID3v2 tag at the beginning of the file.
+			// We will check again after finding the frame sync, in case the tag is buried in junk.
+			[b'I', b'D', b'3', ..] => {
+				// Seek back to read the tag in full
+				reader.seek(SeekFrom::Current(-4))?;
+
+				let header = Id3v2Header::parse(reader)?;
+				let skip_footer = header.flags.footer;
+
+				let id3v2 = parse_id3v2(reader, header, parse_options.parsing_mode)?;
+				if let Some(existing_tag) = &mut file.id3v2_tag {
+					// https://github.com/Serial-ATA/lofty-rs/issues/87
+					// Duplicate tags should have their frames appended to the previous
+					for frame in id3v2.frames {
+						existing_tag.insert(frame);
+					}
+					continue;
+				}
+				file.id3v2_tag = Some(id3v2);
+
+				// Skip over the footer
+				if skip_footer {
+					reader.seek(SeekFrom::Current(10))?;
+				}
+
+				continue;
+			},
 			// TODO: APE tags may suffer the same issue as ID3v2 tag described above.
 			//       They are not nearly as important to preserve, however.
 			[b'A', b'P', b'E', b'T'] => {

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -542,7 +542,11 @@ impl<R: Read + Seek> Probe<R> {
 		}
 
 		// Guess the file type by using these 36 bytes
-		match FileType::from_buffer_inner(&buf[..buf_len]) {
+		let Some(file_type_guess) = FileType::from_buffer_inner(&buf[..buf_len]) else {
+			return Ok(None);
+		};
+
+		match file_type_guess {
 			// We were able to determine a file type
 			FileTypeGuessResult::Determined(file_ty) => Ok(Some(file_ty)),
 			// The file starts with an ID3v2 tag; this means other data can follow (e.g. APE or MP3 frames)


### PR DESCRIPTION
Now when we can't find an ID3v2 tag at the start of the file, we search the area between the start and the first MPEG frame (or just `max_junk_bytes`, whichever is smaller).

For now, this is only done for MPEG files, and ID3v2 tags. APE header tags are less important, so similar functionality can be implemented later.