### PR TITLE
Probe: Introduce `GlobalOptions` to handle allocations and resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `Id3v2ErrorKind::EmptyFrame` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/299))
   - Support converting some TIPL frame values into generic `TagItem`s ([PR](https://github.com/Serial-ATA/lofty-rs/pull/301))
     - Supported TIPL keys are: "producer", "arranger", "engineer", "DJ-mix", "mix".
+- **GlobalOptions**: Options local to the thread that persist between reads and writes ([PR](https://github.com/Serial-ATA/lofty-rs/pull/321))
+  - See [the docs](https://docs.rs/lofty/latest/lofty/struct.GlobalOptions.html) for more information
 
 ### Changed
 - **ID3v1**: Renamed `GENRES[14]` to `"R&B"` (Previously `"Rhythm & Blues"`) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/296))

--- a/examples/custom_resolver/src/main.rs
+++ b/examples/custom_resolver/src/main.rs
@@ -2,8 +2,9 @@ use lofty::ape::ApeTag;
 use lofty::error::Result as LoftyResult;
 use lofty::id3::v2::Id3v2Tag;
 use lofty::resolve::FileResolver;
-use lofty::{FileProperties, FileType, ParseOptions, TagType};
+use lofty::{FileProperties, FileType, GlobalOptions, ParseOptions, TagType};
 use lofty_attr::LoftyFile;
+
 use std::fs::File;
 
 #[rustfmt::skip]
@@ -89,6 +90,11 @@ fn main() {
 	// The name will be used in the `FileType` variant (e.g. FileType::Custom("MyFile")).
 	// The name should preferably match the name of the file struct to avoid confusion.
 	lofty::resolve::register_custom_resolver::<MyFile>("MyFile");
+
+	// By default, lofty will not check for custom files.
+	// We can enable this by updating our `GlobalOptions`.
+	let global_options = GlobalOptions::new().use_custom_resolvers(true);
+	lofty::apply_global_options(global_options);
 
 	// Now when using the following functions, your custom file will be checked
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use crate::global_options::global_options;
 use crate::probe::ParseOptions;
 use crate::properties::FileProperties;
 use crate::resolve::custom_resolvers;
@@ -818,13 +819,15 @@ impl FileType {
 		let ext = ext.as_ref().to_str()?.to_ascii_lowercase();
 
 		// Give custom resolvers priority
-		if let Some((ty, _)) = custom_resolvers()
-			.lock()
-			.ok()?
-			.iter()
-			.find(|(_, f)| f.extension() == Some(ext.as_str()))
-		{
-			return Some(Self::Custom(ty));
+		if unsafe { global_options().use_custom_resolvers } {
+			if let Some((ty, _)) = custom_resolvers()
+				.lock()
+				.ok()?
+				.iter()
+				.find(|(_, f)| f.extension() == Some(ext.as_str()))
+			{
+				return Some(Self::Custom(ty));
+			}
 		}
 
 		match ext.as_str() {

--- a/src/global_options.rs
+++ b/src/global_options.rs
@@ -1,0 +1,121 @@
+use std::cell::UnsafeCell;
+
+thread_local! {
+	static GLOBAL_OPTIONS: UnsafeCell<GlobalOptions> = UnsafeCell::new(GlobalOptions::default());
+}
+
+pub(crate) unsafe fn global_options() -> &'static GlobalOptions {
+	GLOBAL_OPTIONS.with(|global_options| unsafe { &*global_options.get() })
+}
+
+/// Options that control all interactions with Lofty for the current thread
+///
+/// # Examples
+///
+/// ```rust
+/// use lofty::GlobalOptions;
+///
+/// // I have a custom resolver that I need checked
+/// let global_options = GlobalOptions::new().use_custom_resolvers(true);
+/// lofty::apply_global_options(global_options);
+/// ```
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct GlobalOptions {
+	pub(crate) use_custom_resolvers: bool,
+	pub(crate) allocation_limit: usize,
+}
+
+impl GlobalOptions {
+	/// Default allocation limit for any single tag item
+	pub const DEFAULT_ALLOCATION_LIMIT: usize = 16 * 1024 * 1024;
+
+	/// Creates a new `GlobalOptions`, alias for `Default` implementation
+	///
+	/// See also: [`GlobalOptions::default`]
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use lofty::GlobalOptions;
+	///
+	/// let global_options = GlobalOptions::new();
+	/// ```
+	#[must_use]
+	pub const fn new() -> Self {
+		Self {
+			use_custom_resolvers: true,
+			allocation_limit: Self::DEFAULT_ALLOCATION_LIMIT,
+		}
+	}
+
+	/// Whether or not to check registered custom resolvers
+	///
+	/// See also: [`crate::resolve`]
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use lofty::GlobalOptions;
+	///
+	/// // By default, `use_custom_resolvers` is enabled. Here, we don't want to use them.
+	/// let global_options = GlobalOptions::new().use_custom_resolvers(false);
+	/// lofty::apply_global_options(global_options);
+	/// ```
+	pub fn use_custom_resolvers(&mut self, use_custom_resolvers: bool) -> Self {
+		self.use_custom_resolvers = use_custom_resolvers;
+		*self
+	}
+
+	/// The maximum number of bytes to allocate for any single tag item
+	///
+	/// This is a safety measure to prevent allocating too much memory for a single tag item. If a tag item
+	/// exceeds this limit, the allocator will return [`crate::error::ErrorKind::TooMuchData`].
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use lofty::GlobalOptions;
+	///
+	/// // I have files with gigantic images, I'll double the allocation limit!
+	/// let global_options = GlobalOptions::new().allocation_limit(32 * 1024 * 1024);
+	/// lofty::apply_global_options(global_options);
+	/// ```
+	pub fn allocation_limit(&mut self, allocation_limit: usize) -> Self {
+		self.allocation_limit = allocation_limit;
+		*self
+	}
+}
+
+impl Default for GlobalOptions {
+	/// The default implementation for `GlobalOptions`
+	///
+	/// The defaults are as follows:
+	///
+	/// ```rust,ignore
+	/// GlobalOptions {
+	/// 	use_custom_resolvers: true,
+	/// 	allocation_limit: Self::DEFAULT_ALLOCATION_LIMIT,
+	/// }
+	/// ```
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+/// Applies the given `GlobalOptions` to the current thread
+///
+/// # Examples
+///
+/// ```rust
+/// use lofty::GlobalOptions;
+///
+/// // I have a custom resolver that I need checked
+/// let global_options = GlobalOptions::new().use_custom_resolvers(true);
+/// lofty::apply_global_options(global_options);
+/// ```
+pub fn apply_global_options(options: GlobalOptions) {
+	GLOBAL_OPTIONS.with(|global_options| unsafe {
+		*global_options.get() = options;
+	});
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ pub mod ape;
 pub mod error;
 pub(crate) mod file;
 pub mod flac;
+pub(crate) mod global_options;
 pub mod id3;
 pub mod iff;
 pub(crate) mod macros;
@@ -185,5 +186,7 @@ pub use util::text::TextEncoding;
 pub use crate::traits::{Accessor, MergeTag, SplitTag, TagExt};
 
 pub use picture::PictureInformation;
+
+pub use global_options::{apply_global_options, GlobalOptions};
 
 pub use lofty_attr::LoftyFile;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -130,6 +130,7 @@ pub fn register_custom_resolver<T: FileResolver + 'static>(name: &'static str) {
 #[cfg(test)]
 mod tests {
 	use crate::file::{FileType, TaggedFileExt};
+	use crate::global_options::GlobalOptions;
 	use crate::id3::v2::Id3v2Tag;
 	use crate::probe::ParseOptions;
 	use crate::properties::FileProperties;
@@ -193,6 +194,9 @@ mod tests {
 	#[test]
 	fn custom_resolver() {
 		register_custom_resolver::<MyFile>("MyFile");
+
+		let global_options = GlobalOptions::new().use_custom_resolvers(true);
+		crate::apply_global_options(global_options);
 
 		let path = "examples/custom_resolver/test_asset.myfile";
 		let read = crate::read_from_path(path).unwrap();


### PR DESCRIPTION
This moves `ParseOptions::{use_custom_resolvers, allocation_limit}` to the new `GlobalOptions` struct. This makes it easier to check for certain options in places where `ParseOptions` may not be available.

`GlobalOptions` are not truly global, they only apply to the current thread.