### PR TITLE
ID3v1: Fix resize_string to safely split utf-8 chars

### DIFF
--- a/lofty/src/id3/v1/write.rs
+++ b/lofty/src/id3/v1/write.rs
@@ -50,13 +50,18 @@ where
 }
 
 pub(super) fn encode(tag: &Id3v1TagRef<'_>) -> std::io::Result<Vec<u8>> {
+	#[allow(clippy::sliced_string_as_bytes)]
 	fn resize_string(value: Option<&str>, size: usize) -> std::io::Result<Vec<u8>> {
 		let mut cursor = Cursor::new(vec![0; size]);
 		cursor.rewind()?;
 
 		if let Some(val) = value {
 			if val.len() > size {
-				cursor.write_all(val.split_at(size).0.as_bytes())?;
+				let mut end = size;
+				while !val.is_char_boundary(end) {
+					end -= 1;
+				}
+				cursor.write_all(val[..end].as_bytes())?;
 			} else {
 				cursor.write_all(val.as_bytes())?;
 			}


### PR DESCRIPTION
Incorrect UTF-8 string truncation causes panic

The code truncates strings by byte index, assuming that cutting at a fixed byte length is always safe.
However slicing at an arbitrary byte offset may split a multibyte character, which results in a runtime panic.

**Panic example**

```rust
fn main() {
    let s = "На московских... окраинах..."; // UTF-8, Cyrillic characters
    println!("{:?}", &s.split_at(30).0.as_bytes());
}
```

The new version of rust has a suitable method and I emulated its work for splitting UTF-8 characters

https://doc.rust-lang.org/src/core/str/mod.rs.html#410

```rust
fn main() {
    let s = "На московских... окраинах..."; // UTF-8, Cyrillic characters
    let mut end = 30;
    while !s.is_char_boundary(end) {
        end -= 1;
    }
    println!("{:?}", &s[..end].as_bytes());
}
```