### PR TITLE
Add ext functions to file types

### DIFF
--- a/lofty/src/file/file_type.rs
+++ b/lofty/src/file/file_type.rs
@@ -99,33 +99,6 @@ impl FileType {
 		}
 	}
 
-	/// Returns the extension for the `FileType` if it is known
-	///
-	/// # Examples
-	///
-	/// ```rust
-	/// use lofty::file::FileType;
-	///
-	/// assert_eq!(FileType::Mpeg.ext(), Some("mp3"));
-	/// ```
-	pub fn ext(&self) -> Option<&str> {
-		match self {
-			FileType::Aac => Some("aac"),
-			FileType::Aiff => Some("aiff"),
-			FileType::Ape => Some("ape"),
-			FileType::Flac => Some("flac"),
-			FileType::Mpeg => Some("mp3"),
-			FileType::Mp4 => Some("mp4"),
-			FileType::Mpc => Some("mpc"),
-			FileType::Opus => Some("opus"),
-			FileType::Vorbis => Some("ogg"),
-			FileType::Speex => Some("spx"),
-			FileType::Wav => Some("wav"),
-			FileType::WavPack => Some("wv"),
-			FileType::Custom(_) => None,
-		}
-	}
-
 	/// Attempts to extract a [`FileType`] from an extension
 	///
 	/// # Examples

--- a/lofty/src/file/file_type.rs
+++ b/lofty/src/file/file_type.rs
@@ -99,6 +99,33 @@ impl FileType {
 		}
 	}
 
+	/// Returns the extension for the `FileType` if it is known
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use lofty::file::FileType;
+	///
+	/// assert_eq!(FileType::Mpeg.ext(), Some("mp3"));
+	/// ```
+	pub fn ext(&self) -> Option<&str> {
+		match self {
+			FileType::Aac => Some("aac"),
+			FileType::Aiff => Some("aiff"),
+			FileType::Ape => Some("ape"),
+			FileType::Flac => Some("flac"),
+			FileType::Mpeg => Some("mp3"),
+			FileType::Mp4 => Some("mp4"),
+			FileType::Mpc => Some("mpc"),
+			FileType::Opus => Some("opus"),
+			FileType::Vorbis => Some("ogg"),
+			FileType::Speex => Some("spx"),
+			FileType::Wav => Some("wav"),
+			FileType::WavPack => Some("wv"),
+			FileType::Custom(_) => None,
+		}
+	}
+
 	/// Attempts to extract a [`FileType`] from an extension
 	///
 	/// # Examples

--- a/lofty/src/picture.rs
+++ b/lofty/src/picture.rs
@@ -100,6 +100,26 @@ impl MimeType {
 			MimeType::Unknown(unknown) => unknown,
 		}
 	}
+
+	/// Returns the extension for the `MimeType` if it is known
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use lofty::picture::MimeType;
+	///
+	/// assert_eq!(MimeType::Jpeg.ext(), Some("jpg"));
+	/// ```
+	pub fn ext(&self) -> Option<&str> {
+		match self {
+			MimeType::Jpeg => Some("jpg"),
+			MimeType::Png => Some("png"),
+			MimeType::Tiff => Some("tif"),
+			MimeType::Bmp => Some("bmp"),
+			MimeType::Gif => Some("gif"),
+			MimeType::Unknown(_) => None,
+		}
+	}
 }
 
 impl Display for MimeType {


### PR DESCRIPTION
Adds two simple quality of life functions to `FileType` and `MimeType`.

```rust
FileType::Mpeg.ext(); // Some("mp3")
MimeType::Jpeg.ext(); // Some("jpg")
```

My use case is that I want to extract the pictures and save them separately to disk, so this saves me a manual pattern match on the extension of the file.