### PR TITLE
mp4: Fix conversion of u16 track/disc numbers to BE bytes

### DIFF
--- a/src/mp4/ilst/mod.rs
+++ b/src/mp4/ilst/mod.rs
@@ -414,10 +414,10 @@ impl Accessor for Ilst {
 	}
 
 	fn set_track(&mut self, value: u32) {
-		let value = (value as u16).to_be_bytes();
-		let track_total = self.track_total().unwrap_or(0).to_be_bytes();
+		let track = (value as u16).to_be_bytes();
+		let track_total = (self.track_total().unwrap_or(0) as u16).to_be_bytes();
 
-		let data = vec![0, 0, value[0], value[1], track_total[0], track_total[1]];
+		let data = vec![0, 0, track[0], track[1], track_total[0], track_total[1]];
 		self.replace_atom(Atom::unknown_implicit(AtomIdent::Fourcc(*b"trkn"), data));
 	}
 
@@ -430,19 +430,19 @@ impl Accessor for Ilst {
 	}
 
 	fn set_track_total(&mut self, value: u32) {
-		let value = (value as u16).to_be_bytes();
-		let track = self.track().unwrap_or(1).to_be_bytes();
+		let track_total = (value as u16).to_be_bytes();
+		let track = (self.track().unwrap_or(0) as u16).to_be_bytes();
 
-		let data = vec![0, 0, track[0], track[1], value[0], value[1]];
+		let data = vec![0, 0, track[0], track[1], track_total[0], track_total[1]];
 		self.replace_atom(Atom::unknown_implicit(AtomIdent::Fourcc(*b"trkn"), data));
 	}
 
 	fn remove_track_total(&mut self) {
-		let track_num = self.track();
+		let track = self.track();
 		let _ = self.remove(&AtomIdent::Fourcc(*b"trkn"));
 
-		if let Some(track_num) = track_num {
-			let track_bytes = (track_num as u16).to_be_bytes();
+		if let Some(track) = track {
+			let track_bytes = (track as u16).to_be_bytes();
 			let data = vec![0, 0, track_bytes[0], track_bytes[1], 0, 0];
 
 			self.replace_atom(Atom::unknown_implicit(AtomIdent::Fourcc(*b"trkn"), data));
@@ -454,10 +454,10 @@ impl Accessor for Ilst {
 	}
 
 	fn set_disk(&mut self, value: u32) {
-		let value = (value as u16).to_be_bytes();
-		let disk_total = self.disk_total().unwrap_or(0).to_be_bytes();
+		let disk = (value as u16).to_be_bytes();
+		let disk_total = (self.disk_total().unwrap_or(0) as u16).to_be_bytes();
 
-		let data = vec![0, 0, value[0], value[1], disk_total[0], disk_total[1]];
+		let data = vec![0, 0, disk[0], disk[1], disk_total[0], disk_total[1]];
 		self.replace_atom(Atom::unknown_implicit(AtomIdent::Fourcc(*b"disk"), data));
 	}
 
@@ -470,19 +470,19 @@ impl Accessor for Ilst {
 	}
 
 	fn set_disk_total(&mut self, value: u32) {
-		let value = (value as u16).to_be_bytes();
-		let disk = self.disk().unwrap_or(1).to_be_bytes();
+		let disk_total = (value as u16).to_be_bytes();
+		let disk = (self.disk().unwrap_or(0) as u16).to_be_bytes();
 
-		let data = vec![0, 0, disk[0], disk[1], value[0], value[1]];
+		let data = vec![0, 0, disk[0], disk[1], disk_total[0], disk_total[1]];
 		self.replace_atom(Atom::unknown_implicit(AtomIdent::Fourcc(*b"disk"), data));
 	}
 
 	fn remove_disk_total(&mut self) {
-		let disk_num = self.disk();
+		let disk = self.disk();
 		let _ = self.remove(&AtomIdent::Fourcc(*b"disk"));
 
-		if let Some(disk_num) = disk_num {
-			let disk_bytes = (disk_num as u16).to_be_bytes();
+		if let Some(disk) = disk {
+			let disk_bytes = (disk as u16).to_be_bytes();
 			let data = vec![0, 0, disk_bytes[0], disk_bytes[1], 0, 0];
 
 			self.replace_atom(Atom::unknown_implicit(AtomIdent::Fourcc(*b"disk"), data));

--- a/src/mp4/ilst/mod.rs
+++ b/src/mp4/ilst/mod.rs
@@ -599,16 +599,24 @@ impl SplitTag for Ilst {
 								let current = u16::from_be_bytes([data[2], data[3]]);
 								let total = u16::from_be_bytes([data[4], data[5]]);
 
-								tag.insert_text(ItemKey::TrackNumber, current.to_string());
-								tag.insert_text(ItemKey::TrackTotal, total.to_string());
+								if current > 0 {
+									tag.insert_text(ItemKey::TrackNumber, current.to_string());
+								}
+								if total > 0 {
+									tag.insert_text(ItemKey::TrackTotal, total.to_string());
+								}
 								return false; // Atom consumed
 							},
 							b"disk" => {
 								let current = u16::from_be_bytes([data[2], data[3]]);
 								let total = u16::from_be_bytes([data[4], data[5]]);
 
-								tag.insert_text(ItemKey::DiscNumber, current.to_string());
-								tag.insert_text(ItemKey::DiscTotal, total.to_string());
+								if current > 0 {
+									tag.insert_text(ItemKey::DiscNumber, current.to_string());
+								}
+								if total > 0 {
+									tag.insert_text(ItemKey::DiscTotal, total.to_string());
+								}
 								return false; // Atom consumed
 							},
 							_ => {},

--- a/src/tag/mod.rs
+++ b/src/tag/mod.rs
@@ -125,11 +125,7 @@ impl Accessor for Tag {
 	);
 
 	fn track(&self) -> Option<u32> {
-		if let Some(i) = self.get_string(&ItemKey::TrackNumber) {
-			return i.parse::<u32>().ok();
-		}
-
-		None
+		self.get_u32_from_string(&ItemKey::TrackNumber)
 	}
 
 	fn set_track(&mut self, value: u32) {
@@ -141,11 +137,7 @@ impl Accessor for Tag {
 	}
 
 	fn track_total(&self) -> Option<u32> {
-		if let Some(i) = self.get_string(&ItemKey::TrackTotal) {
-			return i.parse::<u32>().ok();
-		}
-
-		None
+		self.get_u32_from_string(&ItemKey::TrackTotal)
 	}
 
 	fn set_track_total(&mut self, value: u32) {
@@ -157,11 +149,7 @@ impl Accessor for Tag {
 	}
 
 	fn disk(&self) -> Option<u32> {
-		if let Some(i) = self.get_string(&ItemKey::DiscNumber) {
-			return i.parse::<u32>().ok();
-		}
-
-		None
+		self.get_u32_from_string(&ItemKey::DiscNumber)
 	}
 
 	fn set_disk(&mut self, value: u32) {
@@ -173,11 +161,7 @@ impl Accessor for Tag {
 	}
 
 	fn disk_total(&self) -> Option<u32> {
-		if let Some(i) = self.get_string(&ItemKey::DiscTotal) {
-			return i.parse::<u32>().ok();
-		}
-
-		None
+		self.get_u32_from_string(&ItemKey::DiscTotal)
 	}
 
 	fn set_disk_total(&mut self, value: u32) {
@@ -272,6 +256,11 @@ impl Tag {
 		}
 
 		None
+	}
+
+	fn get_u32_from_string(&self, key: &ItemKey) -> Option<u32> {
+		let i = self.get_string(key)?;
+		i.parse::<u32>().ok()
 	}
 
 	/// Gets a byte slice from an [`ItemKey`]


### PR DESCRIPTION
A cast was missing.

I also changed the default value to 0 consistently for both current/total numbers and consider 0 as invalid/missing.

All these setters/getters are obviously untested.