### PR TITLE
id3v2: Fix parsing of UTF-16 when BOM is missing

### DIFF
--- a/src/id3/v2/items/sync_text.rs
+++ b/src/id3/v2/items/sync_text.rs
@@ -145,16 +145,9 @@ impl SynchronizedText {
 
 					// Encountered text that doesn't include a BOM
 					if bom != [0xFF, 0xFE] && bom != [0xFE, 0xFF] {
-						if let Some(raw_text) = read_to_terminator(&mut cursor, TextEncoding::UTF16)
-						{
-							// text + null terminator
-							pos += (raw_text.len() + 2) as u64;
-
-							return utf16_decode_bytes(&raw_text, endianness)
-								.map_err(|_| Id3v2Error::new(Id3v2ErrorKind::BadSyncText).into());
-						}
-
-						return Ok(String::new());
+						let (raw_text, _) = read_to_terminator(&mut cursor, TextEncoding::UTF16);
+						return utf16_decode_bytes(&raw_text, endianness)
+							.map_err(|_| Id3v2Error::new(Id3v2ErrorKind::BadSyncText).into());
 					}
 				}
 

--- a/src/id3/v2/tag/tests.rs
+++ b/src/id3/v2/tag/tests.rs
@@ -1338,3 +1338,9 @@ fn flag_item_conversion() {
 		Some("0")
 	);
 }
+
+#[test]
+fn regression_295_fuzzing_id3v24_parse_extended_text_frame_unreachable_panic() {
+	let data = [1, 0, 0, 0];
+	assert!(ExtendedTextFrame::parse(&mut &data[..], Id3v2Version::V4).is_err());
+}


### PR DESCRIPTION
Fixes one of the panics discovered in #295.