### PR TITLE
Tests: Remove macros for file tests

### DIFF
--- a/doc/NEW_FILE.md
+++ b/doc/NEW_FILE.md
@@ -198,11 +198,11 @@ Then we'll store our tests in `tests/files/{format}.rs`.
 There is a simple suite of tests to go in that file:
 
 * `read()`: Read a file containing all possible tags (a Foo file with an ID3v2 *and* APE tag in this case), verifying
-  all expected information is present. This can be done quickly with the `crate::verify_artist!` macro.
-* `write()`: Change the artist field of each tag using the `crate::set_artist!` macro, which will verify the artist
+  all expected information is present. This can be done quickly with the `crate::verify_artist()` function.
+* `write()`: Change the artist field of each tag using the `crate::set_artist()` function, which will verify the artist
   and set a new one. Then, revert the artists using the same method.
 * `remove_{tag}()`: For each tag format the file supports, create a `remove_{tag}()` test that simply calls the
-  `crate::remove_tag!` macro. For example, this format would have `remove_ape()` and `remove_id3v2()`.
+  `crate::remove_tag_test()` function. For example, this format would have `remove_ape()` and `remove_id3v2()`.
 
 #### Fuzz Tests
 

--- a/lofty/tests/files/aac.rs
+++ b/lofty/tests/files/aac.rs
@@ -1,4 +1,3 @@
-use crate::{set_artist, temp_file, verify_artist};
 use lofty::config::ParseOptions;
 use lofty::file::FileType;
 use lofty::prelude::*;
@@ -19,10 +18,10 @@ fn read() {
 	assert_eq!(file.file_type(), FileType::Aac);
 
 	// Verify the ID3v2 tag first
-	crate::verify_artist!(file, primary_tag, "Foo artist", 1);
+	crate::util::verify_artist(&file, TagType::Id3v2, "Foo artist", 1);
 
 	// Now verify ID3v1
-	crate::verify_artist!(file, tag, TagType::Id3v1, "Bar artist", 1);
+	crate::util::verify_artist(&file, TagType::Id3v1, "Bar artist", 1);
 }
 
 #[test_log::test]
@@ -56,53 +55,71 @@ fn read_with_junk_bytes_between_frames() {
 
 #[test_log::test]
 fn write() {
-	let mut file = temp_file!("tests/files/assets/minimal/full_test.aac");
-
-	let mut tagged_file = Probe::new(&mut file)
-		.options(ParseOptions::new().read_properties(false))
-		.guess_file_type()
-		.unwrap()
-		.read()
-		.unwrap();
+	let mut tagged_file = crate::util::read("tests/files/assets/minimal/full_test.aac");
 
 	assert_eq!(tagged_file.file_type(), FileType::Aac);
 
 	// ID3v2
-	crate::set_artist!(tagged_file, primary_tag_mut, "Foo artist", 1 => file, "Bar artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Id3v2,
+		"Foo artist",
+		"Bar artist",
+		1,
+	);
 
 	// ID3v1
-	crate::set_artist!(tagged_file, tag_mut, TagType::Id3v1, "Bar artist", 1 => file, "Baz artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Id3v1,
+		"Bar artist",
+		"Baz artist",
+		1,
+	);
 
 	// Now reread the file
+	let mut file = tagged_file.into_inner();
 	file.rewind().unwrap();
 	let mut tagged_file = Probe::new(&mut file)
 		.options(ParseOptions::new().read_properties(false))
 		.guess_file_type()
 		.unwrap()
-		.read()
+		.read_bound()
 		.unwrap();
 
-	crate::set_artist!(tagged_file, primary_tag_mut, "Bar artist", 1 => file, "Foo artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Id3v2,
+		"Bar artist",
+		"Foo artist",
+		1,
+	);
 
-	crate::set_artist!(tagged_file, tag_mut, TagType::Id3v1, "Baz artist", 1 => file, "Bar artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Id3v1,
+		"Baz artist",
+		"Bar artist",
+		1,
+	);
 }
 
 #[test_log::test]
 fn remove_id3v2() {
-	crate::remove_tag!("tests/files/assets/minimal/full_test.aac", TagType::Id3v2);
+	crate::util::remove_tag_test("tests/files/assets/minimal/full_test.aac", TagType::Id3v2);
 }
 
 #[test_log::test]
 fn remove_id3v1() {
-	crate::remove_tag!("tests/files/assets/minimal/full_test.aac", TagType::Id3v1);
+	crate::util::remove_tag_test("tests/files/assets/minimal/full_test.aac", TagType::Id3v1);
 }
 
 #[test_log::test]
 fn read_no_properties() {
-	crate::no_properties_test!("tests/files/assets/minimal/full_test.aac");
+	crate::util::no_properties_test("tests/files/assets/minimal/full_test.aac");
 }
 
 #[test_log::test]
 fn read_no_tags() {
-	crate::no_tag_test!("tests/files/assets/minimal/full_test.aac");
+	crate::util::no_tag_test("tests/files/assets/minimal/full_test.aac", None);
 }

--- a/lofty/tests/files/ape.rs
+++ b/lofty/tests/files/ape.rs
@@ -1,4 +1,3 @@
-use crate::{set_artist, temp_file, verify_artist};
 use lofty::config::ParseOptions;
 use lofty::file::FileType;
 use lofty::prelude::*;
@@ -19,70 +18,89 @@ fn read() {
 	assert_eq!(file.file_type(), FileType::Ape);
 
 	// Verify the APEv2 tag first
-	crate::verify_artist!(file, primary_tag, "Foo artist", 1);
+	crate::util::verify_artist(&file, TagType::Ape, "Foo artist", 1);
 
 	// Now verify ID3v1
-	crate::verify_artist!(file, tag, TagType::Id3v1, "Bar artist", 1);
+	crate::util::verify_artist(&file, TagType::Id3v1, "Bar artist", 1);
 
 	// Finally, verify ID3v2
-	crate::verify_artist!(file, tag, TagType::Id3v2, "Baz artist", 1);
+	crate::util::verify_artist(&file, TagType::Id3v2, "Baz artist", 1);
 }
 
 #[test_log::test]
 fn write() {
 	// We don't write an ID3v2 tag here since it's against the spec
-	let mut file = temp_file!("tests/files/assets/minimal/full_test.ape");
-
-	let mut tagged_file = Probe::new(&mut file)
-		.options(ParseOptions::new().read_properties(false))
-		.guess_file_type()
-		.unwrap()
-		.read()
-		.unwrap();
+	let mut tagged_file = crate::util::read("tests/files/assets/minimal/full_test.ape");
 
 	assert_eq!(tagged_file.file_type(), FileType::Ape);
 
 	// APEv2
-	crate::set_artist!(tagged_file, primary_tag_mut, "Foo artist", 1 => file, "Bar artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Ape,
+		"Foo artist",
+		"Bar artist",
+		1,
+	);
 
 	// ID3v1
-	crate::set_artist!(tagged_file, tag_mut, TagType::Id3v1, "Bar artist", 1 => file, "Baz artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Id3v1,
+		"Bar artist",
+		"Baz artist",
+		1,
+	);
 
 	// Now reread the file
+	let mut file = tagged_file.into_inner();
 	file.rewind().unwrap();
+
 	let mut tagged_file = Probe::new(&mut file)
 		.options(ParseOptions::new().read_properties(false))
 		.guess_file_type()
 		.unwrap()
-		.read()
+		.read_bound()
 		.unwrap();
 
-	crate::set_artist!(tagged_file, primary_tag_mut, "Bar artist", 1 => file, "Foo artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Ape,
+		"Bar artist",
+		"Foo artist",
+		1,
+	);
 
-	crate::set_artist!(tagged_file, tag_mut, TagType::Id3v1, "Baz artist", 1 => file, "Bar artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Id3v1,
+		"Baz artist",
+		"Bar artist",
+		1,
+	);
 }
 
 #[test_log::test]
 fn remove_ape() {
-	crate::remove_tag!("tests/files/assets/minimal/full_test.ape", TagType::Ape);
+	crate::util::remove_tag_test("tests/files/assets/minimal/full_test.ape", TagType::Ape);
 }
 
 #[test_log::test]
 fn remove_id3v1() {
-	crate::remove_tag!("tests/files/assets/minimal/full_test.ape", TagType::Id3v1);
+	crate::util::remove_tag_test("tests/files/assets/minimal/full_test.ape", TagType::Id3v1);
 }
 
 #[test_log::test]
 fn remove_id3v2() {
-	crate::remove_tag!("tests/files/assets/minimal/full_test.ape", TagType::Id3v2);
+	crate::util::remove_tag_test("tests/files/assets/minimal/full_test.ape", TagType::Id3v2);
 }
 
 #[test_log::test]
 fn read_no_properties() {
-	crate::no_properties_test!("tests/files/assets/minimal/full_test.ape");
+	crate::util::no_properties_test("tests/files/assets/minimal/full_test.ape");
 }
 
 #[test_log::test]
 fn read_no_tags() {
-	crate::no_tag_test!("tests/files/assets/minimal/full_test.ape");
+	crate::util::no_tag_test("tests/files/assets/minimal/full_test.ape", None);
 }

--- a/lofty/tests/files/flac.rs
+++ b/lofty/tests/files/flac.rs
@@ -1,4 +1,4 @@
-use crate::temp_file;
+use crate::util::temp_file;
 
 use std::fs::File;
 use std::io::Seek;
@@ -38,17 +38,17 @@ fn multiple_vorbis_comments() {
 
 #[test_log::test]
 fn read_no_properties() {
-	crate::no_properties_test!("tests/files/assets/minimal/full_test.flac");
+	crate::util::no_properties_test("tests/files/assets/minimal/full_test.flac");
 }
 
 #[test_log::test]
 fn read_no_tags() {
-	crate::no_tag_test!("tests/files/assets/minimal/full_test.flac");
+	crate::util::no_tag_test("tests/files/assets/minimal/full_test.flac", None);
 }
 
 #[test_log::test]
 fn retain_vendor_string() {
-	let mut file = temp_file!("tests/files/assets/minimal/full_test.flac");
+	let mut file = temp_file("tests/files/assets/minimal/full_test.flac");
 
 	let f = FlacFile::read_from(&mut file, ParseOptions::new()).unwrap();
 	file.rewind().unwrap();

--- a/lofty/tests/files/mp4.rs
+++ b/lofty/tests/files/mp4.rs
@@ -1,4 +1,3 @@
-use crate::{set_artist, temp_file, verify_artist};
 use lofty::config::ParseOptions;
 use lofty::file::FileType;
 use lofty::prelude::*;
@@ -19,52 +18,58 @@ fn read() {
 	assert_eq!(file.file_type(), FileType::Mp4);
 
 	// Verify the ilst tag
-	crate::verify_artist!(file, primary_tag, "Foo artist", 1);
+	crate::util::verify_artist(&file, TagType::Mp4Ilst, "Foo artist", 1);
 }
 
 #[test_log::test]
 fn write() {
-	let mut file = temp_file!("tests/files/assets/minimal/m4a_codec_aac.m4a");
-
-	let mut tagged_file = Probe::new(&mut file)
-		.options(ParseOptions::new().read_properties(false))
-		.guess_file_type()
-		.unwrap()
-		.read()
-		.unwrap();
+	let mut tagged_file = crate::util::read("tests/files/assets/minimal/m4a_codec_aac.m4a");
 
 	assert_eq!(tagged_file.file_type(), FileType::Mp4);
 
 	// ilst
-	crate::set_artist!(tagged_file, tag_mut, TagType::Mp4Ilst, "Foo artist", 1 => file, "Bar artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Mp4Ilst,
+		"Foo artist",
+		"Bar artist",
+		1,
+	);
 
 	// Now reread the file
+	let mut file = tagged_file.into_inner();
 	file.rewind().unwrap();
 
 	let mut tagged_file = Probe::new(&mut file)
 		.options(ParseOptions::new().read_properties(false))
 		.guess_file_type()
 		.unwrap()
-		.read()
+		.read_bound()
 		.unwrap();
 
-	crate::set_artist!(tagged_file, tag_mut, TagType::Mp4Ilst, "Bar artist", 1 => file, "Foo artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Mp4Ilst,
+		"Bar artist",
+		"Foo artist",
+		1,
+	);
 }
 
 #[test_log::test]
 fn remove() {
-	crate::remove_tag!(
+	crate::util::remove_tag_test(
 		"tests/files/assets/minimal/m4a_codec_aac.m4a",
-		TagType::Mp4Ilst
+		TagType::Mp4Ilst,
 	);
 }
 
 #[test_log::test]
 fn read_no_properties() {
-	crate::no_properties_test!("tests/files/assets/minimal/m4a_codec_aac.m4a");
+	crate::util::no_properties_test("tests/files/assets/minimal/m4a_codec_aac.m4a");
 }
 
 #[test_log::test]
 fn read_no_tags() {
-	crate::no_tag_test!("tests/files/assets/minimal/m4a_codec_aac.m4a");
+	crate::util::no_tag_test("tests/files/assets/minimal/m4a_codec_aac.m4a", None);
 }

--- a/lofty/tests/files/util/mod.rs
+++ b/lofty/tests/files/util/mod.rs
@@ -1,148 +1,156 @@
-#[macro_export]
-macro_rules! temp_file {
-	($path:tt) => {{
-		use std::io::Write as _;
+use lofty::config::{ParseOptions, WriteOptions};
+use lofty::error::LoftyError;
+use lofty::file::{AudioFile, BoundTaggedFile, TaggedFileExt};
+use lofty::io::{FileLike, Length, Truncate};
+use lofty::probe::Probe;
+use lofty::tag::{ItemKey, TagExt, TagType};
+use std::fs::File;
+use std::io::{Seek as _, Write as _};
+use std::path::Path;
 
-		let mut file = tempfile::tempfile().unwrap();
-		file.write_all(&std::fs::read($path).unwrap()).unwrap();
+/// Create a new temporary file and copy the contents of `path` into it
+pub fn temp_file(path: impl AsRef<Path>) -> File {
+	let content = std::fs::read(path).unwrap();
 
-		file.rewind().unwrap();
+	let mut file = tempfile::tempfile().unwrap();
+	file.write_all(&content).unwrap();
+	file.rewind().unwrap();
 
-		file
-	}};
+	file
 }
 
-#[macro_export]
-macro_rules! no_tag_test {
-	($path:literal) => {{
-		let mut file = $crate::temp_file!($path);
-		let tagged_file = lofty::probe::Probe::new(&mut file)
-			.options(lofty::config::ParseOptions::new().read_tags(false))
-			.guess_file_type()
-			.unwrap()
-			.read()
-			.unwrap();
+/// Copy `path` into a [`temp_file()`] and parse it via [`Probe`]
+pub fn read(path: impl AsRef<Path>) -> BoundTaggedFile<File> {
+	let file = temp_file(path);
+	let tagged_file = Probe::new(file)
+		.options(ParseOptions::new())
+		.guess_file_type()
+		.unwrap()
+		.read_bound()
+		.unwrap();
+
+	tagged_file
+}
+
+/// Verify that the file at `path` has no tags
+///
+/// Some formats (like Opus) *require* a tag, so `expected_len` can be used to check that the tag has
+/// the bare minimum number of values.
+pub fn no_tag_test(path: impl AsRef<Path>, expected_len: Option<usize>) {
+	let mut file = temp_file(path);
+	let tagged_file = Probe::new(&mut file)
+		.options(ParseOptions::new().read_tags(false))
+		.guess_file_type()
+		.unwrap()
+		.read()
+		.unwrap();
+
+	let Some(expected_len) = expected_len else {
 		assert!(!tagged_file.contains_tag());
-	}};
-	(@MANDATORY_TAG $path:literal, expected_len: $expected_len:literal) => {{
-		use lofty::tag::TagExt as _;
+		return;
+	};
 
-		let mut file = $crate::temp_file!($path);
-		let tagged_file = lofty::probe::Probe::new(&mut file)
-			.options(lofty::config::ParseOptions::new().read_tags(false))
-			.guess_file_type()
-			.unwrap()
-			.read()
-			.unwrap();
-		for tag in tagged_file.tags() {
-			assert_eq!(tag.len(), $expected_len);
-		}
-	}};
+	for tag in tagged_file.tags() {
+		assert_eq!(tag.len(), expected_len);
+	}
 }
 
-#[macro_export]
-macro_rules! no_properties_test {
-	($path:literal) => {{
-		let mut file = $crate::temp_file!($path);
-		let tagged_file = lofty::probe::Probe::new(&mut file)
-			.options(lofty::config::ParseOptions::new().read_properties(false))
-			.guess_file_type()
-			.unwrap()
-			.read()
-			.unwrap();
-		assert!(tagged_file.properties().is_empty());
-	}};
+/// Verify that no audio properties are read when requested
+pub fn no_properties_test(path: impl AsRef<Path>) {
+	let mut file = temp_file(path);
+	let tagged_file = Probe::new(&mut file)
+		.options(ParseOptions::new().read_properties(false))
+		.guess_file_type()
+		.unwrap()
+		.read()
+		.unwrap();
+	assert!(tagged_file.properties().is_empty());
 }
 
-#[macro_export]
-macro_rules! verify_artist {
-	($file:ident, $method:ident, $expected_value:literal, $item_count:expr) => {{
-		println!("VERIFY: Expecting `{}` to have {} items, with an artist of \"{}\"", stringify!($method), $item_count, $expected_value);
+/// Verify that the tag of type `tag_type` has an [`ItemKey::TrackArtist`] of `expected_value`
+///
+/// Also verifies that the tag has exactly `expected_item_count` items
+pub fn verify_artist(
+	file: &impl TaggedFileExt,
+	tag_type: TagType,
+	expected_value: &str,
+	expected_item_count: u32,
+) {
+	println!(
+		"VERIFY: Expecting `{tag_type:?}` to have {expected_item_count} items, with an artist of \
+		 \"{expected_value}\""
+	);
 
-		verify_artist!($file, $method(), $expected_value, $item_count)
-	}};
-	($file:ident, $method:ident, $arg:path, $expected_value:literal, $item_count:expr) => {{
-		println!("VERIFY: Expecting `{}` to have {} items, with an artist of \"{}\"", stringify!($arg), $item_count, $expected_value);
+	assert!(file.tag(tag_type).is_some());
 
-		verify_artist!($file, $method($arg), $expected_value, $item_count)
-	}};
-	($file:ident, $method:ident($($arg:path)?), $expected_value:literal, $item_count:expr) => {{
-		assert!($file.$method($($arg)?).is_some());
+	let tag = file.tag(tag_type).unwrap();
 
-		let tag = $file.$method($($arg)?).unwrap();
+	assert_eq!(tag.item_count(), expected_item_count);
 
-		assert_eq!(tag.item_count(), $item_count);
-
-		assert_eq!(
-			tag.get(lofty::prelude::ItemKey::TrackArtist),
-			Some(&lofty::tag::TagItem::new(
-				lofty::prelude::ItemKey::TrackArtist,
-				lofty::tag::ItemValue::Text(String::from($expected_value))
-			))
-		);
-
-		tag
-	}};
+	assert_eq!(
+		tag.get(ItemKey::TrackArtist),
+		Some(&lofty::tag::TagItem::new(
+			ItemKey::TrackArtist,
+			lofty::tag::ItemValue::Text(String::from(expected_value))
+		))
+	);
 }
 
-#[macro_export]
-macro_rules! set_artist {
-	($tagged_file:ident, $method:ident, $expected_value:literal, $item_count:expr => $file_write:ident, $new_value:literal) => {
-		let tag = verify_artist!($tagged_file, $method, $expected_value, $item_count);
-		println!(
-			"WRITE: Writing artist \"{}\" to {}\n",
-			$new_value,
-			stringify!($method)
-		);
-		set_artist!($file_write, $new_value, tag)
-	};
-	($tagged_file:ident, $method:ident, $arg:path, $expected_value:literal, $item_count:expr => $file_write:ident, $new_value:literal) => {
-		let tag = verify_artist!($tagged_file, $method, $arg, $expected_value, $item_count);
-		println!(
-			"WRITE: Writing artist \"{}\" to {}\n",
-			$new_value,
-			stringify!($arg)
-		);
-		set_artist!($file_write, $new_value, tag)
-	};
-	($file_write:ident, $new_value:literal, $tag:ident) => {
-		$tag.insert_unchecked(lofty::tag::TagItem::new(
-			lofty::prelude::ItemKey::TrackArtist,
-			lofty::tag::ItemValue::Text(String::from($new_value)),
-		));
+/// This will:
+///
+/// * Verify that the tag of type `tag_type` has an artist of `expected_value`
+/// * Set the artist to `new_value`
+/// * Write the tag back to the file
+pub fn set_artist<F: FileLike>(
+	tagged_file: &mut BoundTaggedFile<F>,
+	tag_type: TagType,
+	expected_value: &str,
+	new_value: &str,
+	expected_item_count: u32,
+) where
+	LoftyError: From<<F as Truncate>::Error>,
+	LoftyError: From<<F as Length>::Error>,
+{
+	verify_artist(tagged_file, tag_type, expected_value, expected_item_count);
+	println!("WRITE: Writing artist \"{new_value}\" to {tag_type:?}\n",);
 
-		$file_write.rewind().unwrap();
+	let tag = tagged_file.tag_mut(tag_type).unwrap();
 
-		$tag.save_to(&mut $file_write, lofty::config::WriteOptions::default())
-			.unwrap();
-	};
+	tag.insert_unchecked(lofty::tag::TagItem::new(
+		ItemKey::TrackArtist,
+		lofty::tag::ItemValue::Text(String::from(new_value)),
+	));
+
+	tagged_file.save(WriteOptions::default()).unwrap();
 }
 
-#[macro_export]
-macro_rules! remove_tag {
-	($path:tt, $tag_type:path) => {
-		let mut file = temp_file!($path);
+/// Test tag removal
+///
+/// 1. Reads the file at `path`
+/// 2. Removes the tag of type `tag_type`
+/// 3. Re-reads, verifying the tag is removed
+pub fn remove_tag_test(path: impl AsRef<Path>, tag_type: TagType) {
+	let mut file = temp_file(path);
 
-		let tagged_file = lofty::probe::Probe::new(&mut file)
-			.options(lofty::config::ParseOptions::new().read_properties(false))
-			.guess_file_type()
-			.unwrap()
-			.read()
-			.unwrap();
-		assert!(tagged_file.tag($tag_type).is_some());
+	let tagged_file = Probe::new(&mut file)
+		.options(ParseOptions::new().read_properties(false))
+		.guess_file_type()
+		.unwrap()
+		.read()
+		.unwrap();
+	assert!(tagged_file.tag(tag_type).is_some());
 
-		file.rewind().unwrap();
+	file.rewind().unwrap();
 
-		$tag_type.remove_from(&mut file).unwrap();
+	tag_type.remove_from(&mut file).unwrap();
 
-		file.rewind().unwrap();
+	file.rewind().unwrap();
 
-		let tagged_file = lofty::probe::Probe::new(&mut file)
-			.options(lofty::config::ParseOptions::new().read_properties(false))
-			.guess_file_type()
-			.unwrap()
-			.read()
-			.unwrap();
-		assert!(tagged_file.tag($tag_type).is_none());
-	};
+	let tagged_file = Probe::new(&mut file)
+		.options(ParseOptions::new().read_properties(false))
+		.guess_file_type()
+		.unwrap()
+		.read()
+		.unwrap();
+	assert!(tagged_file.tag(tag_type).is_none());
 }

--- a/lofty/tests/files/wav.rs
+++ b/lofty/tests/files/wav.rs
@@ -1,4 +1,3 @@
-use crate::{set_artist, temp_file, verify_artist};
 use lofty::config::ParseOptions;
 use lofty::file::FileType;
 use lofty::prelude::*;
@@ -19,58 +18,77 @@ fn read() {
 	assert_eq!(file.file_type(), FileType::Wav);
 
 	// Verify the ID3v2 tag first
-	crate::verify_artist!(file, primary_tag, "Foo artist", 1);
+	crate::util::verify_artist(&file, TagType::Id3v2, "Foo artist", 1);
 
 	// Now verify the RIFF INFO chunk
-	crate::verify_artist!(file, tag, TagType::RiffInfo, "Bar artist", 1);
+	crate::util::verify_artist(&file, TagType::RiffInfo, "Bar artist", 1);
 }
 
 #[test_log::test]
 fn write() {
-	let mut file = temp_file!("tests/files/assets/minimal/wav_format_pcm.wav");
-
-	let mut tagged_file = Probe::new(&mut file)
-		.options(ParseOptions::new().read_properties(false))
-		.guess_file_type()
-		.unwrap()
-		.read()
-		.unwrap();
+	let mut tagged_file = crate::util::read("tests/files/assets/minimal/wav_format_pcm.wav");
 
 	assert_eq!(tagged_file.file_type(), FileType::Wav);
 
 	// ID3v2
-	crate::set_artist!(tagged_file, primary_tag_mut, "Foo artist", 1 => file, "Bar artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Id3v2,
+		"Foo artist",
+		"Bar artist",
+		1,
+	);
 
 	// RIFF INFO
-	crate::set_artist!(tagged_file, tag_mut, TagType::RiffInfo, "Bar artist", 1 => file, "Baz artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::RiffInfo,
+		"Bar artist",
+		"Baz artist",
+		1,
+	);
 
 	// Now reread the file
+	let mut file = tagged_file.into_inner();
 	file.rewind().unwrap();
+
 	let mut tagged_file = Probe::new(&mut file)
 		.options(ParseOptions::new().read_properties(false))
 		.guess_file_type()
 		.unwrap()
-		.read()
+		.read_bound()
 		.unwrap();
 
-	crate::set_artist!(tagged_file, primary_tag_mut, "Bar artist", 1 => file, "Foo artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::Id3v2,
+		"Bar artist",
+		"Foo artist",
+		1,
+	);
 
-	crate::set_artist!(tagged_file, tag_mut, TagType::RiffInfo, "Baz artist", 1 => file, "Bar artist");
+	crate::util::set_artist(
+		&mut tagged_file,
+		TagType::RiffInfo,
+		"Baz artist",
+		"Bar artist",
+		1,
+	);
 }
 
 #[test_log::test]
 fn remove_id3v2() {
-	crate::remove_tag!(
+	crate::util::remove_tag_test(
 		"tests/files/assets/minimal/wav_format_pcm.wav",
-		TagType::Id3v2
+		TagType::Id3v2,
 	);
 }
 
 #[test_log::test]
 fn remove_riff_info() {
-	crate::remove_tag!(
+	crate::util::remove_tag_test(
 		"tests/files/assets/minimal/wav_format_pcm.wav",
-		TagType::RiffInfo
+		TagType::RiffInfo,
 	);
 }
 
@@ -88,10 +106,10 @@ fn issue_174_divide_by_zero() {
 
 #[test_log::test]
 fn read_no_properties() {
-	crate::no_properties_test!("tests/files/assets/minimal/wav_format_pcm.wav");
+	crate::util::no_properties_test("tests/files/assets/minimal/wav_format_pcm.wav");
 }
 
 #[test_log::test]
 fn read_no_tags() {
-	crate::no_tag_test!("tests/files/assets/minimal/wav_format_pcm.wav");
+	crate::util::no_tag_test("tests/files/assets/minimal/wav_format_pcm.wav", None);
 }


### PR DESCRIPTION
Converted them to functions. No need for them to be macros.