### PR TITLE
ID3v2: Allow for generic conversion of language frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously, these items would be discarded when converting to the generic `Tag`. Now they are stored
     in an immutable container, and silently rejoined with the tag when converting back to the original format
     or when writing.
+- **TagItem**: `set_lang` and `set_description` to allow for generic conversions of additional ID3v2 frames (such as comments) ([issue](https://github.com/Serial-ATA/lofty-rs/issues/383)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/392))
 
 ### Changed
 - **VorbisComments**/**ApeTag**: Verify contents of `ItemKey::FlagCompilation` during `Tag` merge ([PR](https://github.com/Serial-ATA/lofty-rs/pull/387))

--- a/lofty/src/id3/v2/frame/conversion.rs
+++ b/lofty/src/id3/v2/frame/conversion.rs
@@ -1,7 +1,5 @@
 use crate::error::{Id3v2Error, Id3v2ErrorKind, LoftyError, Result};
-use crate::id3::v2::frame::{
-	FrameRef, EMPTY_CONTENT_DESCRIPTOR, MUSICBRAINZ_UFID_OWNER, UNKNOWN_LANGUAGE,
-};
+use crate::id3::v2::frame::{FrameRef, EMPTY_CONTENT_DESCRIPTOR, MUSICBRAINZ_UFID_OWNER};
 use crate::id3::v2::tag::{
 	new_binary_frame, new_comment_frame, new_text_frame, new_unsync_text_frame, new_url_frame,
 	new_user_text_frame, new_user_url_frame,
@@ -11,6 +9,7 @@ use crate::id3::v2::{
 	UniqueFileIdentifierFrame, UnsynchronizedTextFrame,
 };
 use crate::macros::err;
+use crate::tag::items::UNKNOWN_LANGUAGE;
 use crate::tag::{ItemKey, ItemValue, TagItem, TagType};
 use crate::TextEncoding;
 

--- a/lofty/src/id3/v2/frame/mod.rs
+++ b/lofty/src/id3/v2/frame/mod.rs
@@ -29,16 +29,6 @@ pub(super) const MUSICBRAINZ_UFID_OWNER: &str = "http://musicbrainz.org";
 /// and to prevent inconsistencies when writing them.
 pub(super) const EMPTY_CONTENT_DESCRIPTOR: String = String::new();
 
-/// Unknown language-aware text frame
-///
-/// <https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2.4.0-structure.html>
-///
-/// > The three byte language field, present in several frames, is used to describe
-/// > the language of the frame’s content, according to ISO-639-2 [ISO-639-2].
-/// > The language should be represented in lower case. If the language is not known
-/// > the string “XXX” should be used.
-pub(super) const UNKNOWN_LANGUAGE: [u8; 3] = *b"XXX";
-
 // TODO: Messy module, rough conversions
 
 macro_rules! define_frames {

--- a/lofty/src/id3/v2/items/language_frame.rs
+++ b/lofty/src/id3/v2/items/language_frame.rs
@@ -2,6 +2,7 @@ use crate::error::{Id3v2Error, Id3v2ErrorKind, Result};
 use crate::id3::v2::frame::content::verify_encoding;
 use crate::id3::v2::header::Id3v2Version;
 use crate::id3::v2::{FrameFlags, FrameHeader, FrameId};
+use crate::tag::items::Lang;
 use crate::util::text::{decode_text, encode_text, TextDecodeOptions, TextEncoding};
 
 use std::borrow::Cow;
@@ -15,7 +16,7 @@ use byteorder::ReadBytesExt;
 // This exists to deduplicate some code between `CommentFrame` and `UnsynchronizedTextFrame`
 struct LanguageFrame {
 	pub encoding: TextEncoding,
-	pub language: [u8; 3],
+	pub language: Lang,
 	pub description: String,
 	pub content: String,
 }
@@ -78,7 +79,7 @@ pub struct CommentFrame<'a> {
 	/// The encoding of the description and comment text
 	pub encoding: TextEncoding,
 	/// ISO-639-2 language code (3 bytes)
-	pub language: [u8; 3],
+	pub language: Lang,
 	/// Unique content description
 	pub description: String,
 	/// The actual frame content
@@ -87,12 +88,13 @@ pub struct CommentFrame<'a> {
 
 impl<'a> PartialEq for CommentFrame<'a> {
 	fn eq(&self, other: &Self) -> bool {
-		self.description == other.description
+		self.language == other.language && self.description == other.description
 	}
 }
 
 impl<'a> Hash for CommentFrame<'a> {
 	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.language.hash(state);
 		self.description.hash(state);
 	}
 }
@@ -103,7 +105,7 @@ impl<'a> CommentFrame<'a> {
 	/// Create a new [`CommentFrame`]
 	pub fn new(
 		encoding: TextEncoding,
-		language: [u8; 3],
+		language: Lang,
 		description: String,
 		content: String,
 	) -> Self {
@@ -187,7 +189,7 @@ pub struct UnsynchronizedTextFrame<'a> {
 	/// The encoding of the description and content
 	pub encoding: TextEncoding,
 	/// ISO-639-2 language code (3 bytes)
-	pub language: [u8; 3],
+	pub language: Lang,
 	/// Unique content description
 	pub description: String,
 	/// The actual frame content
@@ -196,12 +198,13 @@ pub struct UnsynchronizedTextFrame<'a> {
 
 impl<'a> PartialEq for UnsynchronizedTextFrame<'a> {
 	fn eq(&self, other: &Self) -> bool {
-		self.description == other.description
+		self.language == other.language && self.description == other.description
 	}
 }
 
 impl<'a> Hash for UnsynchronizedTextFrame<'a> {
 	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.language.hash(state);
 		self.description.hash(state);
 	}
 }
@@ -212,7 +215,7 @@ impl<'a> UnsynchronizedTextFrame<'a> {
 	/// Create a new [`UnsynchronizedTextFrame`]
 	pub fn new(
 		encoding: TextEncoding,
-		language: [u8; 3],
+		language: Lang,
 		description: String,
 		content: String,
 	) -> Self {

--- a/lofty/src/id3/v2/tag.rs
+++ b/lofty/src/id3/v2/tag.rs
@@ -1167,13 +1167,13 @@ impl SplitTag for Id3v2Tag {
 									item_key.clone(),
 									ItemValue::Text(c.to_string()),
 								);
-								
+
 								item.set_lang(*language);
-								
+
 								if *description != EMPTY_CONTENT_DESCRIPTOR {
 									item.set_description(std::mem::take(description));
 								}
-								
+
 								tag.items.push(item);
 							}
 							return FRAME_CONSUMED;

--- a/lofty/src/id3/v2/tag/tests.rs
+++ b/lofty/src/id3/v2/tag/tests.rs
@@ -207,8 +207,8 @@ fn tag_to_id3v2() {
 	assert_eq!(
 		frame,
 		&Frame::Comment(CommentFrame::new(
-			TextEncoding::Latin1,
-			*b"eng",
+			TextEncoding::UTF8,
+			*b"XXX",
 			EMPTY_CONTENT_DESCRIPTOR,
 			String::from("Qux comment"),
 		))

--- a/lofty/src/tag/item.rs
+++ b/lofty/src/tag/item.rs
@@ -9,6 +9,7 @@ macro_rules! first_key {
 	};
 }
 
+use crate::tag::items::{Lang, UNKNOWN_LANGUAGE};
 pub(crate) use first_key;
 
 // This is used to create the key/ItemKey maps
@@ -789,6 +790,8 @@ impl<'a> Into<ItemValueRef<'a>> for &'a ItemValue {
 /// Represents a tag item (key/value)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TagItem {
+	pub(crate) lang: Lang,
+	pub(crate) description: String,
 	pub(crate) item_key: ItemKey,
 	pub(crate) item_value: ItemValue,
 }
@@ -806,19 +809,35 @@ impl TagItem {
 		item_key: ItemKey,
 		item_value: ItemValue,
 	) -> Option<Self> {
-		item_key.map_key(tag_type, false).is_some().then_some(Self {
-			item_key,
-			item_value,
-		})
+		item_key
+			.map_key(tag_type, false)
+			.is_some()
+			.then_some(Self::new(item_key, item_value))
 	}
 
 	/// Create a new [`TagItem`]
 	#[must_use]
 	pub const fn new(item_key: ItemKey, item_value: ItemValue) -> Self {
 		Self {
+			lang: UNKNOWN_LANGUAGE,
+			description: String::new(),
 			item_key,
 			item_value,
 		}
+	}
+
+	/// Set a language for the [`TagItem`]
+	///
+	/// NOTE: This will not be reflected in most tag formats.
+	pub fn set_lang(&mut self, lang: Lang) {
+		self.lang = lang;
+	}
+
+	/// Set a description for the [`TagItem`]
+	///
+	/// NOTE: This will not be reflected in most tag formats.
+	pub fn set_description(&mut self, description: String) {
+		self.description = description;
 	}
 
 	/// Returns a reference to the [`ItemKey`]

--- a/lofty/src/tag/items/lang.rs
+++ b/lofty/src/tag/items/lang.rs
@@ -1,0 +1,19 @@
+/// A three character language code, as specified by [ISO-639-2].
+///
+/// For now, this is used exclusively in ID3v2.
+///
+/// Excerpt from <https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2.4.0-structure.html>:
+///
+/// > The three byte language field, present in several frames, is used to describe
+/// > the language of the frame’s content, according to [ISO-639-2].
+/// > The language should be represented in lower case. If the language is not known
+/// > the string “XXX” should be used.
+///
+/// [ISO-639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes.
+pub type Lang = [u8; 3];
+
+/// English language code
+pub const ENGLISH: Lang = *b"eng";
+
+/// Unknown/unspecified language
+pub const UNKNOWN_LANGUAGE: [u8; 3] = *b"XXX";

--- a/lofty/src/tag/items/mod.rs
+++ b/lofty/src/tag/items/mod.rs
@@ -1,5 +1,7 @@
 //! Various generic representations of tag items
 
+mod lang;
 mod timestamp;
 
+pub use lang::*;
 pub use timestamp::Timestamp;

--- a/lofty/tests/tags/conversions.rs
+++ b/lofty/tests/tags/conversions.rs
@@ -18,7 +18,7 @@ fn tag_to_id3v2_lang_frame() {
 		id3.get(&FrameId::Valid(Cow::Borrowed("USLT"))),
 		Some(&Frame::UnsynchronizedText(UnsynchronizedTextFrame::new(
 			TextEncoding::UTF8,
-			*b"eng",
+			*b"XXX",
 			String::new(),
 			String::from("Test lyrics")
 		)))
@@ -28,7 +28,7 @@ fn tag_to_id3v2_lang_frame() {
 		id3.get(&FrameId::Valid(Cow::Borrowed("COMM"))),
 		Some(&Frame::Comment(CommentFrame::new(
 			TextEncoding::UTF8,
-			*b"eng",
+			*b"XXX",
 			String::new(),
 			String::from("Test comment")
 		)))


### PR DESCRIPTION
`TagItem` can now store a language and description, making it possible to convert all ID3v2 `COMM` and `USLT` frames to their generic `ItemKey::{Comment, Lyrics}` counterparts.

fixes #383