### PR TITLE
lofty_attr: Allow dead code

### DIFF
--- a/lofty_attr/src/attribute.rs
+++ b/lofty_attr/src/attribute.rs
@@ -7,6 +7,7 @@ pub(crate) enum AttributeValue {
 	Path(Ident),
 	/// `#[lofty(attribute_name = "value")]`
 	NameValue(Ident, LitStr),
+	#[allow(dead_code)]
 	/// `#[lofty(attribute_name(value1, value2, value3))]`
 	SingleList(Ident, Punctuated<Expr, Token![,]>),
 }


### PR DESCRIPTION
To silence an annoying Clippy error.