### PR TITLE
ID3v2: remove support for `ItemKey::Lyrics`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ItemKey**: `ItemKey::MusicBrainzReleaseType` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/626))
   - See <https://picard-docs.musicbrainz.org/en/appendices/tag_mapping.html#id32>
 
+### Changed
+
+- **ID3v2**: `ItemKey::Lyrics` is no longer supported ([issue](https://github.com/Serial-ATA/lofty-rs/issues/624)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/628))
+  - `ItemKey::Lyrics` is often overloaded with synchronized lyrics in [LRC format](https://en.wikipedia.org/wiki/LRC_(file_format)).
+    In other formats, the distinction between `ItemKey::Lyrics` and `ItemKey::UnsyncLyrics` doesn't matter much as they're both
+    text fields. In ID3v2, however, synchronized lyrics are a separate binary frame. To write synchronized lyrics, you'll have to use
+    [`Id3v2Tag`](https://docs.rs/lofty/latest/lofty/id3/v2/struct.Id3v2Tag.html) and [`SynchronizedTextFrame`](https://docs.rs/lofty/latest/lofty/id3/v2/struct.SynchronizedTextFrame.html)
+    directly.
+
 ### Fixed
 
 - **ID3v2**:

--- a/lofty/src/id3/v2/tag/conversion.rs
+++ b/lofty/src/id3/v2/tag/conversion.rs
@@ -193,14 +193,14 @@ pub(crate) fn from_tag<'a>(
 			},
 
 			// Comment/Unsync text
-			ItemKey::Comment | ItemKey::Lyrics | ItemKey::UnsyncLyrics => {
+			ItemKey::Comment | ItemKey::UnsyncLyrics => {
 				let lang = item.lang;
 				let (value, description) = take_item_text_and_description(item)?;
 
 				let map;
 				match item_key {
 					ItemKey::Comment => map = &mut ctx.comments,
-					ItemKey::Lyrics | ItemKey::UnsyncLyrics => map = &mut ctx.unsync_text,
+					ItemKey::UnsyncLyrics => map = &mut ctx.unsync_text,
 					_ => unreachable!(),
 				}
 

--- a/lofty/src/tag/item.rs
+++ b/lofty/src/tag/item.rs
@@ -149,7 +149,7 @@ gen_map!(
 	"language"                       => Language,
 	"Script"                         => Script,
 	"Lyrics"                         => Lyrics,
-	"UnsynchedLyrics"                => UnsyncLyrics,
+	"UnsyncedLyrics"                 => UnsyncLyrics,
 	"MUSICBRAINZ_TRACKID"            => MusicBrainzRecordingId,
 	"MUSICBRAINZ_RELEASETRACKID"     => MusicBrainzTrackId,
 	"MUSICBRAINZ_ALBUMID"            => MusicBrainzReleaseId,
@@ -247,9 +247,9 @@ gen_map!(
 	"COMM"                                  => Comment,
 	"TLAN"                                  => Language,
 	// Since ID3v2 has its own standard for synchronized lyrics (SYLT frame), and it'd be out of scope
-	// to attempt to parse and convert LRC text into one, we can just treat both `Lyrics` and `UnsyncLyrics`
-	// the same and map them to USLT.
-	"USLT"                                  => Lyrics | UnsyncLyrics,
+	// to attempt to parse and convert LRC text into one. So we can't reasonably support `ItemKey::Lyrics`,
+	// with it being overloaded with both synchronized and unsynchronized lyrics.
+	"USLT"                                  => UnsyncLyrics,
 	// Mapping of MusicBrainzRecordingId is implemented as a special case
 	"MusicBrainz Release Track Id"          => MusicBrainzTrackId,
 	"MusicBrainz Album Id"                  => MusicBrainzReleaseId,
@@ -833,7 +833,7 @@ gen_item_keys!(
 		///
 		/// ID3v2 is the only format that has a *specified* way of storing synchronized lyrics, and
 		/// with it being a binary frame, it's only supported through [`Id3v2Tag`] via [`SynchronizedTextFrame`].
-		/// Both [`ItemKey::Lyrics`] and [`ItemKey::UnsyncLyrics`] will be stored in a `USLT` frame.
+		/// [`ItemKey::Lyrics`] is **not** supported in ID3v2, you must use [`ItemKey::UnsyncLyrics`].
 		///
 		/// [LRC format]: https://en.wikipedia.org/wiki/LRC_(file_format)
 		/// [`Id3v2Tag`]: crate::id3::v2::Id3v2Tag
@@ -1045,8 +1045,8 @@ mod tests {
 
 	#[test]
 	fn one_to_many() {
-		assert_eq!(ItemKey::Lyrics.map_key(TagType::Id3v2), Some("USLT"));
-		assert_eq!(ItemKey::UnsyncLyrics.map_key(TagType::Id3v2), Some("USLT"));
+		assert_eq!(ItemKey::Publisher.map_key(TagType::Id3v2), Some("TPUB"));
+		assert_eq!(ItemKey::Label.map_key(TagType::Id3v2), Some("TPUB"));
 	}
 
 	#[test]

--- a/lofty/tests/tags/conversions.rs
+++ b/lofty/tests/tags/conversions.rs
@@ -17,7 +17,7 @@ use std::borrow::Cow;
 #[test_log::test]
 fn tag_to_id3v2_lang_frame() {
 	let mut tag = Tag::new(TagType::Id3v2);
-	tag.insert_text(ItemKey::Lyrics, String::from("Test lyrics"));
+	tag.insert_text(ItemKey::UnsyncLyrics, String::from("Test lyrics"));
 	tag.insert_text(ItemKey::Comment, String::from("Test comment"));
 
 	let id3: Id3v2Tag = tag.into();


### PR DESCRIPTION
closes #624