### PR TITLE
VorbisComments: Handle disc number field with current/total format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **ID3v2**: Check `TXXX:ALBUMARTIST` and `TXXX:ALBUM ARTIST` for `ItemKey::AlbumArtist` conversions
 - **Vorbis Comments**: Check `ALBUM ARTIST` for `ItemKey::AlbumArtist` conversions
+- **Vorbis Comments**: Support `DISCNUMBER` fields with the `current/total` format. ([issue](https://github.com/Serial-ATA/lofty-rs/issues/543)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/544))
+    - These fields will now properly be split into `DISCNUMBER` and `DISCTOTAL`, making it possible to use them with
+      [Accessor::disk()](https://docs.rs/lofty/latest/lofty/tag/trait.Accessor.html#method.disk) and [Accessor::disk_total()](https://docs.rs/lofty/latest/lofty/tag/trait.Accessor.html#method.disk_total).
 * **ItemKey**: `ItemKey` is now `Copy` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/526))
 
 ### Fixed

--- a/lofty/tests/taglib/test_flac.rs
+++ b/lofty/tests/taglib/test_flac.rs
@@ -296,8 +296,7 @@ fn test_properties() {
 	);
 	tag.push(String::from("COMMENT"), String::from("Comment"));
 	tag.push(String::from("DATE"), String::from("2021-01-10"));
-	tag.push(String::from("DISCNUMBER"), String::from("3"));
-	tag.push(String::from("DISCTOTAL"), String::from("5"));
+	tag.push(String::from("DISCNUMBER"), String::from("3/5"));
 	tag.push(String::from("GENRE"), String::from("Genre"));
 	tag.push(String::from("ISRC"), String::from("UKAAA0500001"));
 	tag.push(String::from("LABEL"), String::from("Label 1"));
@@ -356,7 +355,10 @@ fn test_properties() {
 	}
 	file.rewind().unwrap();
 	{
-		let f = FlacFile::read_from(&mut file, ParseOptions::new()).unwrap();
+		// <current>/<total> DISCNUMBER is a special case in Lofty, so disable implicit_conversions
+		// to match TagLib
+		let f = FlacFile::read_from(&mut file, ParseOptions::new().implicit_conversions(false))
+			.unwrap();
 
 		assert_eq!(f.vorbis_comments(), Some(&tag));
 	}

--- a/lofty/tests/taglib/test_flac.rs
+++ b/lofty/tests/taglib/test_flac.rs
@@ -296,7 +296,8 @@ fn test_properties() {
 	);
 	tag.push(String::from("COMMENT"), String::from("Comment"));
 	tag.push(String::from("DATE"), String::from("2021-01-10"));
-	tag.push(String::from("DISCNUMBER"), String::from("3/5"));
+	tag.push(String::from("DISCNUMBER"), String::from("3"));
+	tag.push(String::from("DISCTOTAL"), String::from("5"));
 	tag.push(String::from("GENRE"), String::from("Genre"));
 	tag.push(String::from("ISRC"), String::from("UKAAA0500001"));
 	tag.push(String::from("LABEL"), String::from("Label 1"));


### PR DESCRIPTION
It is nice working with you.
This is my second contribute to this project.

This PR handle disc `current/total` format in Vorbis Comments like how it handle track `current/total` format.

Should this be handle in a different match block please let me know :).

closes #543