### PR TITLE
Fix references to ItemValue, Picture, and PictureType in ApeTag

### DIFF
--- a/lofty/src/ape/tag/mod.rs
+++ b/lofty/src/ape/tag/mod.rs
@@ -56,10 +56,10 @@ macro_rules! impl_accessor {
 /// ## Item storage
 ///
 /// `APE` isn't a very strict format. An [`ApeItem`] only restricted by its name, meaning it can use
-/// a normal [`ItemValue`](crate::ItemValue) unlike other formats.
+/// a normal [`ItemValue`](crate::tag::ItemValue) unlike other formats.
 ///
-/// Pictures are stored as [`ItemValue::Binary`](crate::ItemValue::Binary), and can be converted with
-/// [`Picture::from_ape_bytes`](crate::Picture::from_ape_bytes). For the appropriate item keys, see
+/// Pictures are stored as [`ItemValue::Binary`](crate::tag::ItemValue::Binary), and can be converted with
+/// [`Picture::from_ape_bytes`](crate::picture::Picture::from_ape_bytes). For the appropriate item keys, see
 /// [`APE_PICTURE_TYPES`](crate::ape::APE_PICTURE_TYPES).
 ///
 /// ## Conversions
@@ -70,7 +70,7 @@ macro_rules! impl_accessor {
 ///
 /// ### From `Tag`
 ///
-/// When converting pictures, any of type [`PictureType::Undefined`](crate::PictureType::Undefined) will be discarded.
+/// When converting pictures, any of type [`PictureType::Undefined`](crate::picture::PictureType::Undefined) will be discarded.
 /// For items, see [`ApeItem::new`].
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 #[tag(


### PR DESCRIPTION
I was looking around in the `ApeTag` documentation and found the following to be pointing to invalid locations: 

- `ItemValue`
- `ItemValue::Binary`
-  `Picture::from_ape_bytes`
-  `PictureType::Undefined` 

I updated them to point to the right locations and tested it on my machine. 
Feel free to let me know if any changes need to be made. :)

