### PR TITLE
ID3v2: Disallow 4 character TXXX descriptions as `ItemKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renamed `Popularimeter` -> `PopularimeterFrame`
   - Renamed `SynchronizedText` -> `SynchronizedTextFrame`
 
+### Fixed
+- **ID3v2**: Disallow 4 character TXXX/WXXX frame descriptions from being converted to `ItemKey` ([issue](https://github.com/Serial-ATA/lofty-rs/issues/309)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/394))
+
 ## [0.19.2] - 2024-04-26
 
 ### Added

--- a/lofty/src/id3/v2/tag.rs
+++ b/lofty/src/id3/v2/tag.rs
@@ -1081,12 +1081,16 @@ fn handle_tag_split(tag: &mut Tag, frame: &mut Frame<'_>) -> bool {
 			!key_value_pairs.is_empty() // Frame is consumed if we consumed all items
 		},
 
+		// TODO: HACK!! We are specifically disallowing descriptions with a length of 4.
+		//       This is due to use storing 4 character IDs as Frame::Text on tag merge.
+		//       Maybe ItemKey could use a "TXXX:" prefix eventually, so we would store
+		//       "TXXX:MusicBrainz Album Id" instead of "MusicBrainz Album Id".
 		// Store TXXX/WXXX frames by their descriptions, rather than their IDs
 		Frame::UserText(ExtendedTextFrame {
 			ref description,
 			ref content,
 			..
-		}) if !description.is_empty() => {
+		}) if !description.is_empty() && description.len() != 4 => {
 			let item_key = ItemKey::from_key(TagType::Id3v2, description);
 			for c in content.split(V4_MULTI_VALUE_SEPARATOR) {
 				tag.items.push(TagItem::new(
@@ -1101,7 +1105,7 @@ fn handle_tag_split(tag: &mut Tag, frame: &mut Frame<'_>) -> bool {
 			ref description,
 			ref content,
 			..
-		}) if !description.is_empty() => {
+		}) if !description.is_empty() && description.len() != 4 => {
 			let item_key = ItemKey::from_key(TagType::Id3v2, description);
 			for c in content.split(V4_MULTI_VALUE_SEPARATOR) {
 				tag.items.push(TagItem::new(

--- a/lofty/src/tag/item.rs
+++ b/lofty/src/tag/item.rs
@@ -1,3 +1,4 @@
+use crate::tag::items::{Lang, UNKNOWN_LANGUAGE};
 use crate::tag::TagType;
 
 use std::borrow::Cow;
@@ -9,7 +10,6 @@ macro_rules! first_key {
 	};
 }
 
-use crate::tag::items::{Lang, UNKNOWN_LANGUAGE};
 pub(crate) use first_key;
 
 // This is used to create the key/ItemKey maps


### PR DESCRIPTION
As mentioned in the TODO, this is a temporary hack that doesn't allow any 4 character TXXX/WXXX descriptions. A better solution in the future would be to have the `ItemKey` map entries be prefixed.

So rather than:
`"REPLAYGAIN_ALBUM_GAIN" => ReplayGainAlbumGain`

It'd be:
`"TXXX:REPLAYGAIN_ALBUM_GAIN" => ReplayGainAlbumGain,`

closes #309