### PR TITLE
FileType: Distinguish read-only tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - These fields will now properly be split into `DISCNUMBER` and `DISCTOTAL`, making it possible to use them with
       [Accessor::disk()](https://docs.rs/lofty/latest/lofty/tag/trait.Accessor.html#method.disk) and [Accessor::disk_total()](https://docs.rs/lofty/latest/lofty/tag/trait.Accessor.html#method.disk_total).
 * **ItemKey**: `ItemKey` is now `Copy` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/526))
+* **FileType**: Replaced `FileType::supports_tag_type()` with `FileType::tag_support()` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/566))
+  * Rather than a simple `bool`, this now returns a `TagSupport`, which can describe three states: unsupported, read-only, and read/write
+* **TaggedFileExt**: Replaced `TaggedFileExt::supports_tag_type()` with `TaggedFileExt::tag_support()` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/566))
+* **FileResolver**: Replaced `FileResolver::supported_tag_types()` with `FileResolver::tag_support()` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/566))
 
 ### Fixed
 - **ID3v2**: Support parsing UTF-16 `COMM`/`USLT` frames with a single BOM ([issue](https://github.com/Serial-ATA/lofty-rs/issues/532)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/535))

--- a/examples/custom_resolver/src/main.rs
+++ b/examples/custom_resolver/src/main.rs
@@ -7,7 +7,7 @@ use lofty::file::FileType;
 use lofty::id3::v2::Id3v2Tag;
 use lofty::properties::FileProperties;
 use lofty::resolve::FileResolver;
-use lofty::tag::TagType;
+use lofty::tag::{TagSupport, TagType};
 use lofty_attr::LoftyFile;
 
 use std::fs::File;
@@ -73,8 +73,11 @@ impl FileResolver for MyFile {
 
 	// All of the `TagType`s this file supports, including the
 	// primary one.
-	fn supported_tag_types() -> &'static [TagType] {
-		&[TagType::Id3v2, TagType::Ape]
+	fn tag_support(tag_type: TagType) -> TagSupport {
+		match tag_type {
+			TagType::Id3v2 | TagType::Ape => TagSupport::ReadWrite,
+			_ => TagSupport::Unsupported,
+		}
 	}
 
 	// This is used to guess the `FileType` when reading the file contents.

--- a/lofty/tests/taglib/test_fileref.rs
+++ b/lofty/tests/taglib/test_fileref.rs
@@ -6,7 +6,7 @@ use lofty::config::{GlobalOptions, ParseOptions, WriteOptions};
 use lofty::error::{ErrorKind, LoftyError};
 use lofty::file::{AudioFile, FileType, TaggedFile, TaggedFileExt};
 use lofty::resolve::FileResolver;
-use lofty::tag::{Accessor, Tag, TagExt, TagType};
+use lofty::tag::{Accessor, Tag, TagExt, TagSupport, TagType};
 
 fn file_ref_save(path: &str, expected_file_type: FileType) {
 	let path = format!("tests/taglib/data/{path}");
@@ -273,7 +273,7 @@ rusty_fork_test! {
 				unimplemented!()
 			}
 
-			fn supported_tag_types() -> &'static [TagType] {
+			fn tag_support(_tag_type: TagType) -> TagSupport {
 				unimplemented!()
 			}
 


### PR DESCRIPTION
`TaggedFile::save_to()` would try to write *every* tag read, which would error if it contained a read-only tag, such as an ID3v2 tag in a FLAC file. Most users of `TaggedFile` aren't checking *all* tags in their files, nor should they need to.

This just makes `TaggedFile::save_to()` skip any tags that don't have write support for the target `FileType`.