### PR TITLE
WAV: Constrain writer to stream length not file length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * If a `free` atom claims to be larger than the remainder of the stream, parsing will simply stop. This will now only
       be a `SizeMismatch` error in `Strict` mode. Invalid padding is a common issue in all tag formats due to buggy software,
       so it's better to work around it by default rather than discard the entire stream as invalid.
+* **WAV**:
+  * When writing tags, the writer will be constrained to the stream size reported by the file, not by the file's actual length ([PR](https://github.com/Serial-ATA/lofty-rs/pull/517))
+    * Previously, tags were simply written to the end of the file, but this would break files that have junk data appended.
+    * This allows for files with appended junk data that falls outside of the stream length. This can be caused by buggy software
+      misusing padding.
 
 ## [0.22.3] - 2025-04-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ into_iter_without_iter 		       = "allow" # This is only going to fire on some i
 struct_excessive_bools 		       = "allow" # I have yet to find one case of this being useful
 needless_continue                  = "allow" # All occurences of this lint are just for clarity in large loops
 unbuffered_bytes                   = "allow" # It is up to the caller to wrap their data in `BufReader`s
+struct_field_names                 = "allow"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/lofty/src/id3/v2/write/chunk_file.rs
+++ b/lofty/src/id3/v2/write/chunk_file.rs
@@ -1,14 +1,16 @@
 use crate::config::WriteOptions;
 use crate::error::{LoftyError, Result};
 use crate::iff::chunk::Chunks;
+use crate::macros::err;
 use crate::util::io::{FileLike, Length, Truncate};
 
-use std::io::SeekFrom;
+use std::io::{Cursor, Seek, SeekFrom, Write};
 
 use byteorder::{ByteOrder, WriteBytesExt};
 
 const CHUNK_NAME_UPPER: [u8; 4] = [b'I', b'D', b'3', b' '];
 const CHUNK_NAME_LOWER: [u8; 4] = [b'i', b'd', b'3', b' '];
+const RIFF_CHUNK_HEADER_SIZE: usize = 8;
 
 pub(in crate::id3::v2) fn write_to_chunk_file<F, B>(
 	file: &mut F,
@@ -21,71 +23,93 @@ where
 	LoftyError: From<<F as Length>::Error>,
 	B: ByteOrder,
 {
-	// RIFF....WAVE
-	file.seek(SeekFrom::Current(12))?;
-
-	let file_len = file.len()?.saturating_sub(12);
-
-	let mut id3v2_chunk = (None, None);
+	// Only rely on the actual file for the first chunk read
+	let file_len = file.len()?;
 
 	let mut chunks = Chunks::<B>::new(file_len);
+	chunks.next(file)?;
 
-	while chunks.next(file).is_ok() {
+	let mut actual_stream_size = chunks.size;
+
+	file.rewind()?;
+
+	let mut file_bytes = Cursor::new(Vec::with_capacity(actual_stream_size as usize));
+	file.read_to_end(file_bytes.get_mut())?;
+
+	if file_bytes.get_ref().len() < (actual_stream_size as usize + RIFF_CHUNK_HEADER_SIZE) {
+		err!(SizeMismatch);
+	}
+
+	// The first chunk format is RIFF....WAVE
+	file_bytes.seek(SeekFrom::Start(12))?;
+
+	let (mut exising_id3_start, mut existing_id3_size) = (None, None);
+
+	let mut chunks = Chunks::<B>::new(u64::from(actual_stream_size));
+	while let Ok(true) = chunks.next(&mut file_bytes) {
 		if chunks.fourcc == CHUNK_NAME_UPPER || chunks.fourcc == CHUNK_NAME_LOWER {
-			id3v2_chunk = (Some(file.stream_position()? - 8), Some(chunks.size));
+			exising_id3_start = Some(file_bytes.stream_position()? - 8);
+			existing_id3_size = Some(chunks.size);
 			break;
 		}
 
-		file.seek(SeekFrom::Current(i64::from(chunks.size)))?;
-
-		chunks.correct_position(file)?;
+		chunks.skip(&mut file_bytes)?;
 	}
 
-	if let (Some(chunk_start), Some(mut chunk_size)) = id3v2_chunk {
-		file.rewind()?;
-
+	if let (Some(exising_id3_start), Some(mut existing_id3_size)) =
+		(exising_id3_start, existing_id3_size)
+	{
 		// We need to remove the padding byte if it exists
-		if chunk_size % 2 != 0 {
-			chunk_size += 1;
+		if existing_id3_size % 2 != 0 {
+			existing_id3_size += 1;
 		}
 
-		let mut file_bytes = Vec::new();
-		file.read_to_end(&mut file_bytes)?;
+		let existing_tag_end =
+			exising_id3_start as usize + RIFF_CHUNK_HEADER_SIZE + existing_id3_size as usize;
+		let _ = file_bytes
+			.get_mut()
+			.drain(exising_id3_start as usize..existing_tag_end);
 
-		file_bytes.splice(
-			chunk_start as usize..(chunk_start + u64::from(chunk_size) + 8) as usize,
-			[],
-		);
-
-		file.rewind()?;
-		file.truncate(0)?;
-		file.write_all(&file_bytes)?;
+		actual_stream_size -= existing_id3_size + RIFF_CHUNK_HEADER_SIZE as u32;
 	}
 
 	if !tag.is_empty() {
-		file.seek(SeekFrom::End(0))?;
-
+		let mut tag_bytes = Cursor::new(Vec::new());
 		if write_options.uppercase_id3v2_chunk {
-			file.write_all(&CHUNK_NAME_UPPER)?;
+			tag_bytes.write_all(&CHUNK_NAME_UPPER)?;
 		} else {
-			file.write_all(&CHUNK_NAME_LOWER)?;
+			tag_bytes.write_all(&CHUNK_NAME_LOWER)?;
 		}
 
-		file.write_u32::<B>(tag.len() as u32)?;
-		file.write_all(tag)?;
+		tag_bytes.write_u32::<B>(tag.len() as u32)?;
+		tag_bytes.write_all(tag)?;
 
 		// It is required an odd length chunk be padded with a 0
 		// The 0 isn't included in the chunk size, however
 		if tag.len() % 2 != 0 {
-			file.write_u8(0)?;
+			tag_bytes.write_u8(0)?;
 		}
 
-		let total_size = file.stream_position()? - 8;
+		let Ok(tag_size): std::result::Result<u32, _> = tag_bytes.get_ref().len().try_into() else {
+			err!(TooMuchData)
+		};
 
-		file.seek(SeekFrom::Start(4))?;
+		let tag_position = actual_stream_size as usize + RIFF_CHUNK_HEADER_SIZE;
 
-		file.write_u32::<B>(total_size as u32)?;
+		file_bytes.get_mut().splice(
+			tag_position..tag_position,
+			tag_bytes.get_ref().iter().copied(),
+		);
+
+		actual_stream_size += tag_size;
 	}
+
+	file_bytes.seek(SeekFrom::Start(4))?;
+	file_bytes.write_u32::<B>(actual_stream_size)?;
+
+	file.rewind()?;
+	file.truncate(0)?;
+	file.write_all(file_bytes.get_ref())?;
 
 	Ok(())
 }

--- a/lofty/src/iff/aiff/read.rs
+++ b/lofty/src/iff/aiff/read.rs
@@ -67,7 +67,7 @@ where
 
 	let mut chunks = Chunks::<BigEndian>::new(file_len);
 
-	while chunks.next(data).is_ok() {
+	while let Ok(true) = chunks.next(data) {
 		match &chunks.fourcc {
 			b"ID3 " | b"id3 " if parse_options.read_tags => {
 				let tag = chunks.id3_chunk(data, parse_options)?;

--- a/lofty/src/iff/aiff/tag.rs
+++ b/lofty/src/iff/aiff/tag.rs
@@ -436,7 +436,7 @@ where
 
 		let mut chunks = Chunks::<BigEndian>::new(file_len);
 
-		while chunks.next(file).is_ok() {
+		while let Ok(true) = chunks.next(file) {
 			match &chunks.fourcc {
 				b"NAME" | b"AUTH" | b"(c) " | b"ANNO" | b"COMT" => {
 					let start = (file.stream_position()? - 8) as usize;

--- a/lofty/src/iff/wav/mod.rs
+++ b/lofty/src/iff/wav/mod.rs
@@ -1,7 +1,7 @@
 //! WAV specific items
 
 mod properties;
-mod read;
+pub(crate) mod read;
 pub(crate) mod tag;
 
 use crate::id3::v2::tag::Id3v2Tag;

--- a/lofty/src/iff/wav/tag/read.rs
+++ b/lofty/src/iff/wav/tag/read.rs
@@ -19,7 +19,7 @@ pub(in crate::iff::wav) fn parse_riff_info<R>(
 where
 	R: Read + Seek,
 {
-	while data.stream_position()? != end && chunks.next(data).is_ok() {
+	while data.stream_position()? != end && matches!(chunks.next(data), Ok(true)) {
 		let key_str = utf8_decode_str(&chunks.fourcc)
 			.map_err(|_| decode_err!(Wav, "Invalid item key found in RIFF INFO"))?;
 


### PR DESCRIPTION
Previously, tags were simply written to the end of the file, but this would break files that have junk data appended.

This allows for files with appended junk data that falls outside of the stream length. This can be caused by buggy software misusing padding.