### PR TITLE
Tests: Move ignored test comments into `#[ignore]` attribute

### DIFF
--- a/lofty/tests/taglib/test_aiff.rs
+++ b/lofty/tests/taglib/test_aiff.rs
@@ -126,10 +126,9 @@ fn test_save_id3v23() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_duplicate_id3v2() {
-	// Marker test, Lofty will overwrite values in the original tag with any new values it finds in the next tag.
-}
+#[ignore = "Marker test, Lofty will overwrite values in the original tag with any new values it \
+            finds in the next tag."]
+fn test_duplicate_id3v2() {}
 
 #[test_log::test]
 fn test_fuzzed_file1() {
@@ -144,7 +143,6 @@ fn test_fuzzed_file1() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_fuzzed_file2() {
-	// Marker test, this file doesn't even have a valid signature. No idea how TagLib manages to read it.
-}
+#[ignore = "Marker test, this file doesn't even have a valid signature. No idea how TagLib manages \
+            to read it."]
+fn test_fuzzed_file2() {}

--- a/lofty/tests/taglib/test_apetag.rs
+++ b/lofty/tests/taglib/test_apetag.rs
@@ -31,16 +31,12 @@ fn test_is_empty_2() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_property_interface_1() {
-	// Marker test, Lofty does not replicate the TagLib property API
-}
+#[ignore = "Marker test, Lofty does not replicate the TagLib property API"]
+fn test_property_interface_1() {}
 
 #[test_log::test]
-#[ignore]
-fn test_property_interface_2() {
-	// Marker test, Lofty does not replicate the TagLib property API
-}
+#[ignore = "Marker test, Lofty does not replicate the TagLib property API"]
+fn test_property_interface_2() {}
 
 #[test_log::test]
 fn test_invalid_keys() {

--- a/lofty/tests/taglib/test_fileref.rs
+++ b/lofty/tests/taglib/test_fileref.rs
@@ -191,10 +191,8 @@ fn test_unsupported() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_create() {
-	// Marker test, Lofty does not replicate this API
-}
+#[ignore = "Marker test, Lofty does not replicate this API"]
+fn test_create() {}
 
 #[test_log::test]
 fn test_audio_properties() {
@@ -205,10 +203,8 @@ fn test_audio_properties() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_default_file_extensions() {
-	// Marker test, Lofty does not replicate this API
-}
+#[ignore = "Marker test, Lofty does not replicate this API"]
+fn test_default_file_extensions() {}
 
 use lofty::io::{FileLike, Length, Truncate};
 use lofty::properties::FileProperties;

--- a/lofty/tests/taglib/test_flac.rs
+++ b/lofty/tests/taglib/test_flac.rs
@@ -21,10 +21,8 @@ fn test_signature() {
 }
 
 #[test_log::test]
-#[ignore]
+#[ignore = "Marker test, Lofty does not replicate TagLib's behavior here"]
 fn test_multiple_comment_blocks() {
-	// Marker test, Lofty does not replicate TagLib's behavior
-	//
 	// TagLib will use the *first* tag in the stream, while we use the latest.
 }
 
@@ -213,10 +211,9 @@ fn test_repeated_save_1() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_repeated_save_2() {
-	// Marker test, this test relies on saving an ID3v2 tag in a FLAC file, something Lofty does not and will not support.
-}
+#[ignore = "Marker test, this test relies on saving an ID3v2 tag in a FLAC file, something Lofty \
+            does not and will not support."]
+fn test_repeated_save_2() {}
 
 // TODO: We don't make use of padding blocks yet
 #[test_log::test]
@@ -264,10 +261,8 @@ fn test_save_multiple_values() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_dict() {
-	// Marker test, Lofty does not replicate the dict API
-}
+#[ignore = "Marker test, Lofty does not replicate the dict API"]
+fn test_dict() {}
 
 #[test_log::test]
 fn test_properties() {
@@ -457,16 +452,14 @@ fn test_shrink_padding() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_save_id3v1() {
-	// Marker test, this test relies on saving an ID3v1 tag in a FLAC file, something Lofty does not and will not support.
-}
+#[ignore = "Marker test, this test relies on saving an ID3v1 tag in a FLAC file, something Lofty \
+            does not and will not support."]
+fn test_save_id3v1() {}
 
 #[test_log::test]
-#[ignore]
-fn test_update_id3v2() {
-	// Marker test, this test relies on saving an ID3v2 tag in a FLAC file, something Lofty does not and will not support.
-}
+#[ignore = "Marker test, this test relies on saving an ID3v2 tag in a FLAC file, something Lofty \
+            does not and will not support."]
+fn test_update_id3v2() {}
 
 #[test_log::test]
 fn test_empty_id3v2() {

--- a/lofty/tests/taglib/test_id3v1.rs
+++ b/lofty/tests/taglib/test_id3v1.rs
@@ -1,10 +1,8 @@
 use lofty::id3::v1::GENRES;
 
 #[test_log::test]
-#[ignore]
-fn test_strip_whitespace() {
-	// Marker test, we'd be overstepping to remove trailing whitespace that may be intentional
-}
+#[ignore = "Marker test, we'd be overstepping to remove trailing whitespace that may be intentional"]
+fn test_strip_whitespace() {}
 
 #[test_log::test]
 fn test_genres() {

--- a/lofty/tests/taglib/test_id3v2.rs
+++ b/lofty/tests/taglib/test_id3v2.rs
@@ -202,10 +202,8 @@ fn test_broken_frame1() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_read_string_field() {
-	// Marker test, this is not an API Lofty replicates
-}
+#[ignore = "Marker test, this is not an API Lofty replicates"]
+fn test_read_string_field() {}
 
 #[test_log::test]
 fn test_parse_apic() {
@@ -288,10 +286,8 @@ fn test_render_apic() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_dont_render22() {
-	// Marker test, not sure what's going on here?
-}
+#[ignore = "Marker test, not sure what's going on here?"]
+fn test_dont_render22() {}
 
 #[test_log::test]
 fn test_parse_geob() {
@@ -374,10 +370,8 @@ fn test_render_popm() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_popm_to_string() {
-	// Marker test, Lofty doesn't have a display impl for Popularimeter
-}
+#[ignore = "Marker test, Lofty doesn't have a display impl for Popularimeter"]
+fn test_popm_to_string() {}
 
 #[test_log::test]
 fn test_popm_from_file() {
@@ -783,16 +777,12 @@ fn test_render_comments_frame() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_parse_podcast_frame() {
-	// Marker test, Lofty doesn't have dedicated support for PCST frames, it seems unnecessary
-}
+#[ignore = "Marker test, Lofty doesn't have dedicated support for PCST frames, it seems unnecessary"]
+fn test_parse_podcast_frame() {}
 
 #[test_log::test]
-#[ignore]
-fn test_render_podcast_frame() {
-	// Marker test, Lofty doesn't have dedicated support for PCST frames, it seems unnecessary
-}
+#[ignore = "Marker test, Lofty doesn't have dedicated support for PCST frames, it seems unnecessary"]
+fn test_render_podcast_frame() {}
 
 #[test_log::test]
 fn test_parse_private_frame() {
@@ -1285,28 +1275,22 @@ fn test_w000() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_property_interface() {
-	// Marker test, Lofty does not replicate the property interface
-}
+#[ignore = "Marker test, Lofty does not replicate the property interface"]
+fn test_property_interface() {}
 
 #[test_log::test]
-#[ignore]
-fn test_property_interface2() {
-	// Marker test, Lofty does not replicate the property interface
-}
+#[ignore = "Marker test, Lofty does not replicate the property interface"]
+fn test_property_interface2() {}
 
 #[test_log::test]
-#[ignore]
+#[ignore = "Marker test, Lofty does not replicate the property interface"]
 fn test_properties_movement() {
-	// Marker test, Lofty does not replicate the property interface.
 	// Outside of that, this is simply a text frame parsing test, which is redundant.
 }
 
 #[test_log::test]
-#[ignore]
+#[ignore = "Marker test, Lofty does not replicate the property interface"]
 fn test_property_grouping() {
-	// Marker test, Lofty does not replicate the property interface.
 	// Outside of that, this is simply a text frame parsing test, which is redundant.
 }
 
@@ -1382,16 +1366,12 @@ fn test_parse_table_of_contents_frame() {}
 fn test_render_table_of_contents_frame() {}
 
 #[test_log::test]
-#[ignore]
-fn test_empty_frame() {
-	// Marker test, Lofty will not remove empty frames, as they can be valid
-}
+#[ignore = "Marker test, Lofty will not remove empty frames, as they can be valid"]
+fn test_empty_frame() {}
 
 #[test_log::test]
-#[ignore]
-fn test_duplicate_tags() {
-	// Marker test, Lofty will combine duplicated tags
-}
+#[ignore = "Marker test, Lofty will combine duplicated tags"]
+fn test_duplicate_tags() {}
 
 // TODO: Support CTOC frames (#189)
 #[test_log::test]

--- a/lofty/tests/taglib/test_mp4.rs
+++ b/lofty/tests/taglib/test_mp4.rs
@@ -259,10 +259,9 @@ fn test_save_existing_when_ilst_is_last() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_64bit_atom() {
-	// Marker test, this just checks the moov atom's length. We don't retain any atoms we don't need.
-}
+#[ignore = "Marker test, this just checks the moov atom's length. We don't retain any atoms we \
+            don't need."]
+fn test_64bit_atom() {}
 
 #[test_log::test]
 fn test_gnre() {
@@ -355,22 +354,16 @@ fn test_covr_read2() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_properties() {
-	// Marker test, Lofty does not replicate the properties API
-}
+#[ignore = "Marker test, Lofty does not replicate the properties API"]
+fn test_properties() {}
 
 #[test_log::test]
-#[ignore]
-fn test_properties_all_supported() {
-	// Marker test, Lofty does not replicate the properties API
-}
+#[ignore = "Marker test, Lofty does not replicate the properties API"]
+fn test_properties_all_supported() {}
 
 #[test_log::test]
-#[ignore]
-fn test_properties_movement() {
-	// Marker test, Lofty does not replicate the properties API
-}
+#[ignore = "Marker test, Lofty does not replicate the properties API"]
+fn test_properties_movement() {}
 
 #[test_log::test]
 fn test_fuzzed_file() {
@@ -412,10 +405,8 @@ fn test_with_zero_length_atom() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_empty_values_remove_items() {
-	// Marker test, Lofty treats empty values as valid
-}
+#[ignore = "Marker test, Lofty treats empty values as valid"]
+fn test_empty_values_remove_items() {}
 
 #[test_log::test]
 fn test_remove_metadata() {

--- a/lofty/tests/taglib/test_mpc.rs
+++ b/lofty/tests/taglib/test_mpc.rs
@@ -57,15 +57,12 @@ fn test_properties_sv7() {
 }
 
 #[test_log::test]
-fn test_properties_sv5() {
-	// Marker test, TagLib doesn't seem to produce the correct properties for SV5
-}
+#[ignore = "Marker test, TagLib doesn't seem to produce the correct properties for SV5"]
+fn test_properties_sv5() {}
 
 #[test_log::test]
-#[ignore]
-fn test_properties_sv4() {
-	// Marker test, TagLib doesn't seem to produce the correct properties for SV4
-}
+#[ignore = "Marker test, TagLib doesn't seem to produce the correct properties for SV4"]
+fn test_properties_sv4() {}
 
 #[test_log::test]
 fn test_fuzzed_file1() {

--- a/lofty/tests/taglib/test_mpeg.rs
+++ b/lofty/tests/taglib/test_mpeg.rs
@@ -133,10 +133,8 @@ fn test_save_id3v24() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_save_id3v24_wrong_param() {
-	// Marker test, Lofty does not replicate the TagLib saving API
-}
+#[ignore = "Marker test, Lofty does not replicate the TagLib saving API"]
+fn test_save_id3v24_wrong_param() {}
 
 #[test_log::test]
 fn test_save_id3v23() {
@@ -177,10 +175,9 @@ fn test_fuzzed_file() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_frame_offset() {
-	// Marker test, Lofty does not replicate this API. Doesn't seem useful to retain frame offsets.
-}
+#[ignore = "Marker test, Lofty does not replicate this API. Doesn't seem useful to retain frame \
+            offsets."]
+fn test_frame_offset() {}
 
 #[test_log::test]
 fn test_strip_and_properties() {
@@ -215,22 +212,16 @@ fn test_strip_and_properties() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_properties() {
-	// Marker test, Lofty does not replicate the properties API
-}
+#[ignore = "Marker test, Lofty does not replicate the properties API"]
+fn test_properties() {}
 
 #[test_log::test]
-#[ignore]
-fn test_repeated_save_1() {
-	// Marker test, yet another case of checking frame offsets that Lofty does not expose.
-}
+#[ignore = "Marker test, yet another case of checking frame offsets that Lofty does not expose."]
+fn test_repeated_save_1() {}
 
 #[test_log::test]
-#[ignore]
-fn test_repeated_save_2() {
-	// Marker test, not entirely sure what's even being tested here?
-}
+#[ignore = "Marker test, not entirely sure what's even being tested here?"]
+fn test_repeated_save_2() {}
 
 #[test_log::test]
 fn test_repeated_save_3() {
@@ -275,22 +266,16 @@ fn test_repeated_save_3() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_empty_id3v2() {
-	// Marker test, Lofty accepts empty strings as valid values
-}
+#[ignore = "Marker test, Lofty accepts empty strings as valid values"]
+fn test_empty_id3v2() {}
 
 #[test_log::test]
-#[ignore]
-fn test_empty_id3v1() {
-	// Marker test, Lofty accepts empty strings as valid values
-}
+#[ignore = "Marker test, Lofty accepts empty strings as valid values"]
+fn test_empty_id3v1() {}
 
 #[test_log::test]
-#[ignore]
-fn test_empty_ape() {
-	// Marker test, Lofty accepts empty strings as valid values
-}
+#[ignore = "Marker test, Lofty accepts empty strings as valid values"]
+fn test_empty_ape() {}
 
 #[test_log::test]
 fn test_ignore_garbage() {

--- a/lofty/tests/taglib/test_ogaflac.rs
+++ b/lofty/tests/taglib/test_ogaflac.rs
@@ -45,7 +45,5 @@ fn test_fuzzed_file() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_split_packets() {
-	// Marker test, Lofty does not retain the packet information
-}
+#[ignore = "Marker test, Lofty does not retain the packet information"]
+fn test_split_packets() {}

--- a/lofty/tests/taglib/test_ogg.rs
+++ b/lofty/tests/taglib/test_ogg.rs
@@ -29,10 +29,8 @@ fn test_simple() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_split_packets1() {
-	// Marker test, Lofty doesn't retain packet information
-}
+#[ignore = "Marker test, Lofty doesn't retain packet information"]
+fn test_split_packets1() {}
 
 #[test_log::test]
 fn test_split_packets2() {
@@ -64,16 +62,12 @@ fn test_split_packets2() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_dict_interface1() {
-	// Marker test, Lofty doesn't replicate the dictionary interface
-}
+#[ignore = "Marker test, Lofty doesn't replicate the dictionary interface"]
+fn test_dict_interface1() {}
 
 #[test_log::test]
-#[ignore]
-fn test_dict_interface2() {
-	// Marker test, Lofty doesn't replicate the dictionary interface
-}
+#[ignore = "Marker test, Lofty doesn't replicate the dictionary interface"]
+fn test_dict_interface2() {}
 
 #[test_log::test]
 fn test_audio_properties() {

--- a/lofty/tests/taglib/test_opus.rs
+++ b/lofty/tests/taglib/test_opus.rs
@@ -56,7 +56,5 @@ fn test_write_comments() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_split_packets() {
-	// Marker test, Lofty does not retain packet information
-}
+#[ignore = "Marker test, Lofty does not retain packet information"]
+fn test_split_packets() {}

--- a/lofty/tests/taglib/test_synchdata.rs
+++ b/lofty/tests/taglib/test_synchdata.rs
@@ -27,16 +27,12 @@ fn test3() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_to_uint_broken() {
-	// Marker test, this behavior is not replicated in Lofty
-}
+#[ignore = "Marker test, this behavior is not replicated in Lofty"]
+fn test_to_uint_broken() {}
 
 #[test_log::test]
-#[ignore]
-fn test_to_uint_broken_and_too_large() {
-	// Marker test, this behavior is not replicated in Lofty
-}
+#[ignore = "Marker test, this behavior is not replicated in Lofty"]
+fn test_to_uint_broken_and_too_large() {}
 
 #[test_log::test]
 fn test_decode1() {

--- a/lofty/tests/taglib/test_wav.rs
+++ b/lofty/tests/taglib/test_wav.rs
@@ -230,11 +230,10 @@ fn test_strip_tags() {
 }
 
 #[test_log::test]
-#[ignore]
+#[ignore = "Marker test, TagLib will ignore any tag except for the first."]
 fn test_duplicate_tags() {
-	// Marker test, TagLib will ignore any tag except for the first. Lofty will *not* do this.
-	// Every tag in the stream is read and merged into the previous one. Whichever tag ends up being
-	// the latest in the stream will have precedence.
+	// Lofty will *not* do this. Every tag in the stream is read and merged into the previous one. Whichever tag ends up
+	// being the latest in the stream will have precedence.
 }
 
 #[test_log::test]
@@ -304,10 +303,8 @@ fn test_file_with_garbage_appended() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_strip_and_properties() {
-	// Marker test, Lofty does not replicate the properties API
-}
+#[ignore = "Marker test, Lofty does not replicate the properties API"]
+fn test_strip_and_properties() {}
 
 #[test_log::test]
 fn test_pcm_with_fact_chunk() {

--- a/lofty/tests/taglib/test_wavpack.rs
+++ b/lofty/tests/taglib/test_wavpack.rs
@@ -27,12 +27,10 @@ fn test_no_length_properties() {
 }
 
 #[test_log::test]
-#[ignore]
+#[ignore = "Marker test, this is not a valid file and TagLib does not handle it properly."]
 fn test_multi_channel_properties() {
-	// Marker test, this is not a valid file and TagLib does not handle it properly.
-	//
-	// A multichannel file should make use of the multichannel metadata sub block, which
-	// this file does not. Even FFMpeg thinks this is a mono file.
+	// A multichannel file should make use of the multichannel metadata sub block, which this file does not.
+	// Even FFmpeg thinks this is a mono file.
 }
 
 #[test_log::test]

--- a/lofty/tests/taglib/test_xiphcomment.rs
+++ b/lofty/tests/taglib/test_xiphcomment.rs
@@ -54,10 +54,8 @@ fn test_set_track() {
 }
 
 #[test_log::test]
-#[ignore]
-fn test_invalid_keys1() {
-	// Marker test, Lofty does not replicate the properties API
-}
+#[ignore = "Marker test, Lofty does not replicate the properties API"]
+fn test_invalid_keys1() {}
 
 #[test_log::test]
 fn test_invalid_keys2() {
@@ -92,10 +90,8 @@ fn test_clear_comment() {
 }
 
 #[test_log::test]
-#[ignore]
+#[ignore = "Marker test, TagLib has some incredibly strange behavior in this test."]
 fn test_remove_fields() {
-	// Marker test, TagLib has some incredibly strange behavior in this test.
-	//
 	// When adding a field of the same key, TagLib will append each value to the same value.
 	// Meaning:
 	//


### PR DESCRIPTION
Don't know where the reason strings appear (or if they even do), but this feels more correct.