### PR TITLE
Add into_inner for BoundTaggedFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     in an immutable container, and silently rejoined with the tag when converting back to the original format
     or when writing.
 - **TagItem**: `set_lang` and `set_description` to allow for generic conversions of additional ID3v2 frames (such as comments) ([issue](https://github.com/Serial-ATA/lofty-rs/issues/383)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/392))
+- **BoundTaggedFile**: `BoundTaggedFile::into_inner` to get the original file handle ([PR](https://github.com/Serial-ATA/lofty-rs/pull/404))
 
 ### Changed
 - **VorbisComments**/**ApeTag**: Verify contents of `ItemKey::FlagCompilation` during `Tag` merge ([PR](https://github.com/Serial-ATA/lofty-rs/pull/387))

--- a/lofty/src/file/tagged_file.rs
+++ b/lofty/src/file/tagged_file.rs
@@ -588,6 +588,15 @@ impl BoundTaggedFile {
 
 		Ok(())
 	}
+
+	/// Consume this tagged file and return the internal file "buffer".
+	/// This allows you to reuse the internal file.
+	///
+	/// Any changes that haven't been commited will be discarded once you
+	/// call this function.
+	pub fn into_inner(self) -> File {
+		self.file_handle
+	}
 }
 
 impl TaggedFileExt for BoundTaggedFile {


### PR DESCRIPTION
Hey, hello there!

I noticed `BoundTaggedFile` (which takes a file) doesn't have a method to retrieve back the original file handle, so I added a fairly simple and short method to retrieve it back. 

I also added a mp3 test case for it.
