### PR TITLE
MPEG: Improve duration calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **MPEG**: Fix durations being slightly off ([issue](https://github.com/Serial-ATA/lofty-rs/issues/412)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/413))
+
 ## [0.20.0] - 2024-06-06
 
 ### Added

--- a/lofty/src/mpeg/read.rs
+++ b/lofty/src/mpeg/read.rs
@@ -194,7 +194,6 @@ where
 			last_frame_offset,
 			xing_header,
 			file_length,
-			parse_options.parsing_mode,
 		)?;
 	}
 


### PR DESCRIPTION
For files with a VBR header:
Thanks to @naglis for correcting the length calculation. (issue: #412)

For files without a VBR header:
`rev_search_for_frame_header` would get tripped up on files with trailing data
that looked like a frame sync (ex. 0xFFFF). This would also result in durations that are
slightly off.

For now, VBR streams are still assumed to be CBR. I have not seen a file this does not
work for yet. Eventually it would be nice to have more accurate calculation, but that will require we read the *entire* file.

closes #412