### PR TITLE
Accessor: Replace `*_year()` with `*_date()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **ID3v2**: Check `TXXX:ALBUMARTIST` and `TXXX:ALBUM ARTIST` for `ItemKey::AlbumArtist` conversions
+- **ID3v1**: The `year` field in `Id3v1Tag` is now a `u16`, instead of a `String` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/574))
 - **Vorbis Comments**: Check `ALBUM ARTIST` for `ItemKey::AlbumArtist` conversions
 - **Vorbis Comments**: Support `DISCNUMBER` fields with the `current/total` format. ([issue](https://github.com/Serial-ATA/lofty-rs/issues/543)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/544))
     - These fields will now properly be split into `DISCNUMBER` and `DISCTOTAL`, making it possible to use them with
@@ -51,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * `Tag` is now intended for generic metadata editing only, with format-specific items only being available through concrete tag types.
       See <https://github.com/Serial-ATA/lofty-rs/issues/521> for the rationale.
 * **Picture**: `Picture::new_unchecked()`, replaced with `Picture::unchecked()` returning a builder ([issue](https://github.com/Serial-ATA/lofty-rs/issues/468)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/569))
+* **Accessor**: `Accessor::*_year()` methods, replaced with `Accessor::*_date()` ([issue](https://github.com/Serial-ATA/lofty-rs/issues/565)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/574))
+  - Since all formats (*except ID3v1*) have full date support, the generic API now accepts `Timestamp`s. For ID3v1, the date will be truncated
+    down to the year for conversions/writing.
+  - Year tags can still be set manually with `ItemKey::Year`
 
 ## [0.22.4] - 2025-04-29
 

--- a/benches/create_tag.rs
+++ b/benches/create_tag.rs
@@ -9,6 +9,7 @@ use lofty::iff::wav::RiffInfoList;
 use lofty::mp4::Ilst;
 use lofty::ogg::VorbisComments;
 use lofty::picture::{MimeType, Picture, PictureType};
+use lofty::tag::items::Timestamp;
 use lofty::tag::{Accessor, TagExt};
 
 use std::borrow::Cow;
@@ -28,7 +29,10 @@ macro_rules! bench_tag_write {
 				$tag_.set_artist(String::from("Dave Eddy"));
 				$tag_.set_title(String::from("TempleOS Hymn Risen (Remix)"));
 				$tag_.set_album(String::from("Summer"));
-				$tag_.set_year(2017);
+				$tag_.set_date(Timestamp {
+					year: 2017,
+					..Timestamp::default()
+				});
 				$tag_.set_track(1);
 				$tag_.set_genre(String::from("Electronic"));
 				$extra_block;

--- a/lofty/src/ape/tag/mod.rs
+++ b/lofty/src/ape/tag/mod.rs
@@ -7,8 +7,10 @@ use crate::config::WriteOptions;
 use crate::error::{LoftyError, Result};
 use crate::id3::v2::util::pairs::{NUMBER_PAIR_KEYS, format_number_pair, set_number};
 use crate::tag::item::ItemValueRef;
+use crate::tag::items::Timestamp;
 use crate::tag::{
-	Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType, try_parse_year,
+	Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType,
+	try_parse_timestamp,
 };
 use crate::util::flag_item;
 use crate::util::io::{FileLike, Truncate};
@@ -293,23 +295,24 @@ impl Accessor for ApeTag {
 		}
 	}
 
-	fn year(&self) -> Option<u32> {
+	// For some reason, the ecosystem agreed on the key "Year", even for full date strings.
+	fn date(&self) -> Option<Timestamp> {
 		if let Some(ApeItem {
 			value: ItemValue::Text(text),
 			..
 		}) = self.get("Year")
 		{
-			return try_parse_year(text);
+			return try_parse_timestamp(text);
 		}
 
 		None
 	}
 
-	fn set_year(&mut self, value: u32) {
+	fn set_date(&mut self, value: Timestamp) {
 		self.insert(ApeItem::text("Year", value.to_string()));
 	}
 
-	fn remove_year(&mut self) {
+	fn remove_date(&mut self) {
 		self.remove("Year");
 	}
 }

--- a/lofty/src/id3/v1/constants.rs
+++ b/lofty/src/id3/v1/constants.rs
@@ -195,12 +195,14 @@ pub const GENRES: [&str; 192] = [
 ];
 
 use crate::tag::ItemKey;
-pub(crate) const VALID_ITEMKEYS: [ItemKey; 7] = [
+pub(crate) const VALID_ITEMKEYS: [ItemKey; 8] = [
 	ItemKey::TrackTitle,
 	ItemKey::TrackArtist,
 	ItemKey::AlbumTitle,
-	ItemKey::Year,
 	ItemKey::Comment,
 	ItemKey::TrackNumber,
 	ItemKey::Genre,
+	// These two are used identically. ID3v1 is the only format that *only* supports year.
+	ItemKey::Year,
+	ItemKey::RecordingDate,
 ];

--- a/lofty/src/id3/v1/write.rs
+++ b/lofty/src/id3/v1/write.rs
@@ -78,7 +78,23 @@ pub(super) fn encode(tag: &Id3v1TagRef<'_>) -> std::io::Result<Vec<u8>> {
 	let album = resize_string(tag.album, 30)?;
 	writer.write_all(&album)?;
 
-	let year = resize_string(tag.year, 4)?;
+	let mut year = [0; 4];
+	if let Some(year_num) = tag.year {
+		let mut year_num = std::cmp::min(year_num, 9999);
+
+		let mut idx = 3;
+		loop {
+			year[idx] = b'0' + (year_num % 10) as u8;
+			year_num /= 10;
+
+			if idx == 0 {
+				break;
+			}
+
+			idx -= 1;
+		}
+	}
+
 	writer.write_all(&year)?;
 
 	let comment = resize_string(tag.comment, 28)?;

--- a/lofty/src/id3/v2/read.rs
+++ b/lofty/src/id3/v2/read.rs
@@ -181,6 +181,7 @@ where
 mod tests {
 	use super::parse_id3v2;
 	use crate::config::ParseOptions;
+	use crate::tag::items::Timestamp;
 
 	#[test_log::test]
 	fn zero_size_id3v2() {
@@ -230,7 +231,13 @@ mod tests {
 		assert_eq!(id3v2.title().as_deref(), Some("Foo title"));
 		assert_eq!(id3v2.artist().as_deref(), Some("Bar artist"));
 		assert_eq!(id3v2.comment().as_deref(), Some("Qux comment"));
-		assert_eq!(id3v2.year(), Some(1984));
+		assert_eq!(
+			id3v2.date(),
+			Some(Timestamp {
+				year: 1984,
+				..Default::default()
+			})
+		);
 		assert_eq!(id3v2.track(), Some(1));
 		assert_eq!(id3v2.genre().as_deref(), Some("Classical"));
 	}

--- a/lofty/src/id3/v2/tag.rs
+++ b/lofty/src/id3/v2/tag.rs
@@ -825,21 +825,21 @@ impl Accessor for Id3v2Tag {
 		let _ = self.remove(&GENRE_ID);
 	}
 
-	fn year(&self) -> Option<u32> {
+	fn date(&self) -> Option<Timestamp> {
 		if let Some(Frame::Timestamp(TimestampFrame { timestamp, .. })) =
 			self.get(&RECORDING_TIME_ID)
 		{
-			return Some(u32::from(timestamp.year));
+			return Some(*timestamp);
 		}
 
 		None
 	}
 
-	fn set_year(&mut self, value: u32) {
+	fn set_date(&mut self, value: Timestamp) {
 		self.insert(Frame::text(Cow::Borrowed("TDRC"), value.to_string()));
 	}
 
-	fn remove_year(&mut self) {
+	fn remove_date(&mut self) {
 		let _ = self.remove(&RECORDING_TIME_ID);
 	}
 

--- a/lofty/src/id3/v2/write/frame.rs
+++ b/lofty/src/id3/v2/write/frame.rs
@@ -1,12 +1,12 @@
 use crate::error::{Id3v2Error, Id3v2ErrorKind, Result};
 use crate::id3::v2::frame::{FrameFlags, FrameRef};
+use crate::id3::v2::tag::GenresIter;
 use crate::id3::v2::util::synchsafe::SynchsafeInteger;
 use crate::id3::v2::{Frame, FrameId, KeyValueFrame, TextInformationFrame};
 use crate::tag::items::Timestamp;
 
 use std::io::Write;
 
-use crate::id3::v2::tag::GenresIter;
 use byteorder::{BigEndian, WriteBytesExt};
 
 pub(in crate::id3::v2) fn create_items<W>(

--- a/lofty/src/iff/wav/tag/mod.rs
+++ b/lofty/src/iff/wav/tag/mod.rs
@@ -3,8 +3,10 @@ mod write;
 
 use crate::config::WriteOptions;
 use crate::error::{LoftyError, Result};
+use crate::tag::items::Timestamp;
 use crate::tag::{
-	Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType, try_parse_year,
+	Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType,
+	try_parse_timestamp,
 };
 use crate::util::io::{FileLike, Length, Truncate};
 
@@ -147,19 +149,19 @@ impl Accessor for RiffInfoList {
 		self.remove("IFRM");
 	}
 
-	fn year(&self) -> Option<u32> {
+	fn date(&self) -> Option<Timestamp> {
 		if let Some(item) = self.get("ICRD") {
-			return try_parse_year(item);
+			return try_parse_timestamp(item);
 		}
 
 		None
 	}
 
-	fn set_year(&mut self, value: u32) {
+	fn set_date(&mut self, value: Timestamp) {
 		self.insert(String::from("ICRD"), value.to_string());
 	}
 
-	fn remove_year(&mut self) {
+	fn remove_date(&mut self) {
 		let _ = self.remove("ICRD");
 	}
 }

--- a/lofty/src/mp4/ilst/mod.rs
+++ b/lofty/src/mp4/ilst/mod.rs
@@ -12,8 +12,10 @@ use crate::error::LoftyError;
 use crate::mp4::ilst::atom::AtomDataStorage;
 use crate::picture::{Picture, PictureType};
 use crate::tag::companion_tag::CompanionTag;
+use crate::tag::items::Timestamp;
 use crate::tag::{
-	Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType, try_parse_year,
+	Accessor, ItemKey, ItemValue, MergeTag, SplitTag, Tag, TagExt, TagItem, TagType,
+	try_parse_timestamp,
 };
 use crate::util::flag_item;
 use crate::util::io::{FileLike, Length, Truncate};
@@ -572,25 +574,25 @@ impl Accessor for Ilst {
 		}
 	}
 
-	fn year(&self) -> Option<u32> {
+	fn date(&self) -> Option<Timestamp> {
 		if let Some(atom) = self.get(&AtomIdent::Fourcc(*b"\xa9day")) {
 			if let Some(AtomData::UTF8(text)) = atom.data().next() {
-				return try_parse_year(text);
+				return try_parse_timestamp(text);
 			}
 		}
 
 		None
 	}
 
-	fn set_year(&mut self, value: u32) {
+	fn set_date(&mut self, value: Timestamp) {
 		self.replace_atom(Atom::text(
 			AtomIdent::Fourcc(*b"\xa9day"),
 			value.to_string(),
 		));
 	}
 
-	fn remove_year(&mut self) {
-		let _ = self.remove(&AtomIdent::Fourcc(*b"Year"));
+	fn remove_date(&mut self) {
+		let _ = self.remove(&AtomIdent::Fourcc(*b"\xa9day"));
 	}
 }
 

--- a/lofty/src/tag/accessor.rs
+++ b/lofty/src/tag/accessor.rs
@@ -1,3 +1,5 @@
+use crate::tag::items::Timestamp;
+
 use std::borrow::Cow;
 
 #[cfg(doc)]
@@ -135,5 +137,5 @@ accessor_trait! {
 	[album ]<Cow<'_, str>, String>, [genre      ]<Cow<'_, str>, String>,
 	[track ]<u32>,                  [track total]<u32>,
 	[disk  ]<u32>,                  [disk total ]<u32>,
-	[year  ]<u32>,                  [comment    ]<Cow<'_, str>, String>,
+	[date  ]<Timestamp>,            [comment    ]<Cow<'_, str>, String>,
 }

--- a/lofty/src/tag/item.rs
+++ b/lofty/src/tag/item.rs
@@ -4,6 +4,12 @@ use crate::tag::items::{Lang, UNKNOWN_LANGUAGE};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
+#[cfg(doc)]
+use crate::{
+	id3::v1::Id3v1Tag,
+	tag::{Accessor, Tag},
+};
+
 macro_rules! first_key {
 	($key:tt $(| $remaining:expr)*) => {
 		$key
@@ -119,7 +125,8 @@ gen_map!(
 	"Disc"                           => DiscTotal,
 	"Track"                          => TrackNumber,
 	"Track"                          => TrackTotal,
-	"Year"                           => Year,
+	// For some reason, the ecosystem agreed on the key "Year", even for full date strings.
+	"Year"                           => RecordingDate | Year,
 	"ORIGINALYEAR"                   => OriginalReleaseDate,
 	"RELEASEDATE"                    => ReleaseDate,
 	"ISRC"                           => Isrc,
@@ -583,15 +590,30 @@ gen_item_keys!(
 		// Dates
 		/// Recording date
 		///
+		/// Note that most applications unfortunately interpret this as the *release* date, so this
+		/// is the key used in [`Accessor::date()`].
+		///
+		/// [`ItemKey::ReleaseDate`] also exists, but its use is not generally recommended.
+		///
 		/// <https://picard-docs.musicbrainz.org/en/appendices/tag_mapping.html#date-10>
 		RecordingDate,
 
-		/// Year
+		/// Release year
+		///
+		/// This is not a commonly used field, but still appears occasionally in the wild. Typically,
+		/// you should use a date field, such as [`ItemKey::RecordingDate`] for wider application support.
+		///
+		/// ## Note for ID3v1
+		///
+		/// Since ID3v1 only supports years, when converting a [`Tag`] to an [`Id3v1Tag`], this key will
+		/// have priority over [`ItemKey::RecordingDate`].
 		Year,
 
 		/// Release date
 		///
 		/// The release date of a podcast episode or any other kind of release.
+		///
+		/// Note that this is **not widely used**, and you should likely be using [`ItemKey::RecordingDate`].
 		///
 		/// <https://picard-docs.musicbrainz.org/en/appendices/tag_mapping.html#release-date-10>
 		ReleaseDate,

--- a/lofty/tests/taglib/test_fileref.rs
+++ b/lofty/tests/taglib/test_fileref.rs
@@ -30,7 +30,10 @@ fn file_ref_save(path: &str, expected_file_type: FileType) {
 		tag.set_album(String::from("albummmm"));
 		tag.set_comment(String::from("a comment"));
 		tag.set_track(5);
-		tag.set_year(2020);
+		tag.set_date(Timestamp {
+			year: 2020,
+			..Timestamp::default()
+		});
 		tag.save_to(&mut file, WriteOptions::default()).unwrap();
 	}
 	file.rewind().unwrap();
@@ -45,14 +48,17 @@ fn file_ref_save(path: &str, expected_file_type: FileType) {
 		assert_eq!(tag.album().as_deref(), Some("albummmm"));
 		assert_eq!(tag.comment().as_deref(), Some("a comment"));
 		assert_eq!(tag.track(), Some(5));
-		assert_eq!(tag.year(), Some(2020));
+		assert_eq!(tag.date().map(|date| date.year), Some(2020));
 		tag.set_artist(String::from("ttest artist"));
 		tag.set_title(String::from("ytest title"));
 		tag.set_genre(String::from("uTest!"));
 		tag.set_album(String::from("ialbummmm"));
 		tag.set_comment(String::from("another comment"));
 		tag.set_track(7);
-		tag.set_year(2080);
+		tag.set_date(Timestamp {
+			year: 2080,
+			..Timestamp::default()
+		});
 		tag.save_to(&mut file, WriteOptions::default()).unwrap();
 	}
 	file.rewind().unwrap();
@@ -67,7 +73,7 @@ fn file_ref_save(path: &str, expected_file_type: FileType) {
 		assert_eq!(tag.album().as_deref(), Some("ialbummmm"));
 		assert_eq!(tag.comment().as_deref(), Some("another comment"));
 		assert_eq!(tag.track(), Some(7));
-		assert_eq!(tag.year(), Some(2080));
+		assert_eq!(tag.date().map(|date| date.year), Some(2080));
 	}
 
 	// NOTE: All tests following this in the TagLib suite are doing the exact same procedures, just
@@ -208,6 +214,7 @@ fn test_default_file_extensions() {}
 
 use lofty::io::{FileLike, Length, Truncate};
 use lofty::properties::FileProperties;
+use lofty::tag::items::Timestamp;
 use rusty_fork::rusty_fork_test;
 
 rusty_fork_test! {

--- a/lofty/tests/taglib/test_id3v2.rs
+++ b/lofty/tests/taglib/test_id3v2.rs
@@ -1018,7 +1018,7 @@ fn test_update_date22() {
 	let mut file = temp_file!("tests/taglib/data/id3v22-tda.mp3");
 	let f = MpegFile::read_from(&mut file, ParseOptions::new()).unwrap();
 	assert!(f.id3v2().is_some());
-	assert_eq!(f.id3v2().unwrap().year(), Some(2010));
+	assert_eq!(f.id3v2().unwrap().date().map(|date| date.year), Some(2010));
 }
 
 // TODO: Determine if this is even worth doing. It is just combining TYE+TDA when upgrading ID3v2.2 to 2.4

--- a/lofty/tests/taglib/test_info.rs
+++ b/lofty/tests/taglib/test_info.rs
@@ -1,5 +1,6 @@
 use lofty::iff::wav::RiffInfoList;
 use lofty::tag::Accessor;
+use lofty::tag::items::Timestamp;
 
 #[test_log::test]
 fn test_title() {
@@ -23,8 +24,11 @@ fn test_numeric_fields() {
 	assert_eq!(tag.track(), Some(1234));
 	assert_eq!(tag.get("IPRT"), Some("1234"));
 
-	assert!(tag.year().is_none());
-	tag.set_year(1234);
-	assert_eq!(tag.year(), Some(1234));
+	assert!(tag.date().is_none());
+	tag.set_date(Timestamp {
+		year: 1234,
+		..Timestamp::default()
+	});
+	assert_eq!(tag.date().map(|date| date.year), Some(1234));
 	assert_eq!(tag.get("ICRD"), Some("1234"));
 }

--- a/lofty/tests/taglib/test_xiphcomment.rs
+++ b/lofty/tests/taglib/test_xiphcomment.rs
@@ -6,21 +6,17 @@ use lofty::config::{ParseOptions, WriteOptions};
 use lofty::file::AudioFile;
 use lofty::ogg::{OggPictureStorage, VorbisComments, VorbisFile};
 use lofty::picture::{MimeType, Picture, PictureInformation, PictureType};
+use lofty::tag::items::Timestamp;
 use lofty::tag::{Accessor, TagExt};
 
 #[test_log::test]
 fn test_year() {
 	let mut cmt = VorbisComments::default();
-	assert_eq!(cmt.year(), None);
+	assert_eq!(cmt.date(), None);
 	cmt.push(String::from("YEAR"), String::from("2009"));
-	assert_eq!(cmt.year(), Some(2009));
-
-	// NOTE: Lofty will *always* prioritize "YEAR" over "DATE". TagLib doesn't have the same ideas,
-	//       so we have to remove "YEAR".
-	let _ = cmt.remove("YEAR");
-
+	assert_eq!(cmt.date().map(|date| date.year), Some(2009));
 	cmt.push(String::from("DATE"), String::from("2008"));
-	assert_eq!(cmt.year(), Some(2008));
+	assert_eq!(cmt.date().map(|date| date.year), Some(2008));
 }
 
 #[test_log::test]
@@ -28,7 +24,10 @@ fn test_set_year() {
 	let mut cmt = VorbisComments::default();
 	cmt.push(String::from("YEAR"), String::from("2009"));
 	cmt.push(String::from("DATE"), String::from("2008"));
-	cmt.set_year(1995);
+	cmt.set_date(Timestamp {
+		year: 1995,
+		..Timestamp::default()
+	});
 	assert!(cmt.get("YEAR").is_none());
 	assert_eq!(cmt.get("DATE"), Some("1995"));
 }


### PR DESCRIPTION
Since almost all formats support full dates, the `Accessor` methods can now accept and return full `Timestamp`s, rather than just a year.

For ID3v1, the timestamp will just be truncated to its year.

This also changes the `year` field of `Id3v1Tag` to a `u16`, rather than a `String`.

closes #565 