### PR TITLE
Add Tag::take_filter()

### DIFF
--- a/lofty/src/tag/item.rs
+++ b/lofty/src/tag/item.rs
@@ -828,16 +828,34 @@ impl TagItem {
 
 	/// Set a language for the [`TagItem`]
 	///
+	/// The default language is empty.
+	///
 	/// NOTE: This will not be reflected in most tag formats.
 	pub fn set_lang(&mut self, lang: Lang) {
 		self.lang = lang;
 	}
 
+	/// Returns a reference to the language of the [`TagItem`]
+	///
+	/// NOTE: This will not be reflected in most tag formats.
+	pub fn lang(&self) -> &Lang {
+		&self.lang
+	}
+
 	/// Set a description for the [`TagItem`]
+	///
+	/// The default description is empty.
 	///
 	/// NOTE: This will not be reflected in most tag formats.
 	pub fn set_description(&mut self, description: String) {
 		self.description = description;
+	}
+
+	/// Returns a reference to the description of the [`TagItem`]
+	///
+	/// NOTE: This will not be reflected in most tag formats.
+	pub fn description(&self) -> &str {
+		&self.description
 	}
 
 	/// Returns a reference to the [`ItemKey`]

--- a/lofty/src/tag/mod.rs
+++ b/lofty/src/tag/mod.rs
@@ -404,6 +404,8 @@ impl Tag {
 	}
 
 	/// Removes all items with the specified [`ItemKey`], and returns them
+	///
+	/// See also: [take_filter()](Self::take_filter)
 	pub fn take(&mut self, key: &ItemKey) -> impl Iterator<Item = TagItem> + '_ {
 		self.take_filter(key, |_| true)
 	}
@@ -411,6 +413,8 @@ impl Tag {
 	/// Removes selected items with the specified [`ItemKey`], and returns them
 	///
 	/// Only takes items for which `filter()` returns `true`. All other items are retained.
+	///
+	/// Returns the selected items in order and preserves the ordering of the remaining items.
 	///
 	/// # Examples
 	///


### PR DESCRIPTION
The behavior of the `take_string()` and other string accessor methods has changed in lofty v0.20.0. They now return values from all `TagItem`s, regardless of their description. This is unexpected for ID3v2 tags where the description is meaningful. Regular `TagItem`s usually have an empty description.

The new methods are needed to extract only regular `TagItem`s with an empty description from an ID3v2 tag. The example demonstrates how to achieve this for `ItemKey::Comment`.