### PR TITLE
update url in tag_reader example to correct url to ItemKey

### DIFF
--- a/examples/tag_reader.rs
+++ b/examples/tag_reader.rs
@@ -32,7 +32,7 @@ fn main() {
 	println!("Album: {}", tag.album().as_deref().unwrap_or("None"));
 	println!("Genre: {}", tag.genre().as_deref().unwrap_or("None"));
 
-	// import keys from https://docs.rs/lofty/latest/lofty/enum.ItemKey.html
+	// import keys from https://docs.rs/lofty/latest/lofty/tag/enum.ItemKey.html
 	println!(
 		"Album Artist: {}",
 		tag.get_string(&ItemKey::AlbumArtist).unwrap_or("None")


### PR DESCRIPTION
I was just looking at your examples for a personal project of mine and saw that the URL to `ItemKey` was invalid