### PR TITLE
mp4: Map "----:com.apple.iTunes:ORIGINALDATE" to OriginalReleaseDate

### DIFF
--- a/src/tag/item.rs
+++ b/src/tag/item.rs
@@ -262,6 +262,7 @@ gen_map!(
 	"rate"                                               => Popularimeter,
 	"rtng"                                               => ParentalAdvisory,
 	"\u{a9}day"                                          => RecordingDate,
+	"----:com.apple.iTunes:ORIGINALDATE"                 => OriginalReleaseDate,
 	"----:com.apple.iTunes:ISRC"                         => Isrc,
 	"----:com.apple.iTunes:BARCODE"                      => Barcode,
 	"----:com.apple.iTunes:CATALOGNUMBER"                => CatalogNumber,


### PR DESCRIPTION
Adopted from TagLib v2.0.