### PR TITLE
MP4: Allow invalid atom sizes with `ParsingMode::Relaxed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Timestamp**: `Timestamp::parse` with empty inputs will return `None` when not using `ParsingMode::Strict` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/416))
+- **MP4**: Atoms with sizes greater than the remaining file size will be ignored with `ParsingMode::Relaxed` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/433))
 
 ### Fixed
 - **Fuzzing** (Thanks [@qarmin](https://github.com/qarmin)!) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/TODO)):

--- a/lofty/src/mp4/atom_info.rs
+++ b/lofty/src/mp4/atom_info.rs
@@ -180,7 +180,14 @@ impl AtomInfo {
 
 		// `len` includes itself and the identifier
 		if (len - ATOM_HEADER_LEN) > reader_size {
-			data.seek(SeekFrom::Current(-4))?;
+			log::warn!("Encountered an atom with an invalid length, stopping");
+
+			if parse_mode == ParsingMode::Relaxed {
+				// Seek to the end, as we cannot gather anything else from the file
+				data.seek(SeekFrom::End(0))?;
+				return Ok(None);
+			}
+
 			err!(SizeMismatch);
 		}
 
@@ -203,6 +210,14 @@ impl AtomInfo {
 			extended,
 			ident: atom_ident,
 		}))
+	}
+
+	pub(crate) fn header_size(&self) -> u64 {
+		if !self.extended {
+			return ATOM_HEADER_LEN;
+		}
+
+		ATOM_HEADER_LEN + 8
 	}
 }
 


### PR DESCRIPTION
If an atom's size is greater than the remaining file size, we can just ignore it with `ParsingMode::Relaxed` and possibly continue as normal.