### PR TITLE
fix: replace paste with maintained fork pastey

### DIFF
--- a/lofty/Cargo.toml
+++ b/lofty/Cargo.toml
@@ -25,7 +25,7 @@ log           = "0.4.22"
 # OGG Vorbis/Opus
 ogg_pager     = "0.7.0"
 # Key maps
-paste         = "1.0.15"
+paste         = { package = "pastey" , version = "0.1.1" }
 
 [features]
 default                   = ["id3v2_compression_support"]


### PR DESCRIPTION
As seen in [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436), [paste](https://github.com/dtolnay/paste) is no longer maintained and users should switch to [pastey](https://github.com/as1100k/pastey) instead.  
The authers of pastey suggested this change as it does not involve changing the source code. I can also change the source code instead if you want.