### PR TITLE
WriteOptions: Add `lossy_text_encoding` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `AttachedPictureFrame`, `PopularimeterFrame`, `KeyValueFrame`, `RelativeVolumeAdjustmentFrame`, `UniqueFileIdentifierFrame`, `OwnershipFrame`, `EventTimingCodesFrame`,
     `PrivateFrame`, `BinaryFrame`
   - `FrameId::is_valid()` and `FrameId::is_outdated()`
+- **WriteOptions**: `WriteOptions::lossy_text_encoding()` to replace invalid characters when encoding strings ([PR](https://github.com/Serial-ATA/lofty-rs/pull/594))
+  - When enabled, any non-representable character will be replaced with `?` (e.g. `lфfty` in `TextEncoding::Latin1` will return `l?fty`)
 - **Other**: `EXTENSIONS` list containing common file extensions for all supported audio file types ([issue](https://github.com/Serial-ATA/lofty-rs/issues/509)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/558))
   - This is useful for filtering files when scanning directories. If your app uses extension filtering, **please consider switching to this**, as to not
     miss any supported files.
 
 ### Changed
 - **ID3v2**: Check `TXXX:ALBUMARTIST` and `TXXX:ALBUM ARTIST` for `ItemKey::AlbumArtist` conversions
-- **ID3v1**: The `year` field in `Id3v1Tag` is now a `u16`, instead of a `String` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/574))
+- **ID3v1**:
+  - The `year` field in `Id3v1Tag` is now a `u16`, instead of a `String` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/574))
+  - Strings are now verified to be Latin-1 ([PR](https://github.com/Serial-ATA/lofty-rs/pull/594))
 - **Vorbis Comments**: Check `ALBUM ARTIST` for `ItemKey::AlbumArtist` conversions
 - **Vorbis Comments**: Support `DISCNUMBER` fields with the `current/total` format. ([issue](https://github.com/Serial-ATA/lofty-rs/issues/543)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/544))
     - These fields will now properly be split into `DISCNUMBER` and `DISCTOTAL`, making it possible to use them with
@@ -69,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Since all formats (*except ID3v1*) have full date support, the generic API now accepts `Timestamp`s. For ID3v1, the date will be truncated
     down to the year for conversions/writing.
   - Year tags can still be set manually with `ItemKey::Year`
+- **ID3v2**: `AttachedPictureFrame::as_bytes()` no longer supports encoding ID3v2.2 `PIC` frames
 
 ## [0.22.4] - 2025-04-29
 

--- a/lofty/src/error.rs
+++ b/lofty/src/error.rs
@@ -6,6 +6,7 @@
 use crate::file::FileType;
 use crate::id3::v2::FrameId;
 use crate::tag::ItemKey;
+pub use crate::util::text::TextEncodingError;
 
 use std::collections::TryReserveError;
 use std::fmt::{Debug, Display, Formatter};
@@ -50,6 +51,8 @@ pub enum ErrorKind {
 	FakeTag,
 	/// Errors that arise while decoding text
 	TextDecode(&'static str),
+	/// Errors that arise while encoding text
+	TextEncode(TextEncodingError),
 	/// Arises when decoding OR encoding a problematic [`Timestamp`](crate::tag::items::Timestamp)
 	BadTimestamp(&'static str),
 	/// Errors that arise while reading/writing ID3v2 tags
@@ -466,6 +469,14 @@ impl From<FileEncodingError> for LoftyError {
 	}
 }
 
+impl From<TextEncodingError> for LoftyError {
+	fn from(input: TextEncodingError) -> Self {
+		Self {
+			kind: ErrorKind::TextEncode(input),
+		}
+	}
+}
+
 impl From<ogg_pager::PageError> for LoftyError {
 	fn from(input: PageError) -> Self {
 		Self {
@@ -546,6 +557,7 @@ impl Display for LoftyError {
 			),
 			ErrorKind::FakeTag => write!(f, "Reading: Expected a tag, found invalid data"),
 			ErrorKind::TextDecode(message) => write!(f, "Text decoding: {message}"),
+			ErrorKind::TextEncode(message) => write!(f, "Text encoding: {message}"),
 			ErrorKind::BadTimestamp(message) => {
 				write!(f, "Encountered an invalid timestamp: {message}")
 			},

--- a/lofty/src/id3/v2/frame/mod.rs
+++ b/lofty/src/id3/v2/frame/mod.rs
@@ -2,13 +2,13 @@ pub(super) mod content;
 pub(super) mod header;
 pub(super) mod read;
 
-use super::header::Id3v2Version;
 use super::items::{
 	AttachedPictureFrame, BinaryFrame, CommentFrame, EventTimingCodesFrame, ExtendedTextFrame,
 	ExtendedUrlFrame, KeyValueFrame, OwnershipFrame, PopularimeterFrame, PrivateFrame,
 	RelativeVolumeAdjustmentFrame, TextInformationFrame, TimestampFrame, UniqueFileIdentifierFrame,
 	UnsynchronizedTextFrame, UrlLinkFrame,
 };
+use crate::config::WriteOptions;
 use crate::error::Result;
 use crate::id3::v2::FrameHeader;
 use crate::util::text::TextEncoding;
@@ -216,31 +216,23 @@ impl Frame<'_> {
 }
 
 impl Frame<'_> {
-	pub(super) fn as_bytes(&self, is_id3v23: bool) -> Result<Vec<u8>> {
+	pub(super) fn as_bytes(&self, write_options: WriteOptions) -> Result<Vec<u8>> {
 		Ok(match self {
-			Frame::Comment(comment) => comment.as_bytes(is_id3v23)?,
-			Frame::UnsynchronizedText(lf) => lf.as_bytes(is_id3v23)?,
-			Frame::Text(tif) => tif.as_bytes(is_id3v23),
-			Frame::UserText(content) => content.as_bytes(is_id3v23),
-			Frame::UserUrl(content) => content.as_bytes(is_id3v23),
-			Frame::Url(link) => link.as_bytes(),
-			Frame::Picture(attached_picture) => {
-				let version = if is_id3v23 {
-					Id3v2Version::V3
-				} else {
-					Id3v2Version::V4
-				};
-
-				attached_picture.as_bytes(version)?
-			},
-			Frame::Popularimeter(popularimeter) => popularimeter.as_bytes()?,
-			Frame::KeyValue(content) => content.as_bytes(is_id3v23),
-			Frame::RelativeVolumeAdjustment(frame) => frame.as_bytes(),
-			Frame::UniqueFileIdentifier(frame) => frame.as_bytes(),
-			Frame::Ownership(frame) => frame.as_bytes(is_id3v23)?,
+			Frame::Comment(comment) => comment.as_bytes(write_options)?,
+			Frame::UnsynchronizedText(lf) => lf.as_bytes(write_options)?,
+			Frame::Text(tif) => tif.as_bytes(write_options)?,
+			Frame::UserText(content) => content.as_bytes(write_options)?,
+			Frame::UserUrl(content) => content.as_bytes(write_options)?,
+			Frame::Url(link) => link.as_bytes(write_options)?,
+			Frame::Picture(attached_picture) => attached_picture.as_bytes(write_options)?,
+			Frame::Popularimeter(popularimeter) => popularimeter.as_bytes(write_options)?,
+			Frame::KeyValue(content) => content.as_bytes(write_options)?,
+			Frame::RelativeVolumeAdjustment(frame) => frame.as_bytes(write_options)?,
+			Frame::UniqueFileIdentifier(frame) => frame.as_bytes(write_options)?,
+			Frame::Ownership(frame) => frame.as_bytes(write_options)?,
 			Frame::EventTimingCodes(frame) => frame.as_bytes(),
-			Frame::Private(frame) => frame.as_bytes()?,
-			Frame::Timestamp(frame) => frame.as_bytes(is_id3v23)?,
+			Frame::Private(frame) => frame.as_bytes(write_options)?,
+			Frame::Timestamp(frame) => frame.as_bytes(write_options)?,
 			Frame::Binary(frame) => frame.as_bytes(),
 		})
 	}

--- a/lofty/src/id3/v2/items/extended_url_frame.rs
+++ b/lofty/src/id3/v2/items/extended_url_frame.rs
@@ -1,8 +1,9 @@
+use crate::config::WriteOptions;
 use crate::error::Result;
 use crate::id3::v2::frame::content::verify_encoding;
 use crate::id3::v2::header::Id3v2Version;
 use crate::id3::v2::{FrameFlags, FrameHeader, FrameId};
-use crate::util::text::{TextDecodeOptions, TextEncoding, decode_text, encode_text};
+use crate::util::text::{TextDecodeOptions, TextEncoding, decode_text};
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
@@ -117,18 +118,26 @@ impl<'a> ExtendedUrlFrame<'a> {
 	}
 
 	/// Convert an [`ExtendedUrlFrame`] to a byte vec
-	pub fn as_bytes(&self, is_id3v23: bool) -> Vec<u8> {
+	///
+	/// # Errors
+	///
+	/// * [`WriteOptions::lossy_text_encoding()`] is disabled and the content cannot be encoded in the specified [`TextEncoding`].
+	pub fn as_bytes(&self, write_options: WriteOptions) -> Result<Vec<u8>> {
 		let mut encoding = self.encoding;
-		if is_id3v23 {
+		if write_options.use_id3v23 {
 			encoding = encoding.to_id3v23();
 		}
 
 		let mut bytes = vec![encoding as u8];
 
-		bytes.extend(encode_text(&self.description, encoding, true).iter());
-		bytes.extend(encode_text(&self.content, encoding, false));
+		bytes.extend(
+			encoding
+				.encode(&self.description, true, write_options.lossy_text_encoding)?
+				.iter(),
+		);
+		bytes.extend(encoding.encode(&self.content, false, write_options.lossy_text_encoding)?);
 
-		bytes
+		Ok(bytes)
 	}
 }
 

--- a/lofty/src/id3/v2/items/url_link_frame.rs
+++ b/lofty/src/id3/v2/items/url_link_frame.rs
@@ -1,7 +1,8 @@
 use crate::error::Result;
 use crate::id3::v2::{FrameFlags, FrameHeader, FrameId};
-use crate::util::text::{TextDecodeOptions, TextEncoding, decode_text, encode_text};
+use crate::util::text::{TextDecodeOptions, TextEncoding, decode_text};
 
+use crate::config::WriteOptions;
 use std::borrow::Cow;
 use std::hash::Hash;
 use std::io::Read;
@@ -82,8 +83,14 @@ impl<'a> UrlLinkFrame<'a> {
 	}
 
 	/// Convert an [`UrlLinkFrame`] to a byte vec
-	pub fn as_bytes(&self) -> Vec<u8> {
-		encode_text(&self.content, TextEncoding::Latin1, false)
+	///
+	/// # Errors
+	///
+	/// If [`WriteOptions::lossy_text_encoding()`] is disabled and the content cannot be Latin-1 encoded.
+	pub fn as_bytes(&self, write_options: WriteOptions) -> Result<Vec<u8>> {
+		TextEncoding::Latin1
+			.encode(&self.content, false, write_options.lossy_text_encoding)
+			.map_err(Into::into)
 	}
 
 	/// Get the URL of the frame

--- a/lofty/src/id3/v2/write/mod.rs
+++ b/lofty/src/id3/v2/write/mod.rs
@@ -127,9 +127,9 @@ pub(super) fn create_tag<'a, I: Iterator<Item = Frame<'a>> + 'a>(
 
 	// Write the items
 	if is_id3v23 {
-		frame::create_items_v3(&mut id3v2, &mut peek)?;
+		frame::create_items_v3(&mut id3v2, &mut peek, write_options)?;
 	} else {
-		frame::create_items(&mut id3v2, &mut peek)?;
+		frame::create_items(&mut id3v2, &mut peek, write_options)?;
 	}
 
 	let mut len = id3v2.get_ref().len() - header_len;

--- a/lofty/tests/picture/format_parsers.rs
+++ b/lofty/tests/picture/format_parsers.rs
@@ -1,5 +1,5 @@
 use lofty::TextEncoding;
-use lofty::config::ParsingMode;
+use lofty::config::{ParsingMode, WriteOptions};
 use lofty::id3::v2::{AttachedPictureFrame, FrameFlags, Id3v2Version};
 use lofty::picture::{Picture, PictureInformation, PictureType};
 
@@ -43,7 +43,7 @@ fn as_apic_bytes() {
 	let original_picture = create_original_picture();
 	let apic = AttachedPictureFrame::new(TextEncoding::Latin1, original_picture);
 
-	let original_as_apic = apic.as_bytes(Id3v2Version::V4).unwrap();
+	let original_as_apic = apic.as_bytes(WriteOptions::default()).unwrap();
 
 	assert_eq!(buf, original_as_apic);
 }
@@ -56,18 +56,6 @@ fn id3v22_pic() {
 		.unwrap();
 
 	assert_eq!(&create_original_picture(), &*pic.picture);
-}
-
-#[test_log::test]
-fn as_apic_bytes_v2() {
-	let buf = get_buf("tests/picture/assets/png_640x628.pic");
-
-	let original_picture = create_original_picture();
-	let pic = AttachedPictureFrame::new(TextEncoding::Latin1, original_picture);
-
-	let original_as_pic = pic.as_bytes(Id3v2Version::V2).unwrap();
-
-	assert_eq!(buf, original_as_pic);
 }
 
 #[test_log::test]

--- a/lofty/tests/taglib/test_id3v2.rs
+++ b/lofty/tests/taglib/test_id3v2.rs
@@ -48,7 +48,9 @@ fn test_downgrade_utf8_for_id3v23_1() {
 		.save_to(&mut file, WriteOptions::new().use_id3v23(true))
 		.unwrap();
 
-	let data = f.as_bytes(true);
+	let data = f
+		.as_bytes(WriteOptions::default().use_id3v23(true))
+		.unwrap();
 	assert_eq!(data.len(), 1 + 6 + 2); // NOTE: This does not include frame headers like TagLib does
 
 	let f2 = TextInformationFrame::parse(
@@ -81,7 +83,9 @@ fn test_downgrade_utf8_for_id3v23_2() {
 		.save_to(&mut file, WriteOptions::new().use_id3v23(true))
 		.unwrap();
 
-	let data = f.as_bytes(true).unwrap();
+	let data = f
+		.as_bytes(WriteOptions::default().use_id3v23(true))
+		.unwrap();
 	assert_eq!(data.len(), 1 + 3 + 2 + 2 + 6 + 2); // NOTE: This does not include frame headers like TagLib does
 
 	let f2 =
@@ -101,7 +105,7 @@ fn test_utf16be_delimiter() {
 		String::from("Foo\0Bar"),
 	);
 
-	let data = f.as_bytes(false);
+	let data = f.as_bytes(WriteOptions::default()).unwrap();
 
 	let no_bom_be_data = b"\x02\
 	\0F\0o\0o\0\0\
@@ -127,7 +131,7 @@ fn test_utf16_delimiter() {
 		String::from("Foo\0Bar"),
 	);
 
-	let data = f.as_bytes(false);
+	let data = f.as_bytes(WriteOptions::default()).unwrap();
 
 	// TODO: TagLib writes a BOM to every string, making the output identical to `mutli_bom_le_data`,
 	//       rather than `single_bom_le_data` in Lofty's case. Not sure if we should be writing the BOM
@@ -275,7 +279,7 @@ fn test_render_apic() {
 	);
 
 	assert_eq!(
-		f.as_bytes(Id3v2Version::V4).unwrap(),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	\x03\
 	image/png\x00\
@@ -317,7 +321,7 @@ fn test_render_geob() {
 	);
 
 	assert_eq!(
-		f.as_bytes(),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	\x00\
 	application/octet-stream\x00\
@@ -361,7 +365,7 @@ fn test_render_popm() {
 	let f = PopularimeterFrame::new(String::from("email@example.com"), 2, 3);
 
 	assert_eq!(
-		f.as_bytes().unwrap(),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	email@example.com\x00\
 	\x02\
@@ -451,7 +455,7 @@ fn test_render_relative_volume_frame() {
 	});
 
 	assert_eq!(
-		f.as_bytes(),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	ident\x00\
     \x02\
@@ -496,7 +500,7 @@ fn test_render_unique_file_identifier_frame() {
 	let f = UniqueFileIdentifierFrame::new(String::from("owner"), b"\x01\x02\x03".to_vec());
 
 	assert_eq!(
-		f.as_bytes(),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 owner\x00\
 \x01\x02\x03"
@@ -524,7 +528,10 @@ fn test_render_url_link_frame() {
 	)
 	.unwrap()
 	.unwrap();
-	assert_eq!(f.as_bytes(), b"http://example.com");
+	assert_eq!(
+		f.as_bytes(WriteOptions::default()).unwrap(),
+		b"http://example.com"
+	);
 }
 
 #[test_log::test]
@@ -553,7 +560,7 @@ fn test_render_user_url_link_frame() {
 	);
 
 	assert_eq!(
-		f.as_bytes(false),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	\x00\
 	foo\x00\
@@ -589,7 +596,7 @@ fn test_render_ownership_frame() {
 	);
 
 	assert_eq!(
-		f.as_bytes(false).unwrap(),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 		\x00\
         GBP1.99\x00\
@@ -673,7 +680,7 @@ fn test_render_synchronized_lyrics_frame() {
 	);
 
 	assert_eq!(
-		f.as_bytes().unwrap(),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	\x00\
 	eng\
@@ -767,7 +774,7 @@ fn test_render_comments_frame() {
 	);
 
 	assert_eq!(
-		f.as_bytes(false).unwrap(),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	\x01\
 	eng\
@@ -804,7 +811,7 @@ fn test_render_private_frame() {
 	let f = PrivateFrame::new(String::from("WM/Provider"), b"TL".to_vec());
 
 	assert_eq!(
-		f.as_bytes().unwrap(),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	WM/Provider\x00\
 	TL"
@@ -849,7 +856,7 @@ fn test_render_user_text_identification_frame() {
 	let mut f = ExtendedTextFrame::new(TextEncoding::Latin1, String::new(), String::from("Text"));
 
 	assert_eq!(
-		f.as_bytes(false),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	\x00\
 	\x00\
@@ -859,7 +866,7 @@ fn test_render_user_text_identification_frame() {
 	f.description = Cow::Borrowed("Description");
 
 	assert_eq!(
-		f.as_bytes(false),
+		f.as_bytes(WriteOptions::default()).unwrap(),
 		b"\
 	\x00\
 	Description\x00\


### PR DESCRIPTION
Text encoding is now fallible, with the option to replace invalid characters with `'?'` or return an error. For now, the only fallible encoding is `TextEncoding::Latin1`.