### PR TITLE
ID3v2: Support writing ID3v2.3 tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ParseOptions::read_tags` to skip the parsing of tags ([issue](https://github.com/Serial-ATA/lofty-rs/issues/251)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/406))
   - `ParseOptions::read_cover_art` ([issue](https://github.com/Serial-ATA/lofty-rs/issues/186)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/415))
     - As cover art can be large, it is now possible to disable reading it when parsing a file.
+  - `ParseOptions::implicit_conversions` to prevent automatic data conversions ([PR](https://github.com/Serial-ATA/lofty-rs/pull/411))
+    - Be sure to read the warnings in the docs to understand what this means.
+- **ID3v2**: Support writing ID3v2.3 tags ([issue](https://github.com/Serial-ATA/lofty-rs/issues/62)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/411))
+    - This can be done by setting `WriteOptions::use_id3v23` to `true`.
 
 ## [0.20.1] - 2024-07-02
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ ignored_unit_patterns 			   = "allow" # Not a fan of this lint, doesn't make any
 needless_return 				   = "allow" # Explicit returns are needed from time to time for clarity
 redundant_guards 				   = "allow" # Currently broken for some cases, might enable later
 into_iter_without_iter 		       = "allow" # This is only going to fire on some internal types, doesn't matter much
+struct_excessive_bools 		       = "allow" # I have yet to find one case of this being useful
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/lofty/src/ape/read.rs
+++ b/lofty/src/ape/read.rs
@@ -8,7 +8,7 @@ use crate::id3::v1::tag::Id3v1Tag;
 use crate::id3::v2::read::parse_id3v2;
 use crate::id3::v2::tag::Id3v2Tag;
 use crate::id3::{find_id3v1, find_id3v2, find_lyrics3v2, FindId3v2Config, ID3FindResults};
-use crate::macros::{decode_err, err};
+use crate::macros::decode_err;
 
 use std::io::{Read, Seek, SeekFrom};
 
@@ -82,7 +82,7 @@ where
 				})?;
 
 				if &remaining[..4] != b"AGEX" {
-					err!(FakeTag)
+					decode_err!(@BAIL Ape, "Found incomplete APE tag");
 				}
 
 				let ape_header = read_ape_header(data, false)?;

--- a/lofty/src/config/parse_options.rs
+++ b/lofty/src/config/parse_options.rs
@@ -7,6 +7,7 @@ pub struct ParseOptions {
 	pub(crate) parsing_mode: ParsingMode,
 	pub(crate) max_junk_bytes: usize,
 	pub(crate) read_cover_art: bool,
+	pub(crate) implicit_conversions: bool,
 }
 
 impl Default for ParseOptions {
@@ -21,6 +22,7 @@ impl Default for ParseOptions {
 	/// 	parsing_mode: ParsingMode::BestAttempt,
 	///     max_junk_bytes: 1024,
 	///     read_cover_art: true,
+	///     implicit_conversions: true,
 	/// }
 	/// ```
 	fn default() -> Self {
@@ -54,6 +56,7 @@ impl ParseOptions {
 			parsing_mode: Self::DEFAULT_PARSING_MODE,
 			max_junk_bytes: Self::DEFAULT_MAX_JUNK_BYTES,
 			read_cover_art: true,
+			implicit_conversions: true,
 		}
 	}
 
@@ -132,6 +135,31 @@ impl ParseOptions {
 	/// ```
 	pub fn read_cover_art(&mut self, read_cover_art: bool) -> Self {
 		self.read_cover_art = read_cover_art;
+		*self
+	}
+
+	/// Whether or not to perform implicit conversions
+	///
+	/// Implicit conversions are conversions that are not explicitly defined by the spec, but are commonly used.
+	///
+	/// ⚠ **Warning** ⚠
+	///
+	/// Turning this off may cause some [`Accessor`](crate::tag::Accessor) methods to return nothing.
+	/// Lofty makes some assumptions about the data, if they are broken, the caller will have more
+	/// responsibility.
+	///
+	/// Examples include:
+	///
+	/// * Converting the outdated MP4 `gnre` atom to a `©gen` atom
+	/// * Combining the ID3v2.3 `TYER`, `TDAT`, and `TIME` frames into a single `TDRC` frame
+	///
+	/// Examples of what this does *not* include:
+	///
+	/// * Converting a Vorbis `COVERART` field to `METADATA_BLOCK_PICTURE`
+	///   * This is a non-standard field, with a well-defined conversion. Lofty will not support
+	///     the non-standard `COVERART` for [`Picture`](crate::picture::Picture)s.
+	pub fn implicit_conversions(&mut self, implicit_conversions: bool) -> Self {
+		self.implicit_conversions = implicit_conversions;
 		*self
 	}
 }

--- a/lofty/src/config/write_options.rs
+++ b/lofty/src/config/write_options.rs
@@ -9,6 +9,7 @@ pub struct WriteOptions {
 	pub(crate) remove_others: bool,
 	pub(crate) respect_read_only: bool,
 	pub(crate) uppercase_id3v2_chunk: bool,
+	pub(crate) use_id3v23: bool,
 }
 
 impl WriteOptions {
@@ -32,6 +33,7 @@ impl WriteOptions {
 			remove_others: false,
 			respect_read_only: true,
 			uppercase_id3v2_chunk: true,
+			use_id3v23: false,
 		}
 	}
 
@@ -148,6 +150,33 @@ impl WriteOptions {
 		self.uppercase_id3v2_chunk = uppercase_id3v2_chunk;
 		self
 	}
+
+	/// Whether or not to use ID3v2.3 when saving [`TagType::Id3v2`](crate::tag::TagType::Id3v2)
+	/// or [`Id3v2Tag`](crate::id3::v2::Id3v2Tag)
+	///
+	/// By default, Lofty will save ID3v2.4 tags. This option allows you to save ID3v2.3 tags instead.
+	///
+	/// # Examples
+	///
+	/// ```rust,no_run
+	/// use lofty::config::WriteOptions;
+	/// use lofty::prelude::*;
+	/// use lofty::tag::{Tag, TagType};
+	///
+	/// # fn main() -> lofty::error::Result<()> {
+	/// let mut id3v2_tag = Tag::new(TagType::Id3v2);
+	///
+	/// // ...
+	///
+	/// // I need to save ID3v2.3 tags to support older software
+	/// let options = WriteOptions::new().use_id3v23(true);
+	/// id3v2_tag.save_to_path("test.mp3", options)?;
+	/// # Ok(()) }
+	/// ```
+	pub fn use_id3v23(&mut self, use_id3v23: bool) -> Self {
+		self.use_id3v23 = use_id3v23;
+		*self
+	}
 }
 
 impl Default for WriteOptions {
@@ -161,6 +190,7 @@ impl Default for WriteOptions {
 	///     remove_others: false,
 	///     respect_read_only: true,
 	///     uppercase_id3v2_chunk: true,
+	///     use_id3v23: false,
 	/// }
 	/// ```
 	fn default() -> Self {

--- a/lofty/src/id3/v2/frame/content.rs
+++ b/lofty/src/id3/v2/frame/content.rs
@@ -36,13 +36,13 @@ pub(super) fn parse_content<R: Read>(
 		"OWNE" => OwnershipFrame::parse(reader, flags)?.map(Frame::Ownership),
 		"ETCO" => EventTimingCodesFrame::parse(reader, flags)?.map(Frame::EventTimingCodes),
 		"PRIV" => PrivateFrame::parse(reader, flags)?.map(Frame::Private),
+		"TDEN" | "TDOR" | "TDRC" | "TDRL" | "TDTG" => TimestampFrame::parse(reader, id, flags, parse_mode)?.map(Frame::Timestamp),
 		i if i.starts_with('T') => TextInformationFrame::parse(reader, id, flags, version)?.map(Frame::Text),
 		// Apple proprietary frames
 		// WFED (Podcast URL), GRP1 (Grouping), MVNM (Movement Name), MVIN (Movement Number)
 		"WFED" | "GRP1" | "MVNM" | "MVIN" => TextInformationFrame::parse(reader, id, flags, version)?.map(Frame::Text),
 		i if i.starts_with('W') => UrlLinkFrame::parse(reader, id, flags)?.map(Frame::Url),
 		"POPM" => Some(Frame::Popularimeter(PopularimeterFrame::parse(reader, flags)?)),
-		"TDEN" | "TDOR" | "TDRC" | "TDRL" | "TDTG" => TimestampFrame::parse(reader, id, flags, parse_mode)?.map(Frame::Timestamp),
 		// SYLT, GEOB, and any unknown frames
 		_ => {
 			Some(Frame::Binary(BinaryFrame::parse(reader, id, flags)?))

--- a/lofty/src/id3/v2/frame/header/mod.rs
+++ b/lofty/src/id3/v2/frame/header/mod.rs
@@ -29,7 +29,7 @@ impl<'a> FrameHeader<'a> {
 	}
 
 	/// Get the ID of the frame
-	pub const fn id(&self) -> &FrameId<'a> {
+	pub const fn id(&'a self) -> &'a FrameId<'a> {
 		&self.id
 	}
 }

--- a/lofty/src/id3/v2/header.rs
+++ b/lofty/src/id3/v2/header.rs
@@ -40,6 +40,46 @@ pub struct Id3v2TagFlags {
 	pub restrictions: Option<TagRestrictions>,
 }
 
+impl Id3v2TagFlags {
+	/// Get the **ID3v2.4** byte representation of the flags
+	///
+	/// NOTE: This does not include the extended header flags
+	pub fn as_id3v24_byte(&self) -> u8 {
+		let mut byte = 0;
+
+		if self.unsynchronisation {
+			byte |= 0x80;
+		}
+
+		if self.experimental {
+			byte |= 0x20;
+		}
+
+		if self.footer {
+			byte |= 0x10;
+		}
+
+		byte
+	}
+
+	/// Get the **ID3v2.3** byte representation of the flags
+	///
+	/// NOTE: This does not include the extended header flags
+	pub fn as_id3v23_byte(&self) -> u8 {
+		let mut byte = 0;
+
+		if self.experimental {
+			byte |= 0x40;
+		}
+
+		if self.footer {
+			byte |= 0x10;
+		}
+
+		byte
+	}
+}
+
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct Id3v2Header {
 	pub version: Id3v2Version,

--- a/lofty/src/id3/v2/items/attached_picture_frame.rs
+++ b/lofty/src/id3/v2/items/attached_picture_frame.rs
@@ -135,7 +135,12 @@ impl<'a> AttachedPictureFrame<'a> {
 	///
 	/// * The mimetype is not [`MimeType::Png`] or [`MimeType::Jpeg`]
 	pub fn as_bytes(&self, version: Id3v2Version) -> Result<Vec<u8>> {
-		let mut data = vec![self.encoding as u8];
+		let mut encoding = self.encoding;
+		if version != Id3v2Version::V4 {
+			encoding = encoding.to_id3v23();
+		}
+
+		let mut data = vec![encoding as u8];
 
 		let max_size = match version {
 			// ID3v2.2 uses a 24-bit number for sizes
@@ -168,7 +173,7 @@ impl<'a> AttachedPictureFrame<'a> {
 		data.write_u8(self.picture.pic_type.as_u8())?;
 
 		match &self.picture.description {
-			Some(description) => data.write_all(&encode_text(description, self.encoding, true))?,
+			Some(description) => data.write_all(&encode_text(description, encoding, true))?,
 			None => data.write_u8(0)?,
 		}
 

--- a/lofty/src/id3/v2/items/extended_text_frame.rs
+++ b/lofty/src/id3/v2/items/extended_text_frame.rs
@@ -165,11 +165,16 @@ impl<'a> ExtendedTextFrame<'a> {
 	}
 
 	/// Convert an [`ExtendedTextFrame`] to a byte vec
-	pub fn as_bytes(&self) -> Vec<u8> {
-		let mut bytes = vec![self.encoding as u8];
+	pub fn as_bytes(&self, is_id3v23: bool) -> Vec<u8> {
+		let mut encoding = self.encoding;
+		if is_id3v23 {
+			encoding = encoding.to_id3v23();
+		}
 
-		bytes.extend(encode_text(&self.description, self.encoding, true).iter());
-		bytes.extend(encode_text(&self.content, self.encoding, false));
+		let mut bytes = vec![encoding as u8];
+
+		bytes.extend(encode_text(&self.description, encoding, true).iter());
+		bytes.extend(encode_text(&self.content, encoding, false));
 
 		bytes
 	}

--- a/lofty/src/id3/v2/items/extended_url_frame.rs
+++ b/lofty/src/id3/v2/items/extended_url_frame.rs
@@ -113,11 +113,16 @@ impl<'a> ExtendedUrlFrame<'a> {
 	}
 
 	/// Convert an [`ExtendedUrlFrame`] to a byte vec
-	pub fn as_bytes(&self) -> Vec<u8> {
-		let mut bytes = vec![self.encoding as u8];
+	pub fn as_bytes(&self, is_id3v23: bool) -> Vec<u8> {
+		let mut encoding = self.encoding;
+		if is_id3v23 {
+			encoding = encoding.to_id3v23();
+		}
 
-		bytes.extend(encode_text(&self.description, self.encoding, true).iter());
-		bytes.extend(encode_text(&self.content, self.encoding, false));
+		let mut bytes = vec![encoding as u8];
+
+		bytes.extend(encode_text(&self.description, encoding, true).iter());
+		bytes.extend(encode_text(&self.content, encoding, false));
 
 		bytes
 	}

--- a/lofty/src/id3/v2/items/key_value_frame.rs
+++ b/lofty/src/id3/v2/items/key_value_frame.rs
@@ -114,12 +114,17 @@ impl<'a> KeyValueFrame<'a> {
 	}
 
 	/// Convert a [`KeyValueFrame`] to a byte vec
-	pub fn as_bytes(&self) -> Vec<u8> {
-		let mut content = vec![self.encoding as u8];
+	pub fn as_bytes(&self, is_id3v23: bool) -> Vec<u8> {
+		let mut encoding = self.encoding;
+		if is_id3v23 {
+			encoding = encoding.to_id3v23();
+		}
+
+		let mut content = vec![encoding as u8];
 
 		for (key, value) in &self.key_value_pairs {
-			content.append(&mut encode_text(key, self.encoding, true));
-			content.append(&mut encode_text(value, self.encoding, true));
+			content.append(&mut encode_text(key, encoding, true));
+			content.append(&mut encode_text(value, encoding, true));
 		}
 		content
 	}

--- a/lofty/src/id3/v2/items/language_frame.rs
+++ b/lofty/src/id3/v2/items/language_frame.rs
@@ -51,11 +51,16 @@ impl LanguageFrame {
 	}
 
 	fn create_bytes(
-		encoding: TextEncoding,
+		mut encoding: TextEncoding,
 		language: [u8; 3],
 		description: &str,
 		content: &str,
+		is_id3v23: bool,
 	) -> Result<Vec<u8>> {
+		if is_id3v23 {
+			encoding = encoding.to_id3v23();
+		}
+
 		let mut bytes = vec![encoding as u8];
 
 		if language.len() != 3 || language.iter().any(|c| !c.is_ascii_alphabetic()) {
@@ -175,12 +180,13 @@ impl<'a> CommentFrame<'a> {
 	///
 	/// * `language` is not exactly 3 bytes
 	/// * `language` contains invalid characters (Only `'a'..='z'` and `'A'..='Z'` allowed)
-	pub fn as_bytes(&self) -> Result<Vec<u8>> {
+	pub fn as_bytes(&self, is_id3v23: bool) -> Result<Vec<u8>> {
 		LanguageFrame::create_bytes(
 			self.encoding,
 			self.language,
 			&self.description,
 			&self.content,
+			is_id3v23,
 		)
 	}
 }
@@ -290,12 +296,13 @@ impl<'a> UnsynchronizedTextFrame<'a> {
 	///
 	/// * `language` is not exactly 3 bytes
 	/// * `language` contains invalid characters (Only `'a'..='z'` and `'A'..='Z'` allowed)
-	pub fn as_bytes(&self) -> Result<Vec<u8>> {
+	pub fn as_bytes(&self, is_id3v23: bool) -> Result<Vec<u8>> {
 		LanguageFrame::create_bytes(
 			self.encoding,
 			self.language,
 			&self.description,
 			&self.content,
+			is_id3v23,
 		)
 	}
 }

--- a/lofty/src/id3/v2/items/ownership_frame.rs
+++ b/lofty/src/id3/v2/items/ownership_frame.rs
@@ -116,8 +116,13 @@ impl<'a> OwnershipFrame<'a> {
 	/// # Errors
 	///
 	/// * `date_of_purchase` is not at least 8 characters (it will be truncated if greater)
-	pub fn as_bytes(&self) -> Result<Vec<u8>> {
-		let mut bytes = vec![self.encoding as u8];
+	pub fn as_bytes(&self, is_id3v23: bool) -> Result<Vec<u8>> {
+		let mut encoding = self.encoding;
+		if is_id3v23 {
+			encoding = encoding.to_id3v23();
+		}
+
+		let mut bytes = vec![encoding as u8];
 
 		bytes.extend(encode_text(&self.price_paid, TextEncoding::Latin1, true));
 		if self.date_of_purchase.len() < 8 {
@@ -125,7 +130,7 @@ impl<'a> OwnershipFrame<'a> {
 		}
 
 		bytes.extend(self.date_of_purchase.as_bytes().iter().take(8));
-		bytes.extend(encode_text(&self.seller, self.encoding, false));
+		bytes.extend(encode_text(&self.seller, encoding, false));
 
 		Ok(bytes)
 	}
@@ -161,7 +166,7 @@ mod tests {
 
 	#[test]
 	fn owne_encode() {
-		let encoded = expected().as_bytes().unwrap();
+		let encoded = expected().as_bytes(false).unwrap();
 
 		let expected_bytes =
 			crate::tag::utils::test_utils::read_path("tests/tags/assets/id3v2/test.owne");

--- a/lofty/src/id3/v2/items/text_information_frame.rs
+++ b/lofty/src/id3/v2/items/text_information_frame.rs
@@ -93,10 +93,15 @@ impl<'a> TextInformationFrame<'a> {
 	}
 
 	/// Convert an [`TextInformationFrame`] to a byte vec
-	pub fn as_bytes(&self) -> Vec<u8> {
-		let mut content = encode_text(&self.value, self.encoding, false);
+	pub fn as_bytes(&self, is_id3v23: bool) -> Vec<u8> {
+		let mut encoding = self.encoding;
+		if is_id3v23 {
+			encoding = encoding.to_id3v23();
+		}
 
-		content.insert(0, self.encoding as u8);
+		let mut content = encode_text(&self.value, encoding, false);
+
+		content.insert(0, encoding as u8);
 		content
 	}
 }

--- a/lofty/src/id3/v2/items/timestamp_frame.rs
+++ b/lofty/src/id3/v2/items/timestamp_frame.rs
@@ -106,11 +106,16 @@ impl<'a> TimestampFrame<'a> {
 	///
 	/// * The timestamp is invalid
 	/// * Failure to write to the buffer
-	pub fn as_bytes(&self) -> Result<Vec<u8>> {
+	pub fn as_bytes(&self, is_id3v23: bool) -> Result<Vec<u8>> {
+		let mut encoding = self.encoding;
+		if is_id3v23 {
+			encoding = encoding.to_id3v23();
+		}
+
 		self.timestamp.verify()?;
 
-		let mut encoded_text = encode_text(&self.timestamp.to_string(), self.encoding, false);
-		encoded_text.insert(0, self.encoding as u8);
+		let mut encoded_text = encode_text(&self.timestamp.to_string(), encoding, false);
+		encoded_text.insert(0, encoding as u8);
 
 		Ok(encoded_text)
 	}

--- a/lofty/src/id3/v2/tag.rs
+++ b/lofty/src/id3/v2/tag.rs
@@ -20,9 +20,7 @@ use crate::mp4::AdvisoryRating;
 use crate::picture::{Picture, PictureType, TOMBSTONE_PICTURE};
 use crate::tag::companion_tag::CompanionTag;
 use crate::tag::items::{Lang, Timestamp, UNKNOWN_LANGUAGE};
-use crate::tag::{
-	try_parse_year, Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType,
-};
+use crate::tag::{Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType};
 use crate::util::flag_item;
 use crate::util::io::{FileLike, Length, Truncate};
 use crate::util::text::{decode_text, TextDecodeOptions, TextEncoding};
@@ -569,7 +567,7 @@ impl Id3v2Tag {
 	}
 }
 
-struct GenresIter<'a> {
+pub(crate) struct GenresIter<'a> {
 	value: &'a str,
 	pos: usize,
 }
@@ -817,9 +815,10 @@ impl Accessor for Id3v2Tag {
 	}
 
 	fn year(&self) -> Option<u32> {
-		if let Some(Frame::Text(TextInformationFrame { value, .. })) = self.get(&RECORDING_TIME_ID)
+		if let Some(Frame::Timestamp(TimestampFrame { timestamp, .. })) =
+			self.get(&RECORDING_TIME_ID)
 		{
-			return try_parse_year(value);
+			return Some(u32::from(timestamp.year));
 		}
 
 		None

--- a/lofty/src/util/text.rs
+++ b/lofty/src/util/text.rs
@@ -34,6 +34,22 @@ impl TextEncoding {
 	pub(crate) fn verify_latin1(text: &str) -> bool {
 		text.chars().all(|c| c as u32 <= 255)
 	}
+
+	/// ID3v2.4 introduced two new text encodings.
+	///
+	/// When writing ID3v2.3, we just substitute with UTF-16.
+	pub(crate) fn to_id3v23(self) -> Self {
+		match self {
+			Self::UTF8 | Self::UTF16BE => {
+				log::warn!(
+					"Text encoding {:?} is not supported in ID3v2.3, substituting with UTF-16",
+					self
+				);
+				Self::UTF16
+			},
+			_ => self,
+		}
+	}
 }
 
 #[derive(Eq, PartialEq, Debug)]


### PR DESCRIPTION
Using `WriteOptions::use_id3v23`, the caller now has the choice to write ID3v2.3 tags, which is necessary for older software.

closes #62