### PR TITLE
MP4: Fix freeform atom size validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     header, then the parser would error.
 - **FLAC**: Fix corruption of files with no metadata blocks ([issue](https://github.com/Serial-ATA/lofty-rs/issues/549)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/583))
 - **OGG**: Improved performance of page searching ([issue](https://github.com/Serial-ATA/lofty-rs/issues/588)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/600))
+- **MP4**: Don't error on freeform atoms with no data ([PR](https://github.com/Serial-ATA/lofty-rs/pull/599))
 
 ### Removed
 * **ItemKey**: `ItemKey::Unknown` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/526))

--- a/lofty/src/mp4/atom_info.rs
+++ b/lofty/src/mp4/atom_info.rs
@@ -180,7 +180,12 @@ impl AtomInfo {
 
 		// `len` includes itself and the identifier
 		if (len - ATOM_HEADER_LEN) > reader_size {
-			log::warn!("Encountered an atom with an invalid length, stopping");
+			log::warn!(
+				"Atom size exceeds remaining data (ident={} len={}, remaining={})",
+				identifier.escape_ascii(),
+				len,
+				reader_size
+			);
 
 			// As with all formats, there's a good chance certain software won't know how to actually use padding.
 			// If the file ends with an incorrectly sized padding atom, we can just ignore it.
@@ -271,7 +276,7 @@ where
 				err!(BadAtom("Found an incomplete freeform identifier chunk"));
 			}
 
-			if len >= *reader_size {
+			if len > *reader_size {
 				err!(SizeMismatch);
 			}
 


### PR DESCRIPTION
Change freeform chunk size check from >= to > to allow atoms that exactly fill the remaining space