### PR TITLE
Fuzz: Make all targets build again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
 	"lofty",
 	"lofty_attr",
 	"ogg_pager",
+	"fuzz",
 ]
 
 [workspace.dependencies]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,10 +14,6 @@ libfuzzer-sys = "0.4"
 [dependencies.lofty]
 path = "../lofty"
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
-
 [[bin]]
 name = "filetype_from_buffer"
 path = "fuzz_targets/filetype_from_buffer.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,75 +17,113 @@ path = "../lofty"
 [[bin]]
 name = "filetype_from_buffer"
 path = "fuzz_targets/filetype_from_buffer.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "mpcfile_read_from"
 path = "fuzz_targets/mpcfile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "mpegfile_read_from"
 path = "fuzz_targets/mpegfile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "aacfile_read_from"
 path = "fuzz_targets/aacfile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "aifffile_read_from"
 path = "fuzz_targets/aifffile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "apefile_read_from"
 path = "fuzz_targets/apefile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "flacfile_read_from"
 path = "fuzz_targets/flacfile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "mp4file_read_from"
 path = "fuzz_targets/mp4file_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "opusfile_read_from"
 path = "fuzz_targets/opusfile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "vorbisfile_read_from"
 path = "fuzz_targets/vorbisfile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "speexfile_read_from"
 path = "fuzz_targets/speexfile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "wavfile_read_from"
 path = "fuzz_targets/wavfile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "wavpackfile_read_from"
 path = "fuzz_targets/wavpackfile_read_from.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "pictureinformation_from_jpeg"
 path = "fuzz_targets/pictureinformation_from_jpeg.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "pictureinformation_from_png"
 path = "fuzz_targets/pictureinformation_from_png.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "picture_from_reader"
 path = "fuzz_targets/picture_from_reader.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "picture_from_flac_bytes"
 path = "fuzz_targets/picture_from_flac_bytes.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "picture_from_ape_bytes"
 path = "fuzz_targets/picture_from_ape_bytes.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "probe_read"
 path = "fuzz_targets/probe_read.rs"
+test = false
+doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 
 [dependencies.lofty]
-path = ".."
+path = "../lofty"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/aacfile_read_from.rs
+++ b/fuzz/fuzz_targets/aacfile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::aac::AacFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/aifffile_read_from.rs
+++ b/fuzz/fuzz_targets/aifffile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::iff::aiff::AiffFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/apefile_read_from.rs
+++ b/fuzz/fuzz_targets/apefile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::ape::ApeFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/filetype_from_buffer.rs
+++ b/fuzz/fuzz_targets/filetype_from_buffer.rs
@@ -2,5 +2,5 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = lofty::FileType::from_buffer(data);
+	let _ = lofty::file::FileType::from_buffer(data);
 });

--- a/fuzz/fuzz_targets/flacfile_read_from.rs
+++ b/fuzz/fuzz_targets/flacfile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::flac::FlacFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/mp4file_read_from.rs
+++ b/fuzz/fuzz_targets/mp4file_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::mp4::Mp4File::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/mpcfile_read_from.rs
+++ b/fuzz/fuzz_targets/mpcfile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::musepack::MpcFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/mpegfile_read_from.rs
+++ b/fuzz/fuzz_targets/mpegfile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::mpeg::MpegFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/opusfile_read_from.rs
+++ b/fuzz/fuzz_targets/opusfile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::ogg::OpusFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/picture_from_ape_bytes.rs
+++ b/fuzz/fuzz_targets/picture_from_ape_bytes.rs
@@ -2,5 +2,5 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = lofty::Picture::from_ape_bytes("Cover Art (Front)", data);
+	let _ = lofty::picture::Picture::from_ape_bytes("Cover Art (Front)", data);
 });

--- a/fuzz/fuzz_targets/picture_from_flac_bytes.rs
+++ b/fuzz/fuzz_targets/picture_from_flac_bytes.rs
@@ -1,9 +1,9 @@
 #![no_main]
-use lofty::ParsingMode;
 
 use libfuzzer_sys::fuzz_target;
+use lofty::config::ParsingMode;
 
 fuzz_target!(|data: &[u8]| {
-	let _ = lofty::Picture::from_flac_bytes(data, true, ParsingMode::Relaxed);
-	let _ = lofty::Picture::from_flac_bytes(data, false, ParsingMode::Relaxed);
+	let _ = lofty::picture::Picture::from_flac_bytes(data, true, ParsingMode::Relaxed);
+	let _ = lofty::picture::Picture::from_flac_bytes(data, false, ParsingMode::Relaxed);
 });

--- a/fuzz/fuzz_targets/picture_from_reader.rs
+++ b/fuzz/fuzz_targets/picture_from_reader.rs
@@ -2,5 +2,5 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = lofty::Picture::from_reader(&mut &*data);
+	let _ = lofty::picture::Picture::from_reader(&mut &*data);
 });

--- a/fuzz/fuzz_targets/pictureinformation_from_jpeg.rs
+++ b/fuzz/fuzz_targets/pictureinformation_from_jpeg.rs
@@ -2,5 +2,5 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = lofty::PictureInformation::from_jpeg(data);
+	let _ = lofty::picture::PictureInformation::from_jpeg(data);
 });

--- a/fuzz/fuzz_targets/pictureinformation_from_png.rs
+++ b/fuzz/fuzz_targets/pictureinformation_from_png.rs
@@ -2,5 +2,5 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = lofty::PictureInformation::from_png(data);
+	let _ = lofty::picture::PictureInformation::from_png(data);
 });

--- a/fuzz/fuzz_targets/probe_read.rs
+++ b/fuzz/fuzz_targets/probe_read.rs
@@ -3,7 +3,7 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::Probe;
+use lofty::probe::Probe;
 
 fuzz_target!(|data: Vec<u8>| {
 	if let Ok(probe) = Probe::new(&mut Cursor::new(data)).guess_file_type() {

--- a/fuzz/fuzz_targets/speexfile_read_from.rs
+++ b/fuzz/fuzz_targets/speexfile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::ogg::SpeexFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/vorbisfile_read_from.rs
+++ b/fuzz/fuzz_targets/vorbisfile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::ogg::VorbisFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/wavfile_read_from.rs
+++ b/fuzz/fuzz_targets/wavfile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::iff::wav::WavFile::read_from(&mut Cursor::new(data), ParseOptions::new());

--- a/fuzz/fuzz_targets/wavpackfile_read_from.rs
+++ b/fuzz/fuzz_targets/wavpackfile_read_from.rs
@@ -3,7 +3,8 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
 	let _ = lofty::wavpack::WavPackFile::read_from(&mut Cursor::new(data), ParseOptions::new());


### PR DESCRIPTION
None of the fuzz targets have been touched in awhile, so they haven't been compiling for most of the year probably.

`lofty-fuzz` has been added to the workspace, so any future build failures should be caught by CI.