### PR TITLE
ID3v2: Ignore empty timestamp frames

### DIFF
--- a/lofty/src/id3/v2/items/timestamp_frame.rs
+++ b/lofty/src/id3/v2/items/timestamp_frame.rs
@@ -96,7 +96,12 @@ impl<'a> TimestampFrame<'a> {
 
 		let reader = &mut value.as_bytes();
 
-		frame.timestamp = Timestamp::parse(reader, parse_mode)?;
+		let Some(timestamp) = Timestamp::parse(reader, parse_mode)? else {
+			// Timestamp is empty
+			return Ok(None);
+		};
+
+		frame.timestamp = timestamp;
 		Ok(Some(frame))
 	}
 


### PR DESCRIPTION
I had a file with an empty timestamp frame that errored with `ParsingMode::BestAttempt`. Now that's only an error case with `ParsingMode::Strict`.