### PR TITLE
MP4: Demote missing mdat atom error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* **MP4**: A missing `mdat` atom is no longer a hard error when reading properties ([PR](https://github.com/Serial-ATA/lofty-rs/pull/515))
+  * This is now only an error in `Strict` mode. Note that any properties read in a file with no `mdat` atom are essentially useless.
+
 ## [0.22.3] - 2025-04-04
 
 ### Added


### PR DESCRIPTION
An MP4 file with no `mdat` atom is still a *valid* file, but reading its properties is useless. This is only a hard error in `ParsingMode::Strict` now.