### PR TITLE
ID3v2: Cleanup `SplitTag` impl

### DIFF
--- a/lofty/src/id3/v2/items/attached_picture_frame.rs
+++ b/lofty/src/id3/v2/items/attached_picture_frame.rs
@@ -35,6 +35,11 @@ impl<'a> AttachedPictureFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/audio_text_frame.rs
+++ b/lofty/src/id3/v2/items/audio_text_frame.rs
@@ -103,6 +103,11 @@ impl<'a> AudioTextFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/binary_frame.rs
+++ b/lofty/src/id3/v2/items/binary_frame.rs
@@ -18,6 +18,11 @@ impl<'a> BinaryFrame<'a> {
 		Self { header, data }
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> &FrameId<'_> {
+		&self.header.id
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/encapsulated_object.rs
+++ b/lofty/src/id3/v2/items/encapsulated_object.rs
@@ -42,6 +42,11 @@ impl<'a> GeneralEncapsulatedObject<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/event_timing_codes_frame.rs
+++ b/lofty/src/id3/v2/items/event_timing_codes_frame.rs
@@ -196,6 +196,11 @@ impl<'a> EventTimingCodesFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/extended_text_frame.rs
+++ b/lofty/src/id3/v2/items/extended_text_frame.rs
@@ -56,6 +56,11 @@ impl<'a> ExtendedTextFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/extended_url_frame.rs
+++ b/lofty/src/id3/v2/items/extended_url_frame.rs
@@ -53,6 +53,11 @@ impl<'a> ExtendedUrlFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/key_value_frame.rs
+++ b/lofty/src/id3/v2/items/key_value_frame.rs
@@ -33,6 +33,11 @@ impl<'a> KeyValueFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> &FrameId<'_> {
+		&self.header.id
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/language_frame.rs
+++ b/lofty/src/id3/v2/items/language_frame.rs
@@ -119,6 +119,11 @@ impl<'a> CommentFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		Self::FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags
@@ -227,6 +232,11 @@ impl<'a> UnsynchronizedTextFrame<'a> {
 			description,
 			content,
 		}
+	}
+
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		Self::FRAME_ID
 	}
 
 	/// Get the flags for the frame

--- a/lofty/src/id3/v2/items/ownership_frame.rs
+++ b/lofty/src/id3/v2/items/ownership_frame.rs
@@ -51,6 +51,11 @@ impl<'a> OwnershipFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/popularimeter.rs
+++ b/lofty/src/id3/v2/items/popularimeter.rs
@@ -54,6 +54,11 @@ impl<'a> PopularimeterFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/private_frame.rs
+++ b/lofty/src/id3/v2/items/private_frame.rs
@@ -32,6 +32,11 @@ impl<'a> PrivateFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/relative_volume_adjustment_frame.rs
+++ b/lofty/src/id3/v2/items/relative_volume_adjustment_frame.rs
@@ -113,6 +113,11 @@ impl<'a> RelativeVolumeAdjustmentFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/sync_text.rs
+++ b/lofty/src/id3/v2/items/sync_text.rs
@@ -108,6 +108,11 @@ impl<'a> SynchronizedTextFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/text_information_frame.rs
+++ b/lofty/src/id3/v2/items/text_information_frame.rs
@@ -42,6 +42,11 @@ impl<'a> TextInformationFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> &FrameId<'_> {
+		&self.header.id
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/timestamp_frame.rs
+++ b/lofty/src/id3/v2/items/timestamp_frame.rs
@@ -41,6 +41,11 @@ impl<'a> TimestampFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> &FrameId<'_> {
+		&self.header.id
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/unique_file_identifier.rs
+++ b/lofty/src/id3/v2/items/unique_file_identifier.rs
@@ -43,6 +43,11 @@ impl<'a> UniqueFileIdentifierFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> FrameId<'_> {
+		FRAME_ID
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/items/url_link_frame.rs
+++ b/lofty/src/id3/v2/items/url_link_frame.rs
@@ -33,6 +33,11 @@ impl<'a> UrlLinkFrame<'a> {
 		}
 	}
 
+	/// Get the ID for the frame
+	pub fn id(&self) -> &FrameId<'_> {
+		&self.header.id
+	}
+
 	/// Get the flags for the frame
 	pub fn flags(&self) -> FrameFlags {
 		self.header.flags

--- a/lofty/src/id3/v2/tag/tests.rs
+++ b/lofty/src/id3/v2/tag/tests.rs
@@ -109,23 +109,6 @@ fn id3v2_to_tag() {
 }
 
 #[test]
-fn id3v2_to_tag_popm() {
-	let id3v2 = read_tag("tests/tags/assets/id3v2/test_popm.id3v24");
-
-	let tag: Tag = id3v2.into();
-
-	assert_eq!(
-		tag.get_binary(&ItemKey::Popularimeter, false),
-		Some(
-			&[
-				b'f', b'o', b'o', b'@', b'b', b'a', b'r', b'.', b'c', b'o', b'm', 0, 196, 0, 0,
-				255, 255,
-			][..]
-		),
-	);
-}
-
-#[test]
 fn tag_to_id3v2_popm() {
 	let mut tag = Tag::new(TagType::Id3v2);
 	tag.insert(TagItem::new(


### PR DESCRIPTION
Rustfmt was starting to struggle with the level of indentation previously.

Everything is now in a single `match` statement. Also took the opportunity to remove the generic conversion of POPM frames.