### PR TITLE
WavPack: Add a TODO for unknown sample counts

### DIFF
--- a/src/wavpack/properties.rs
+++ b/src/wavpack/properties.rs
@@ -215,6 +215,12 @@ where
 		offset += u64::from(block_header.block_size + 8);
 	}
 
+	// TODO: Support unknown sample counts in WavPack
+	if total_samples == !0 {
+		log::warn!("Unable to calculate duration, unknown sample counts are not yet supported");
+		return Ok(properties);
+	}
+	
 	if total_samples == 0 || properties.sample_rate == 0 {
 		if parse_mode == ParsingMode::Strict {
 			decode_err!(@BAIL WavPack, "Unable to calculate duration (sample count == 0 || sample rate == 0)")


### PR DESCRIPTION
WavPack supports unknown sample counts:

```c
typedef struct {
    // ...
    uint32_t total_samples;     // total samples for entire file, but this is
                                // only valid if block_index == 0 and a value of
                                // -1 indicates unknown length
    // ...
} WavpackHeader;
```

(https://web.archive.org/web/20150424062034/https://www.wavpack.com/file_format.txt)

This wasn't checked for before, so it would produce wild results for the duration. I don't plan on actually fixing this anytime soon, I'd just rather produce no results than wrong results.