### PR TITLE
Fix File Type References in Supported File Types Section in Tag Documentation

### DIFF
--- a/lofty/Cargo.toml
+++ b/lofty/Cargo.toml
@@ -18,7 +18,7 @@ byteorder     = { workspace = true }
 # ID3 compressed frames
 flate2        = { version = "1.0.30", optional = true }
 # Proc macros
-lofty_attr = "0.11.0"
+lofty_attr = { path = "../lofty_attr" }
 # Debug logging
 log           = "0.4.22"
 # OGG Vorbis/Opus

--- a/lofty_attr/src/lofty_tag.rs
+++ b/lofty_attr/src/lofty_tag.rs
@@ -17,11 +17,11 @@ impl SupportedFormat {
 	fn emit_doc_comment(&self) -> String {
 		match self {
 			SupportedFormat::Full(path) => format!(
-				"* [`FileType::{ft}`](crate::FileType::{ft})\n",
+				"* [`FileType::{ft}`](crate::file::FileType::{ft})\n",
 				ft = path.get_ident().unwrap()
 			),
 			SupportedFormat::ReadOnly(path) => format!(
-				"* [`FileType::{ft}`](crate::FileType::{ft}) **(READ ONLY)**\n",
+				"* [`FileType::{ft}`](crate::file::FileType::{ft}) **(READ ONLY)**\n",
 				ft = path.get_ident().unwrap()
 			),
 		}


### PR DESCRIPTION
This fixes #505

I went an implemented the fix suggested in the said issue.

I also changed referencing `lofty_attr` to use `path` instead of published version in `lofty`, 
If this is not wanted, I can easily revert it.

Let me know if this is good to go!