### PR TITLE
ID3v2: fallback when BOM is not present in UTF-16 data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **ID3v2**: Don't error on empty UTF-16 descriptions ([issue](https://github.com/Serial-ATA/lofty-rs/issues/613)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/614))
+
 ## [0.23.2] - 2026-02-14
+
+### Fixed
 
 - **FLAC**:
   - Fix duplicate `Last-metadata-block` flags in the presence of PADDING blocks ([issue](https://github.com/Serial-ATA/lofty-rs/issues/607)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/609))


### PR DESCRIPTION
Resolves #613

This restores the behavior prior to #535 where language frames are still parsed successfully if the BOM is not present in UTF-16 data. I don't have any files that cause an issue here with text frames, but I updated it there too for consistently. I can revert that if desired.