### PR TITLE
ID3: Search through junk in `find_id3v2()`

### DIFF
--- a/src/ape/read.rs
+++ b/src/ape/read.rs
@@ -6,7 +6,7 @@ use crate::error::Result;
 use crate::id3::v1::tag::Id3v1Tag;
 use crate::id3::v2::read::parse_id3v2;
 use crate::id3::v2::tag::Id3v2Tag;
-use crate::id3::{find_id3v1, find_id3v2, find_lyrics3v2, ID3FindResults};
+use crate::id3::{find_id3v1, find_id3v2, find_lyrics3v2, FindId3v2Config, ID3FindResults};
 use crate::macros::decode_err;
 use crate::probe::ParseOptions;
 
@@ -28,7 +28,9 @@ where
 	let mut ape_tag: Option<ApeTag> = None;
 
 	// ID3v2 tags are unsupported in APE files, but still possible
-	if let ID3FindResults(Some(header), Some(content)) = find_id3v2(data, true)? {
+	if let ID3FindResults(Some(header), Some(content)) =
+		find_id3v2(data, FindId3v2Config::READ_TAG)?
+	{
 		log::warn!("Encountered an ID3v2 tag. This tag cannot be rewritten to the APE file!");
 
 		stream_len -= u64::from(header.size);

--- a/src/ape/tag/write.rs
+++ b/src/ape/tag/write.rs
@@ -3,7 +3,7 @@ use super::ApeTagRef;
 use crate::ape::constants::APE_PREAMBLE;
 use crate::ape::tag::read;
 use crate::error::Result;
-use crate::id3::{find_id3v1, find_id3v2, find_lyrics3v2};
+use crate::id3::{find_id3v1, find_id3v2, find_lyrics3v2, FindId3v2Config};
 use crate::macros::{decode_err, err};
 use crate::probe::Probe;
 use crate::tag::item::ItemValueRef;
@@ -28,7 +28,7 @@ where
 	let data = probe.into_inner();
 
 	// We don't actually need the ID3v2 tag, but reading it will seek to the end of it if it exists
-	find_id3v2(data, false)?;
+	find_id3v2(data, FindId3v2Config::NO_READ_TAG)?;
 
 	let mut ape_preamble = [0; 8];
 	data.read_exact(&mut ape_preamble)?;

--- a/src/flac/read.rs
+++ b/src/flac/read.rs
@@ -7,7 +7,7 @@ use crate::flac::block::{
 	BLOCK_ID_VORBIS_COMMENTS,
 };
 use crate::id3::v2::read::parse_id3v2;
-use crate::id3::{find_id3v2, ID3FindResults};
+use crate::id3::{find_id3v2, FindId3v2Config, ID3FindResults};
 use crate::macros::decode_err;
 use crate::ogg::read::read_comments;
 use crate::picture::Picture;
@@ -48,7 +48,9 @@ where
 	};
 
 	// It is possible for a FLAC file to contain an ID3v2 tag
-	if let ID3FindResults(Some(header), Some(content)) = find_id3v2(data, true)? {
+	if let ID3FindResults(Some(header), Some(content)) =
+		find_id3v2(data, FindId3v2Config::READ_TAG)?
+	{
 		log::warn!("Encountered an ID3v2 tag. This tag cannot be rewritten to the FLAC file!");
 
 		let reader = &mut &*content;

--- a/src/id3/v2/write/mod.rs
+++ b/src/id3/v2/write/mod.rs
@@ -4,11 +4,11 @@ mod frame;
 use super::Id3v2TagFlags;
 use crate::error::Result;
 use crate::file::FileType;
-use crate::id3::find_id3v2;
 use crate::id3::v2::frame::FrameRef;
 use crate::id3::v2::tag::Id3v2TagRef;
 use crate::id3::v2::util::synchsafe::SynchsafeInteger;
 use crate::id3::v2::Id3v2Tag;
+use crate::id3::{find_id3v2, FindId3v2Config};
 use crate::macros::err;
 use crate::probe::Probe;
 
@@ -82,7 +82,8 @@ pub(crate) fn write_id3v2<'a, I: Iterator<Item = FrameRef<'a>> + Clone + 'a>(
 	let id3v2 = create_tag(tag)?;
 
 	// find_id3v2 will seek us to the end of the tag
-	find_id3v2(data, false)?;
+	// TODO: Search through junk
+	find_id3v2(data, FindId3v2Config::NO_READ_TAG)?;
 
 	let mut file_bytes = Vec::new();
 	data.read_to_end(&mut file_bytes)?;

--- a/src/musepack/read.rs
+++ b/src/musepack/read.rs
@@ -4,7 +4,7 @@ use super::sv8::MpcSv8Properties;
 use super::{MpcFile, MpcProperties, MpcStreamVersion};
 use crate::error::Result;
 use crate::id3::v2::read::parse_id3v2;
-use crate::id3::{find_id3v1, find_id3v2, find_lyrics3v2, ID3FindResults};
+use crate::id3::{find_id3v1, find_id3v2, find_lyrics3v2, FindId3v2Config, ID3FindResults};
 use crate::probe::ParseOptions;
 use crate::traits::SeekStreamLen;
 
@@ -25,7 +25,9 @@ where
 
 	// ID3v2 tags are unsupported in MPC files, but still possible
 	#[allow(unused_variables)]
-	if let ID3FindResults(Some(header), Some(content)) = find_id3v2(reader, true)? {
+	if let ID3FindResults(Some(header), Some(content)) =
+		find_id3v2(reader, FindId3v2Config::READ_TAG)?
+	{
 		let reader = &mut &*content;
 
 		let id3v2 = parse_id3v2(reader, header, parse_options.parsing_mode)?;


### PR DESCRIPTION
This moves the existing search through junk from MPEG into `find_id3v2()`, so that other formats can potentially take advantage of it.