### PR TITLE
Benches: Update benchmarks to use `gungraun`

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,14 +29,14 @@ jobs:
                 run: |
                     sudo apt-get update
                     sudo apt-get install -y valgrind
-            -   name: Install iai-callgrind-runner
+            -   name: Install gungraun-runner
                 run: |
                     version=$(cargo metadata --format-version=1 |\
-                      jq '.packages[] | select(.name == "iai-callgrind").version' |\
+                      jq '.packages[] | select(.name == "gungraun").version' |\
                       tr -d '"'
                     )
-                    cargo install iai-callgrind-runner --version $version
+                    cargo install gungraun-runner --version $version
             -   uses: bencherdev/bencher@main
             -   name: Run Bencher
                 run: |
-                    bencher run --adapter rust_iai_callgrind --err "cargo bench"
+                    bencher run --adapter rust_gungraun --err "cargo bench"

--- a/benches/create_tag.rs
+++ b/benches/create_tag.rs
@@ -13,7 +13,7 @@ use lofty::tag::{Accessor, TagExt};
 
 use std::borrow::Cow;
 
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use gungraun::{library_benchmark, library_benchmark_group, main};
 
 const ENCODER: &str = "Lavf57.56.101";
 
@@ -44,12 +44,10 @@ bench_tag_write!([
 		use lofty::ape::ApeItem;
 		use lofty::tag::ItemValue;
 
-		let picture = Picture::new_unchecked(
-			PictureType::CoverFront,
-			Some(MimeType::Jpeg),
-			None,
-			include_bytes!("./assets/cover.jpg").to_vec(),
-		);
+		let picture = Picture::unchecked(include_bytes!("./assets/cover.jpg").to_vec())
+			.pic_type(PictureType::CoverFront)
+			.mime_type(MimeType::Jpeg)
+			.build();
 
 		tag.insert(
 			ApeItem::new(
@@ -70,12 +68,10 @@ bench_tag_write!([
 		use lofty::TextEncoding;
 		use lofty::id3::v2::{Frame, TextInformationFrame};
 
-		let picture = Picture::new_unchecked(
-			PictureType::CoverFront,
-			Some(MimeType::Jpeg),
-			None,
-			include_bytes!("./assets/cover.jpg").to_vec(),
-		);
+		let picture = Picture::unchecked(include_bytes!("./assets/cover.jpg").to_vec())
+			.pic_type(PictureType::CoverFront)
+			.mime_type(MimeType::Jpeg)
+			.build();
 
 		tag.insert_picture(picture);
 		tag.insert(Frame::Text(TextInformationFrame::new(
@@ -88,12 +84,10 @@ bench_tag_write!([
 	(ilst, Ilst, |tag| {
 		use lofty::mp4::{Atom, AtomData, AtomIdent};
 
-		let picture = Picture::new_unchecked(
-			PictureType::CoverFront,
-			Some(MimeType::Jpeg),
-			None,
-			include_bytes!("./assets/cover.jpg").to_vec(),
-		);
+		let picture = Picture::unchecked(include_bytes!("./assets/cover.jpg").to_vec())
+			.pic_type(PictureType::CoverFront)
+			.mime_type(MimeType::Jpeg)
+			.build();
 
 		tag.insert_picture(picture);
 		tag.insert(Atom::new(
@@ -107,12 +101,10 @@ bench_tag_write!([
 	(vorbis_comments, VorbisComments, |tag| {
 		use lofty::ogg::OggPictureStorage;
 
-		let picture = Picture::new_unchecked(
-			PictureType::CoverFront,
-			Some(MimeType::Jpeg),
-			None,
-			include_bytes!("./assets/cover.jpg").to_vec(),
-		);
+		let picture = Picture::unchecked(include_bytes!("./assets/cover.jpg").to_vec())
+			.pic_type(PictureType::CoverFront)
+			.mime_type(MimeType::Jpeg)
+			.build();
 
 		let _ = tag.insert_picture(picture, None).unwrap();
 		tag.push(String::from("ENCODER"), String::from(ENCODER));

--- a/benches/read_file.rs
+++ b/benches/read_file.rs
@@ -3,7 +3,7 @@
 use lofty::config::ParseOptions;
 use lofty::probe::Probe;
 
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use gungraun::{library_benchmark, library_benchmark_group, main};
 
 use std::hint::black_box;
 use std::io::Cursor;

--- a/lofty/Cargo.toml
+++ b/lofty/Cargo.toml
@@ -47,7 +47,7 @@ rusty-fork = "0.3.0"
 structopt = { version = "0.3.26", default-features = false }
 tempfile  = "3.15.0"
 test-log = "0.2.16"
-iai-callgrind = "0.16.0"
+gungraun = "0.17.0"
 
 [lints]
 workspace = true


### PR DESCRIPTION
`iai-callgrind` renamed to `gungraun`