### PR TITLE
Handle edge case for track() parsing

### DIFF
--- a/lofty/src/tag/mod.rs
+++ b/lofty/src/tag/mod.rs
@@ -138,8 +138,16 @@ impl Accessor for Tag {
 		Comment     => comment
 	);
 
+	// Some specifications, like IDv2, allow for the track value to be in the
+	// format of x/y, where x is the track position and y is the total number of
+	// tracks. This function only returns the track position and ignores the
+	// total number of tracks.
 	fn track(&self) -> Option<u32> {
-		self.get_u32_from_string(&ItemKey::TrackNumber)
+		let mut i = self.get_string(&ItemKey::TrackNumber)?;
+		if let Some(idx) = i.find('/') {
+			i = &i[..idx];
+		};
+		i.parse::<u32>().ok()
 	}
 
 	fn set_track(&mut self, value: u32) {

--- a/lofty/tests/files/mpeg.rs
+++ b/lofty/tests/files/mpeg.rs
@@ -211,6 +211,40 @@ fn save_number_of_track_and_disk_to_id3v2() {
 }
 
 #[test]
+fn track_edge_case_id3v2() {
+	let mut file = temp_file!("tests/files/assets/minimal/full_test.mp3");
+
+	let tagged_file = Probe::new(&mut file)
+		.options(ParseOptions::new().read_properties(false))
+		.guess_file_type()
+		.unwrap()
+		.read()
+		.unwrap();
+
+	assert_eq!(tagged_file.file_type(), FileType::Mpeg);
+
+	let mut tag = Tag::new(TagType::Id3v2);
+
+	tag.insert_text(ItemKey::TrackNumber, "22/33".to_string());
+
+	file.rewind().unwrap();
+	tag.save_to(&mut file, WriteOptions::default()).unwrap();
+
+	// Now reread the file
+	file.rewind().unwrap();
+	let tagged_file = Probe::new(&mut file)
+		.options(ParseOptions::new().read_properties(false))
+		.guess_file_type()
+		.unwrap()
+		.read()
+		.unwrap();
+
+	let tag = tagged_file.tag(TagType::Id3v2).unwrap();
+
+	assert_eq!(tag.track().unwrap(), 22);
+}
+
+#[test]
 fn test_bound_tagged_into_inner() {
 	let file = temp_file!("tests/files/assets/minimal/full_test.mp3");
 


### PR DESCRIPTION
Some audio files also include the total number of tracks in the 'track' tag. This should be ignored in the `track()` parsing. A test is added to verify the new behavior.