### PR TITLE
MPEG: Improve duration estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **ID3v2**: Disallow 4 character TXXX/WXXX frame descriptions from being converted to `ItemKey` ([issue](https://github.com/Serial-ATA/lofty-rs/issues/309)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/394))
+- **MPEG**: Durations estimated by bitrate are more accurate ([PR](https://github.com/Serial-ATA/lofty-rs/pull/395))
 
 ## [0.19.2] - 2024-04-26
 

--- a/lofty/src/mpeg/read.rs
+++ b/lofty/src/mpeg/read.rs
@@ -1,4 +1,4 @@
-use super::header::{cmp_header, search_for_frame_sync, Header, HeaderCmpResult, XingHeader};
+use super::header::{cmp_header, search_for_frame_sync, Header, HeaderCmpResult, VbrHeader};
 use super::{MpegFile, MpegProperties};
 use crate::ape::header::read_ape_header;
 use crate::config::{ParseOptions, ParsingMode};
@@ -6,6 +6,7 @@ use crate::error::Result;
 use crate::id3::v2::header::Id3v2Header;
 use crate::id3::v2::read::parse_id3v2;
 use crate::id3::{find_id3v1, find_lyrics3v2, FindId3v2Config, ID3FindResults};
+use crate::io::SeekStreamLen;
 use crate::macros::{decode_err, err};
 use crate::mpeg::header::HEADER_MASK;
 
@@ -182,9 +183,9 @@ where
 		let mut xing_reader = [0; 32];
 		reader.read_exact(&mut xing_reader)?;
 
-		let xing_header = XingHeader::read(&mut &xing_reader[..])?;
+		let xing_header = VbrHeader::read(&mut &xing_reader[..])?;
 
-		let file_length = reader.seek(SeekFrom::End(0))?;
+		let file_length = reader.stream_len_hack()?;
 
 		super::properties::read_properties(
 			&mut file.properties,
@@ -193,6 +194,7 @@ where
 			last_frame_offset,
 			xing_header,
 			file_length,
+			parse_options.parsing_mode,
 		)?;
 	}
 

--- a/lofty/src/properties/tests.rs
+++ b/lofty/src/properties/tests.rs
@@ -75,7 +75,7 @@ const MP1_PROPERTIES: MpegProperties = MpegProperties {
 	copyright: false,
 	original: true,
 	duration: Duration::from_millis(588), // FFmpeg reports 576, possibly an issue
-	overall_bitrate: 383,                 // TODO: FFmpeg reports 392
+	overall_bitrate: 384,                 // TODO: FFmpeg reports 392
 	audio_bitrate: 384,
 	sample_rate: 32000,
 	channels: 2,
@@ -89,8 +89,8 @@ const MP2_PROPERTIES: MpegProperties = MpegProperties {
 	mode_extension: None,
 	copyright: false,
 	original: true,
-	duration: Duration::from_millis(1344), // TODO: FFmpeg reports 1440 here
-	overall_bitrate: 411,                  // FFmpeg reports 384, related to above issue
+	duration: Duration::from_millis(1440),
+	overall_bitrate: 384,
 	audio_bitrate: 384,
 	sample_rate: 48000,
 	channels: 2,


### PR DESCRIPTION
When estimating the duration of an MPEG file using the bitrate, we rely on the offset of the last frame in the file. Turns out the last frame wasn't being returned, just one that happened to be near the end of the file. This wasn't major, as it just reported durations 100ms or so off.