### PR TITLE
ParseOptions: Add `ParseOptions::read_tags`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ParseOptions**: `ParseOptions::read_tags` to skip the parsing of tags ([issue](https://github.com/Serial-ATA/lofty-rs/issues/251)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/406))
+
 ## [0.20.1] - 2024-07-02
 
 ### Fixed

--- a/lofty/src/aac/read.rs
+++ b/lofty/src/aac/read.rs
@@ -48,18 +48,20 @@ where
 
 				stream_len -= u64::from(header.size);
 
-				let id3v2 = parse_id3v2(reader, header, parse_mode)?;
-				if let Some(existing_tag) = &mut file.id3v2_tag {
-					log::warn!("Duplicate ID3v2 tag found, appending frames to previous tag");
+				if parse_options.read_tags {
+					let id3v2 = parse_id3v2(reader, header, parse_mode)?;
+					if let Some(existing_tag) = &mut file.id3v2_tag {
+						log::warn!("Duplicate ID3v2 tag found, appending frames to previous tag");
 
-					// https://github.com/Serial-ATA/lofty-rs/issues/87
-					// Duplicate tags should have their frames appended to the previous
-					for frame in id3v2.frames {
-						existing_tag.insert(frame);
+						// https://github.com/Serial-ATA/lofty-rs/issues/87
+						// Duplicate tags should have their frames appended to the previous
+						for frame in id3v2.frames {
+							existing_tag.insert(frame);
+						}
+						continue;
 					}
-					continue;
+					file.id3v2_tag = Some(id3v2);
 				}
-				file.id3v2_tag = Some(id3v2);
 
 				// Skip over the footer
 				if skip_footer {
@@ -94,7 +96,7 @@ where
 	}
 
 	#[allow(unused_variables)]
-	let ID3FindResults(header, id3v1) = find_id3v1(reader, true)?;
+	let ID3FindResults(header, id3v1) = find_id3v1(reader, parse_options.read_tags)?;
 
 	if header.is_some() {
 		stream_len -= 128;

--- a/lofty/src/ape/tag/mod.rs
+++ b/lofty/src/ape/tag/mod.rs
@@ -622,9 +622,11 @@ mod tests {
 		let tag = crate::tag::utils::test_utils::read_path("tests/tags/assets/test.apev2");
 		let mut reader = Cursor::new(tag);
 
-		let (parsed_tag, _) = crate::ape::tag::read::read_ape_tag(&mut reader, false)
-			.unwrap()
-			.unwrap();
+		let (Some(parsed_tag), _) =
+			crate::ape::tag::read::read_ape_tag(&mut reader, false, true).unwrap()
+		else {
+			unreachable!();
+		};
 
 		assert_eq!(expected_tag.len(), parsed_tag.len());
 
@@ -638,9 +640,11 @@ mod tests {
 		let tag_bytes = crate::tag::utils::test_utils::read_path("tests/tags/assets/test.apev2");
 		let mut reader = Cursor::new(tag_bytes);
 
-		let (parsed_tag, _) = crate::ape::tag::read::read_ape_tag(&mut reader, false)
-			.unwrap()
-			.unwrap();
+		let (Some(parsed_tag), _) =
+			crate::ape::tag::read::read_ape_tag(&mut reader, false, true).unwrap()
+		else {
+			unreachable!();
+		};
 
 		let mut writer = Vec::new();
 		parsed_tag
@@ -649,9 +653,11 @@ mod tests {
 
 		let mut temp_reader = Cursor::new(writer);
 
-		let (temp_parsed_tag, _) = crate::ape::tag::read::read_ape_tag(&mut temp_reader, false)
-			.unwrap()
-			.unwrap();
+		let (Some(temp_parsed_tag), _) =
+			crate::ape::tag::read::read_ape_tag(&mut temp_reader, false, true).unwrap()
+		else {
+			unreachable!()
+		};
 
 		assert_eq!(parsed_tag, temp_parsed_tag);
 	}
@@ -661,9 +667,10 @@ mod tests {
 		let tag_bytes = crate::tag::utils::test_utils::read_path("tests/tags/assets/test.apev2");
 		let mut reader = Cursor::new(tag_bytes);
 
-		let (ape, _) = crate::ape::tag::read::read_ape_tag(&mut reader, false)
-			.unwrap()
-			.unwrap();
+		let (Some(ape), _) = crate::ape::tag::read::read_ape_tag(&mut reader, false, true).unwrap()
+		else {
+			unreachable!()
+		};
 
 		let tag: Tag = ape.into();
 

--- a/lofty/src/ape/tag/read.rs
+++ b/lofty/src/ape/tag/read.rs
@@ -86,16 +86,20 @@ where
 pub(crate) fn read_ape_tag<R: Read + Seek>(
 	reader: &mut R,
 	footer: bool,
-) -> Result<Option<(ApeTag, ApeHeader)>> {
+	read_tag: bool,
+) -> Result<(Option<ApeTag>, Option<ApeHeader>)> {
 	let mut ape_preamble = [0; 8];
 	reader.read_exact(&mut ape_preamble)?;
 
+	let mut ape_tag = None;
 	if &ape_preamble == APE_PREAMBLE {
 		let ape_header = header::read_ape_header(reader, footer)?;
+		if read_tag {
+			ape_tag = Some(read_ape_tag_with_header(reader, ape_header)?);
+		}
 
-		let ape = read_ape_tag_with_header(reader, ape_header)?;
-		return Ok(Some((ape, ape_header)));
+		return Ok((ape_tag, Some(ape_header)));
 	}
 
-	Ok(None)
+	Ok((None, None))
 }

--- a/lofty/src/ape/tag/write.rs
+++ b/lofty/src/ape/tag/write.rs
@@ -48,8 +48,8 @@ where
 	let mut header_ape_tag = (false, (0, 0));
 
 	let start = file.stream_position()?;
-	match read::read_ape_tag(file, false)? {
-		Some((mut existing_tag, header)) => {
+	match read::read_ape_tag(file, false, true)? {
+		(Some(mut existing_tag), Some(header)) => {
 			if write_options.respect_read_only {
 				// Only keep metadata around that's marked read only
 				existing_tag.items.retain(|i| i.read_only);
@@ -61,7 +61,7 @@ where
 
 			header_ape_tag = (true, (start, start + u64::from(header.size)))
 		},
-		None => {
+		_ => {
 			file.seek(SeekFrom::Current(-8))?;
 		},
 	}
@@ -80,7 +80,7 @@ where
 
 	// Also check this tag for any read only items
 	let start = file.stream_position()? as usize + 32;
-	if let Some((mut existing_tag, header)) = read::read_ape_tag(file, true)? {
+	if let (Some(mut existing_tag), Some(header)) = read::read_ape_tag(file, true, true)? {
 		if write_options.respect_read_only {
 			existing_tag.items.retain(|i| i.read_only);
 

--- a/lofty/src/config/parse_options.rs
+++ b/lofty/src/config/parse_options.rs
@@ -3,6 +3,7 @@
 #[non_exhaustive]
 pub struct ParseOptions {
 	pub(crate) read_properties: bool,
+	pub(crate) read_tags: bool,
 	pub(crate) parsing_mode: ParsingMode,
 	pub(crate) max_junk_bytes: usize,
 }
@@ -15,6 +16,7 @@ impl Default for ParseOptions {
 	/// ```rust,ignore
 	/// ParseOptions {
 	/// 	read_properties: true,
+	///     read_tags: true,
 	/// 	parsing_mode: ParsingMode::BestAttempt,
 	///     max_junk_bytes: 1024
 	/// }
@@ -46,6 +48,7 @@ impl ParseOptions {
 	pub const fn new() -> Self {
 		Self {
 			read_properties: true,
+			read_tags: true,
 			parsing_mode: Self::DEFAULT_PARSING_MODE,
 			max_junk_bytes: Self::DEFAULT_MAX_JUNK_BYTES,
 		}
@@ -63,6 +66,21 @@ impl ParseOptions {
 	/// ```
 	pub fn read_properties(&mut self, read_properties: bool) -> Self {
 		self.read_properties = read_properties;
+		*self
+	}
+
+	/// Whether or not to read the tags
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use lofty::config::ParseOptions;
+	///
+	/// // By default, `read_tags` is enabled. Here, we don't want to read them.
+	/// let parsing_options = ParseOptions::new().read_tags(false);
+	/// ```
+	pub fn read_tags(&mut self, read_tags: bool) -> Self {
+		self.read_tags = read_tags;
 		*self
 	}
 

--- a/lofty/src/iff/wav/read.rs
+++ b/lofty/src/iff/wav/read.rs
@@ -78,7 +78,7 @@ where
 				data.read_exact(&mut list_type)?;
 
 				match &list_type {
-					b"INFO" => {
+					b"INFO" if parse_options.read_tags => {
 						let end = data.stream_position()? + u64::from(chunks.size - 4);
 						super::tag::read::parse_riff_info(data, &mut chunks, end, &mut riff_info)?;
 					},
@@ -88,7 +88,7 @@ where
 					},
 				}
 			},
-			b"ID3 " | b"id3 " => {
+			b"ID3 " | b"id3 " if parse_options.read_tags => {
 				let tag = chunks.id3_chunk(data, parse_options.parsing_mode)?;
 				if let Some(existing_tag) = id3v2_tag.as_mut() {
 					log::warn!("Duplicate ID3v2 tag found, appending frames to previous tag");

--- a/lofty/src/mp4/read.rs
+++ b/lofty/src/mp4/read.rs
@@ -192,11 +192,7 @@ where
 	let moov_info = Moov::find(&mut reader)?;
 	reader.reset_bounds(moov_info.start + 8, moov_info.len - 8);
 
-	let moov = Moov::parse(
-		&mut reader,
-		parse_options.parsing_mode,
-		parse_options.read_properties,
-	)?;
+	let moov = Moov::parse(&mut reader, parse_options)?;
 
 	Ok(Mp4File {
 		ftyp,

--- a/lofty/src/ogg/opus/mod.rs
+++ b/lofty/src/ogg/opus/mod.rs
@@ -30,7 +30,7 @@ impl OpusFile {
 		R: Read + Seek,
 	{
 		let file_information =
-			super::read::read_from(reader, OPUSHEAD, OPUSTAGS, 2, parse_options.parsing_mode)?;
+			super::read::read_from(reader, OPUSHEAD, OPUSTAGS, 2, parse_options)?;
 
 		Ok(Self {
 			properties: if parse_options.read_properties {
@@ -38,8 +38,8 @@ impl OpusFile {
 			} else {
 				OpusProperties::default()
 			},
-			// Safe to unwrap, a metadata packet is mandatory in Opus
-			vorbis_comments_tag: file_information.0.unwrap(),
+			// A metadata packet is mandatory in Opus
+			vorbis_comments_tag: file_information.0.unwrap_or_default(),
 		})
 	}
 }

--- a/lofty/src/ogg/opus/properties.rs
+++ b/lofty/src/ogg/opus/properties.rs
@@ -32,7 +32,11 @@ impl From<OpusProperties> for FileProperties {
 			sample_rate: Some(input.input_sample_rate),
 			bit_depth: None,
 			channels: Some(input.channels),
-			channel_mask: Some(input.channel_mask),
+			channel_mask: if input.channel_mask == ChannelMask(0) {
+				None
+			} else {
+				Some(input.channel_mask)
+			},
 		}
 	}
 }

--- a/lofty/src/ogg/speex/mod.rs
+++ b/lofty/src/ogg/speex/mod.rs
@@ -28,8 +28,7 @@ impl SpeexFile {
 	where
 		R: Read + Seek,
 	{
-		let file_information =
-			super::read::read_from(reader, SPEEXHEADER, &[], 2, parse_options.parsing_mode)?;
+		let file_information = super::read::read_from(reader, SPEEXHEADER, &[], 2, parse_options)?;
 
 		Ok(Self {
 			properties: if parse_options.read_properties {
@@ -37,8 +36,8 @@ impl SpeexFile {
 			} else {
 				SpeexProperties::default()
 			},
-			// Safe to unwrap, a metadata packet is mandatory in Speex
-			vorbis_comments_tag: file_information.0.unwrap(),
+			// A metadata packet is mandatory in Speex
+			vorbis_comments_tag: file_information.0.unwrap_or_default(),
 		})
 	}
 }

--- a/lofty/src/ogg/vorbis/mod.rs
+++ b/lofty/src/ogg/vorbis/mod.rs
@@ -34,7 +34,7 @@ impl VorbisFile {
 			VORBIS_IDENT_HEAD,
 			VORBIS_COMMENT_HEAD,
 			3,
-			parse_options.parsing_mode,
+			parse_options,
 		)?;
 
 		Ok(Self {
@@ -43,8 +43,8 @@ impl VorbisFile {
 			} else {
 				VorbisProperties::default()
 			},
-			// Safe to unwrap, a metadata packet is mandatory in OGG Vorbis
-			vorbis_comments_tag: file_information.0.unwrap(),
+			// A metadata packet is mandatory in OGG Vorbis
+			vorbis_comments_tag: file_information.0.unwrap_or_default(),
 		})
 	}
 }

--- a/lofty/src/probe.rs
+++ b/lofty/src/probe.rs
@@ -459,6 +459,10 @@ impl<R: Read + Seek> Probe<R> {
 		let reader = &mut self.inner;
 		let options = self.options.unwrap_or_default();
 
+		if !options.read_tags && !options.read_properties {
+			log::warn!("Skipping both tag and property reading, file will be empty");
+		}
+
 		match self.f_ty {
 			Some(f_type) => Ok(match f_type {
 				FileType::Aac => AacFile::read_from(reader, options)?.into(),

--- a/lofty/src/properties/file_properties.rs
+++ b/lofty/src/properties/file_properties.rs
@@ -85,4 +85,21 @@ impl FileProperties {
 	pub fn channel_mask(&self) -> Option<ChannelMask> {
 		self.channel_mask
 	}
+
+	/// Used for tests
+	#[doc(hidden)]
+	pub fn is_empty(&self) -> bool {
+		matches!(
+			self,
+			Self {
+				duration: Duration::ZERO,
+				overall_bitrate: None | Some(0),
+				audio_bitrate: None | Some(0),
+				sample_rate: None | Some(0),
+				bit_depth: None | Some(0),
+				channels: None | Some(0),
+				channel_mask: None,
+			}
+		)
+	}
 }

--- a/lofty/src/wavpack/properties.rs
+++ b/lofty/src/wavpack/properties.rs
@@ -32,7 +32,11 @@ impl From<WavPackProperties> for FileProperties {
 			sample_rate: Some(input.sample_rate),
 			bit_depth: Some(input.bit_depth),
 			channels: Some(input.channels as u8),
-			channel_mask: Some(input.channel_mask),
+			channel_mask: if input.channel_mask == ChannelMask(0) {
+				None
+			} else {
+				Some(input.channel_mask)
+			},
 		}
 	}
 }

--- a/lofty/src/wavpack/read.rs
+++ b/lofty/src/wavpack/read.rs
@@ -17,7 +17,7 @@ where
 	let mut id3v1_tag = None;
 	let mut ape_tag = None;
 
-	let ID3FindResults(id3v1_header, id3v1) = find_id3v1(reader, true)?;
+	let ID3FindResults(id3v1_header, id3v1) = find_id3v1(reader, parse_options.read_tags)?;
 
 	if id3v1_header.is_some() {
 		stream_length -= 128;
@@ -38,9 +38,11 @@ where
 	// Strongly recommended to be at the end of the file
 	reader.seek(SeekFrom::Current(-32))?;
 
-	if let Some((tag, header)) = crate::ape::tag::read::read_ape_tag(reader, true)? {
+	if let (tag, Some(header)) =
+		crate::ape::tag::read::read_ape_tag(reader, true, parse_options.read_tags)?
+	{
 		stream_length -= u64::from(header.size);
-		ape_tag = Some(tag);
+		ape_tag = tag;
 	}
 
 	Ok(WavPackFile {

--- a/lofty/tests/files/aac.rs
+++ b/lofty/tests/files/aac.rs
@@ -5,7 +5,7 @@ use lofty::prelude::*;
 use lofty::probe::Probe;
 use lofty::tag::TagType;
 
-use std::io::{Seek, Write};
+use std::io::Seek;
 
 #[test]
 fn read() {
@@ -95,4 +95,14 @@ fn remove_id3v2() {
 #[test]
 fn remove_id3v1() {
 	crate::remove_tag!("tests/files/assets/minimal/full_test.aac", TagType::Id3v1);
+}
+
+#[test]
+fn read_no_properties() {
+	crate::no_properties_test!("tests/files/assets/minimal/full_test.aac");
+}
+
+#[test]
+fn read_no_tags() {
+	crate::no_tag_test!("tests/files/assets/minimal/full_test.aac");
 }

--- a/lofty/tests/files/aiff.rs
+++ b/lofty/tests/files/aiff.rs
@@ -5,7 +5,7 @@ use lofty::prelude::*;
 use lofty::probe::Probe;
 use lofty::tag::TagType;
 
-use std::io::{Seek, Write};
+use std::io::Seek;
 
 #[test]
 fn read() {
@@ -69,4 +69,14 @@ fn remove_text_chunks() {
 #[test]
 fn remove_id3v2() {
 	crate::remove_tag!("tests/files/assets/minimal/full_test.aiff", TagType::Id3v2);
+}
+
+#[test]
+fn read_no_properties() {
+	crate::no_properties_test!("tests/files/assets/minimal/full_test.aiff");
+}
+
+#[test]
+fn read_no_tags() {
+	crate::no_tag_test!("tests/files/assets/minimal/full_test.aiff");
 }

--- a/lofty/tests/files/ape.rs
+++ b/lofty/tests/files/ape.rs
@@ -5,7 +5,7 @@ use lofty::prelude::*;
 use lofty::probe::Probe;
 use lofty::tag::TagType;
 
-use std::io::{Seek, Write};
+use std::io::Seek;
 
 #[test]
 fn read() {
@@ -75,4 +75,14 @@ fn remove_id3v1() {
 #[test]
 fn remove_id3v2() {
 	crate::remove_tag!("tests/files/assets/minimal/full_test.ape", TagType::Id3v2);
+}
+
+#[test]
+fn read_no_properties() {
+	crate::no_properties_test!("tests/files/assets/minimal/full_test.ape");
+}
+
+#[test]
+fn read_no_tags() {
+	crate::no_tag_test!("tests/files/assets/minimal/full_test.ape");
 }

--- a/lofty/tests/files/flac.rs
+++ b/lofty/tests/files/flac.rs
@@ -30,3 +30,13 @@ fn multiple_vorbis_comments() {
 		Some("Artist 2")
 	);
 }
+
+#[test]
+fn read_no_properties() {
+	crate::no_properties_test!("tests/files/assets/minimal/full_test.flac");
+}
+
+#[test]
+fn read_no_tags() {
+	crate::no_tag_test!("tests/files/assets/minimal/full_test.flac");
+}

--- a/lofty/tests/files/mp4.rs
+++ b/lofty/tests/files/mp4.rs
@@ -5,7 +5,7 @@ use lofty::prelude::*;
 use lofty::probe::Probe;
 use lofty::tag::TagType;
 
-use std::io::{Seek, Write};
+use std::io::Seek;
 
 #[test]
 fn read() {
@@ -57,4 +57,14 @@ fn remove() {
 		"tests/files/assets/minimal/m4a_codec_aac.m4a",
 		TagType::Mp4Ilst
 	);
+}
+
+#[test]
+fn read_no_properties() {
+	crate::no_properties_test!("tests/files/assets/minimal/m4a_codec_aac.m4a");
+}
+
+#[test]
+fn read_no_tags() {
+	crate::no_tag_test!("tests/files/assets/minimal/m4a_codec_aac.m4a");
 }

--- a/lofty/tests/files/mpc.rs
+++ b/lofty/tests/files/mpc.rs
@@ -6,7 +6,7 @@ use lofty::prelude::*;
 use lofty::probe::Probe;
 use lofty::tag::TagType;
 
-use std::io::{Seek, Write};
+use std::io::Seek;
 
 // Marker test so IntelliJ Rust recognizes this as a test module
 #[test]
@@ -78,6 +78,16 @@ macro_rules! generate_tests {
 			#[test]
 			fn [<remove_ape_ $stream_version>]() {
 				crate::remove_tag!($path, TagType::Ape);
+			}
+
+			#[test]
+			fn [<read_no_properties_ $stream_version>]() {
+				crate::no_properties_test!($path);
+			}
+
+			#[test]
+			fn [<read_no_tags_ $stream_version>]() {
+				crate::no_tag_test!($path);
 			}
 		}
 	};

--- a/lofty/tests/files/mpeg.rs
+++ b/lofty/tests/files/mpeg.rs
@@ -8,7 +8,7 @@ use lofty::probe::Probe;
 use lofty::tag::{Tag, TagType};
 
 use std::borrow::Cow;
-use std::io::{Seek, Write};
+use std::io::Seek;
 
 #[test]
 fn read() {
@@ -368,4 +368,27 @@ fn read_and_write_tpil_frame() {
 	};
 
 	assert_eq!(key_value_pairs, content.key_value_pairs);
+}
+
+#[test]
+fn read_no_properties() {
+	let mut file = crate::temp_file!("tests/files/assets/minimal/full_test.mp3");
+	let tagged_file = Probe::new(&mut file)
+		.options(ParseOptions::new().read_properties(false))
+		.guess_file_type()
+		.unwrap()
+		.read()
+		.unwrap();
+	let properties = tagged_file.properties();
+	assert!(properties.duration().is_zero());
+	assert_eq!(properties.overall_bitrate(), Some(0));
+	assert_eq!(properties.audio_bitrate(), Some(0));
+	assert_eq!(properties.sample_rate(), Some(0));
+	assert!(properties.bit_depth().is_none());
+	assert_eq!(properties.channels(), Some(0));
+}
+
+#[test]
+fn read_no_tags() {
+	crate::no_tag_test!("tests/files/assets/minimal/full_test.mp3");
 }

--- a/lofty/tests/files/ogg.rs
+++ b/lofty/tests/files/ogg.rs
@@ -5,9 +5,9 @@ use lofty::prelude::*;
 use lofty::probe::Probe;
 use lofty::tag::TagType;
 
-use std::io::{Seek, Write};
+use std::io::Seek;
 
-// The tests for OGG Opus/Vorbis are nearly identical
+// The tests for OGG Opus/Vorbis/Speex are nearly identical
 // We have the vendor string and a title stored in the tag
 
 #[test]
@@ -185,4 +185,34 @@ fn flac_try_write_non_empty_id3v2() {
 			WriteOptions::default()
 		)
 		.is_err());
+}
+
+#[test]
+fn read_no_properties_opus() {
+	crate::no_properties_test!("tests/files/assets/minimal/full_test.opus");
+}
+
+#[test]
+fn read_no_tags_opus() {
+	crate::no_tag_test!(@MANDATORY_TAG "tests/files/assets/minimal/full_test.opus", expected_len: 1);
+}
+
+#[test]
+fn read_no_properties_vorbis() {
+	crate::no_properties_test!("tests/files/assets/minimal/full_test.ogg");
+}
+
+#[test]
+fn read_no_tags_vorbis() {
+	crate::no_tag_test!(@MANDATORY_TAG "tests/files/assets/minimal/full_test.ogg", expected_len: 1);
+}
+
+#[test]
+fn read_no_properties_speex() {
+	crate::no_properties_test!("tests/files/assets/minimal/full_test.spx");
+}
+
+#[test]
+fn read_no_tags_speex() {
+	crate::no_tag_test!(@MANDATORY_TAG "tests/files/assets/minimal/full_test.spx", expected_len: 1);
 }

--- a/lofty/tests/files/wav.rs
+++ b/lofty/tests/files/wav.rs
@@ -5,7 +5,7 @@ use lofty::prelude::*;
 use lofty::probe::Probe;
 use lofty::tag::TagType;
 
-use std::io::{Seek, Write};
+use std::io::Seek;
 
 #[test]
 fn read() {
@@ -84,4 +84,14 @@ fn issue_174_divide_by_zero() {
 	.unwrap();
 
 	assert_eq!(file.file_type(), FileType::Wav);
+}
+
+#[test]
+fn read_no_properties() {
+	crate::no_properties_test!("tests/files/assets/minimal/wav_format_pcm.wav");
+}
+
+#[test]
+fn read_no_tags() {
+	crate::no_tag_test!("tests/files/assets/minimal/wav_format_pcm.wav");
 }

--- a/lofty/tests/files/wavpack.rs
+++ b/lofty/tests/files/wavpack.rs
@@ -5,7 +5,7 @@ use lofty::prelude::*;
 use lofty::probe::Probe;
 use lofty::tag::TagType;
 
-use std::io::{Seek, Write};
+use std::io::Seek;
 
 #[test]
 fn read() {
@@ -66,4 +66,14 @@ fn remove_id3v1() {
 #[test]
 fn remove_ape() {
 	crate::remove_tag!("tests/files/assets/minimal/full_test.wv", TagType::Ape);
+}
+
+#[test]
+fn read_no_properties() {
+	crate::no_properties_test!("tests/files/assets/minimal/full_test.wv");
+}
+
+#[test]
+fn read_no_tags() {
+	crate::no_tag_test!("tests/files/assets/minimal/full_test.wv");
 }


### PR DESCRIPTION
This makes it possible to use Lofty exclusively for its property reading, which many projects do at this point.

closes #251