### PR TITLE
Improve documentation with fixes, comments, and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **APE**: The `Tag` -> `ApeTag` conversion will now preserve multi-value items ([issue](https://github.com/Serial-ATA/lofty-rs/issues/631)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/633))
 
+### Removed
+
+- **ItemKey**: `ItemKey::FileType` and `ItemKey::MusicianCredits` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/636))
+    - These are ID3v2-specific fields with special formats.
+
 ## [0.23.3] - 2026-03-14
 
 ### Added

--- a/doc/ISSUES.md
+++ b/doc/ISSUES.md
@@ -97,7 +97,7 @@ The "[MISC] Feature Request" issue template is for feature requests that either:
 
 The "[API] Feature Request" issue template is for feature requests that have a specific design.
 
-If you have an feature with an exact idea of how it should be used, be sure to use this template.
+If you have a feature with an exact idea of how it should be used, be sure to use this template.
 
 The "API design" form should only serve as a design, not an implementation.
 

--- a/doc/NEW_FILE.md
+++ b/doc/NEW_FILE.md
@@ -57,7 +57,7 @@ Now that the directories are created, we can start working on defining our file.
 
 Before we can define the file struct, we need to add a variant to `FileType`.
 
-Go to [src/file.rs](../src/file.rs) and edit the `FileType` enum to add your new variant.
+Go to [src/file/file_type.rs](../lofty/src/file/file_type.rs) and edit the `FileType` enum to add your new variant.
 
 ```rust
 pub enum FileType {
@@ -216,7 +216,8 @@ They can be easily defined in a few lines:
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use lofty::{AudioFile, ParseOptions};
+use lofty::config::ParseOptions;
+use lofty::file::AudioFile;
 
 fuzz_target!(|data: Vec<u8>| {
     let _ = lofty::foo::FooFile::read_from(

--- a/doc/NEW_TAG.md
+++ b/doc/NEW_TAG.md
@@ -35,7 +35,7 @@ This document will cover the implementation of a tag file format named "Foo".
 To define a new tag format, first determine if it is supported by a single format. In this example it is,
 so we would place its definition in a subdirectory of the `foo` directory, where we defined the Foo audio format.
 If this was a generic tag format supported by multiple audio formats, like ID3, you'd simply define it in its own
-folder inside [src/](../src).
+folder inside [src/](../lofty/src).
 
 There are some files that every tag needs:
 
@@ -62,7 +62,7 @@ Now that the directories are created, we can start working on defining our file.
 
 Before we can define the tag struct, we need to add a variant to `TagType`.
 
-Go to [src/tag/mod.rs](../src/tag/mod.rs) and edit the `TagType` enum to add your new variant.
+Go to [src/tag/mod.rs](../lofty/src/tag/mod.rs) and edit the `TagType` enum to add your new variant.
 
 ```rust
 pub enum TagType {
@@ -149,7 +149,7 @@ impl Accessor for FooTag {
 
     fn artist(&self) -> Option<Cow<'_, str>> { /**/ }
     fn set_artist(&mut self, value: String) { /**/ }
-    fn remove_artist() { /**/ }
+    fn remove_artist(&mut self) { /**/ }
 
     fn album(&self) -> Option<Cow<'_, str>> { /**/ }
     fn set_album(&mut self, value: String) { /**/ }
@@ -187,8 +187,8 @@ impl FooTag {
         self.items.push((key, value))
     }
 
-    pub fn remove<'a>(&'a mut self, key: &str) -> impl Iterator<Item=String> + use<'a> {
-        self.items.retain(|(k, _)| !k.eq_ignore_ascii_case(&key));
+    pub fn remove(&mut self, key: &str) {
+        self.items.retain(|(k, _)| !k.eq_ignore_ascii_case(key));
     }
 }
 ```
@@ -240,7 +240,7 @@ Converting your concrete tag type into the generic `Tag` involves the following:
 
 ##### Defining Generic Mappings
 
-The `ItemKey` mappings are defined in [src/tag/item.rs](../src/tag/item.rs).
+The `ItemKey` mappings are defined in [src/tag/item.rs](../lofty/src/tag/item.rs).
 
 See the comments for the `gen_map!` macro, which explains its use in detail, and will be kept up to
 date with any future changes.
@@ -411,7 +411,7 @@ TODO
 
 #### Assets
 
-Test assets for tag formats are to be placed in [tests/tags/assets/](../tests/tags/assets).
+Test assets for tag formats are to be placed in [tests/tags/assets/](../lofty/tests/tags/assets).
 
 There should at least be one asset, which is a binary file containing the tag below:
 
@@ -444,7 +444,7 @@ There are at least 4 unit tests that should be created for every tag format:
   * Using `crate::tag::utils::test_utils::create_tag()`, verify that the converted tag is correct
 
 These tests should be placed in the tag's `read` module. If there are many tests, feel free to break them out
-into their own module (ex. See the [ID3v2 `tests` module](../src/id3/v2/tag)).
+into their own module (ex. See the [ID3v2 `tests` module](../lofty/src/id3/v2/tag)).
 
 For an example of these tests, see the [ApeTag tests](https://github.com/Serial-ATA/lofty-rs/blob/9c0ea926c690bc6338ba95aceccc4d93e2ee9826/src/ape/tag/mod.rs#L540-L656).
 
@@ -452,4 +452,4 @@ For an example of these tests, see the [ApeTag tests](https://github.com/Serial-
 
 Integration testing is not normally necessary for tag formats, as they are typically
 tested extensively through the module's unit tests. However, if one wants to create integration tests,
-they can be placed in [tests/tags/](../tests/tags).
+they can be placed in [tests/tags/](../lofty/tests/tags).

--- a/doc/PULL_REQUESTS.md
+++ b/doc/PULL_REQUESTS.md
@@ -14,7 +14,7 @@
 Before you create a PR, we ask that you do the following:
 
 1. **If fixing a bug, make an issue first**: The issue tracker should have a searchable history of
-bugs reports.
+bug reports.
 
 2. **If adding a feature, make an issue or discussion first**: Features should be discussed prior to implementation.
 

--- a/lofty/src/file/file_type.rs
+++ b/lofty/src/file/file_type.rs
@@ -47,21 +47,33 @@ pub const EXTENSIONS: &[&str] = &[
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[allow(clippy::unsafe_derive_deserialize)]
-#[allow(missing_docs)]
 #[non_exhaustive]
 pub enum FileType {
+	/// Advanced Audio Coding (AAC/ADTS)
 	Aac,
+	/// Audio Interchange File Format
 	Aiff,
+	/// Monkey's Audio
 	Ape,
+	/// Free Lossless Audio Codec
 	Flac,
+	/// MPEG-1/2 Audio (MP1, MP2, MP3)
 	Mpeg,
+	/// MPEG-4 Audio (M4A, M4B, etc.)
 	Mp4,
+	/// Musepack
 	Mpc,
+	/// Opus
 	Opus,
+	/// Ogg Vorbis
 	Vorbis,
+	/// Speex
 	Speex,
+	/// Waveform Audio
 	Wav,
+	/// WavPack
 	WavPack,
+	/// A custom file type, registered through [`register_custom_resolver`](crate::resolve::register_custom_resolver)
 	Custom(&'static str),
 }
 

--- a/lofty/src/id3/mod.rs
+++ b/lofty/src/id3/mod.rs
@@ -1,7 +1,9 @@
 //! ID3 specific items
 //!
-//! ID3 does things differently than other tags, making working with them a little more effort than other formats.
-//! Check the other modules for important notes and/or warnings.
+//! This covers both [`v1`] (ID3v1) and [`v2`] (ID3v2) tag formats.
+//!
+//! ID3 does things differently than other tags, making them a little more cumbersome to work with.
+//! Check the other modules for important notes and warnings.
 
 pub mod v1;
 pub mod v2;

--- a/lofty/src/id3/v2/frame/header/mod.rs
+++ b/lofty/src/id3/v2/frame/header/mod.rs
@@ -14,9 +14,9 @@ use std::fmt::{Display, Formatter};
 /// These are rarely constructed by hand. Usually they are created in the background
 /// when making a new [`Frame`](crate::id3::v2::Frame).
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[allow(missing_docs)]
 pub struct FrameHeader<'a> {
 	pub(crate) id: FrameId<'a>,
+	/// The frame's flags
 	pub flags: FrameFlags,
 }
 

--- a/lofty/src/id3/v2/items/event_timing_codes_frame.rs
+++ b/lofty/src/id3/v2/items/event_timing_codes_frame.rs
@@ -22,54 +22,93 @@ const FRAME_ID: FrameId<'static> = FrameId::Valid(Cow::Borrowed("ETCO"));
 /// >>> like setting off an explosion on-stage, activating a screensaver etc.
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
-#[allow(missing_docs)]
 pub enum EventType {
+	/// Padding (has no meaning)
 	Padding = 0x00,
+	/// End of initial silence
 	EndOfInitialSilence = 0x01,
+	/// Intro start
 	IntroStart = 0x02,
+	/// Main part start
 	MainPartStart = 0x03,
+	/// Outro start
 	OutroStart = 0x04,
+	/// Outro end
 	OutroEnd = 0x05,
+	/// Verse start
 	VerseStart = 0x06,
+	/// Refrain start
 	RefrainStart = 0x07,
+	/// Interlude start
 	InterludeStart = 0x08,
+	/// Theme start
 	ThemeStart = 0x09,
+	/// Variation start
 	VariationStart = 0x0A,
+	/// Key change
 	KeyChange = 0x0B,
+	/// Time change
 	TimeChange = 0x0C,
+	/// Momentary unwanted noise (Alarm, Phone, etc.)
 	MomentaryUnwantedNoise = 0x0D,
+	/// Sustained noise
 	SustainedNoise = 0x0E,
+	/// Sustained noise end
 	SustainedNoiseEnd = 0x0F,
+	/// Intro end
 	IntroEnd = 0x10,
+	/// Main part end
 	MainPartEnd = 0x11,
+	/// Verse end
 	VerseEnd = 0x12,
+	/// Refrain end
 	RefrainEnd = 0x13,
+	/// Theme end
 	ThemeEnd = 0x14,
+	/// Profanity
 	Profanity = 0x15,
+	/// Profanity end
 	ProfanityEnd = 0x16,
 
-	// User-defined events
+	/// Not predefined synch 0 (user event)
 	NotPredefinedSynch0 = 0xE0,
+	/// Not predefined synch 1 (user event)
 	NotPredefinedSynch1 = 0xE1,
+	/// Not predefined synch 2 (user event)
 	NotPredefinedSynch2 = 0xE2,
+	/// Not predefined synch 3 (user event)
 	NotPredefinedSynch3 = 0xE3,
+	/// Not predefined synch 4 (user event)
 	NotPredefinedSynch4 = 0xE4,
+	/// Not predefined synch 5 (user event)
 	NotPredefinedSynch5 = 0xE5,
+	/// Not predefined synch 6 (user event)
 	NotPredefinedSynch6 = 0xE6,
+	/// Not predefined synch 7 (user event)
 	NotPredefinedSynch7 = 0xE7,
+	/// Not predefined synch 8 (user event)
 	NotPredefinedSynch8 = 0xE8,
+	/// Not predefined synch 9 (user event)
 	NotPredefinedSynch9 = 0xE9,
+	/// Not predefined synch A (user event)
 	NotPredefinedSynchA = 0xEA,
+	/// Not predefined synch B (user event)
 	NotPredefinedSynchB = 0xEB,
+	/// Not predefined synch C (user event)
 	NotPredefinedSynchC = 0xEC,
+	/// Not predefined synch D (user event)
 	NotPredefinedSynchD = 0xED,
+	/// Not predefined synch E (user event)
 	NotPredefinedSynchE = 0xEE,
+	/// Not predefined synch F (user event)
 	NotPredefinedSynchF = 0xEF,
 
+	/// Audio end (start of silence)
 	AudioEnd = 0xFD,
+	/// Audio file ends
 	AudioFileEnds = 0xFE,
 
-	/// 0x17..=0xDF and 0xF0..=0xFC
+	/// Reserved event type (0x17..=0xDF and 0xF0..=0xFC)
 	Reserved,
 }
 

--- a/lofty/src/id3/v2/items/relative_volume_adjustment_frame.rs
+++ b/lofty/src/id3/v2/items/relative_volume_adjustment_frame.rs
@@ -16,16 +16,24 @@ const FRAME_ID: FrameId<'static> = FrameId::Valid(Cow::Borrowed("RVA2"));
 /// A channel identifier used in the RVA2 frame
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
-#[allow(missing_docs)]
 pub enum ChannelType {
+	/// Other channel type
 	Other = 0,
+	/// Master volume
 	MasterVolume = 1,
+	/// Front right
 	FrontRight = 2,
+	/// Front left
 	FrontLeft = 3,
+	/// Back right
 	BackRight = 4,
+	/// Back left
 	BackLeft = 5,
+	/// Front centre
 	FrontCentre = 6,
+	/// Back centre
 	BackCentre = 7,
+	/// Subwoofer
 	Subwoofer = 8,
 }
 

--- a/lofty/src/id3/v2/items/sync_text.rs
+++ b/lofty/src/id3/v2/items/sync_text.rs
@@ -38,16 +38,24 @@ impl TimestampFormat {
 /// The type of text stored in a [`SynchronizedTextFrame`]
 #[derive(Copy, Clone, PartialEq, Debug, Eq, Hash)]
 #[repr(u8)]
-#[allow(missing_docs)]
 pub enum SyncTextContentType {
+	/// Other content type
 	Other = 0,
+	/// Lyrics
 	Lyrics = 1,
+	/// Text transcription
 	TextTranscription = 2,
+	/// Movement/part name (e.g. "Adagio")
 	PartName = 3,
+	/// Events (e.g. "Don Quixote enters the stage")
 	Events = 4,
+	/// Chord (e.g. "Bb F Fsus")
 	Chord = 5,
+	/// Trivia/"pop up" information
 	Trivia = 6,
+	/// URLs to webpages
 	WebpageURL = 7,
+	/// URLs to images
 	ImageURL = 8,
 }
 

--- a/lofty/src/id3/v2/items/timestamp_frame.rs
+++ b/lofty/src/id3/v2/items/timestamp_frame.rs
@@ -11,10 +11,11 @@ use byteorder::ReadBytesExt;
 
 /// An `ID3v2` timestamp frame
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[allow(missing_docs)]
 pub struct TimestampFrame<'a> {
 	pub(crate) header: FrameHeader<'a>,
+	/// The text encoding used for the timestamp
 	pub encoding: TextEncoding,
+	/// The timestamp value
 	pub timestamp: Timestamp,
 }
 

--- a/lofty/src/id3/v2/tag/conversion.rs
+++ b/lofty/src/id3/v2/tag/conversion.rs
@@ -131,7 +131,6 @@ pub(crate) fn from_tag<'a>(
 			| ItemKey::Conductor
 			| ItemKey::Writer
 			| ItemKey::Lyricist
-			| ItemKey::MusicianCredits
 			| ItemKey::InternetRadioStationName
 			| ItemKey::InternetRadioStationOwner
 			| ItemKey::Remixer

--- a/lofty/src/iff/mod.rs
+++ b/lofty/src/iff/mod.rs
@@ -1,4 +1,7 @@
-//! WAV/AIFF specific items
+//! IFF container format items
+//!
+//! The Interchange File Format (IFF) is a generic container used by both [`AIFF`](aiff) and [`WAV`](wav) files.
+
 pub mod aiff;
 pub(crate) mod chunk;
 pub mod wav;

--- a/lofty/src/iff/wav/properties.rs
+++ b/lofty/src/iff/wav/properties.rs
@@ -12,11 +12,14 @@ const IEEE_FLOAT: u16 = 0x0003;
 const EXTENSIBLE: u16 = 0xFFFE;
 
 /// A WAV file's format
-#[allow(missing_docs, non_camel_case_types)]
+#[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WavFormat {
+	/// Pulse-code modulation (uncompressed)
 	PCM,
+	/// IEEE 754 floating-point
 	IEEE_FLOAT,
+	/// Other format identified by its format tag
 	Other(u16),
 }
 

--- a/lofty/src/mp4/properties.rs
+++ b/lofty/src/mp4/properties.rs
@@ -13,69 +13,116 @@ use std::time::Duration;
 use byteorder::{BigEndian, ReadBytesExt};
 
 /// An MP4 file's audio codec
-#[allow(missing_docs)]
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Mp4Codec {
+	/// Some other codec unknown to Lofty
 	#[default]
 	Unknown,
+	/// Advanced Audio Coding
 	AAC,
+	/// Apple Lossless Audio Codec
 	ALAC,
+	/// MPEG Audio Layer 3
 	MP3,
+	/// Free Lossless Audio Codec
 	FLAC,
 }
 
-#[allow(missing_docs)]
+/// MPEG-4 Audio Object Type as defined in ISO 14496-3
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 #[rustfmt::skip]
 #[non_exhaustive]
 pub enum AudioObjectType {
 	// https://en.wikipedia.org/wiki/MPEG-4_Part_3#MPEG-4_Audio_Object_Types
 
+	/// Null/unknown object type
 	#[default]
 	NULL = 0,
-	AacMain = 1,                                       // AAC Main Profile
-	AacLowComplexity = 2,                              // AAC Low Complexity
-	AacScalableSampleRate = 3,                         // AAC Scalable Sample Rate
-	AacLongTermPrediction = 4,                         // AAC Long Term Predictor
-	SpectralBandReplication = 5,                       // Spectral band Replication
-	AACScalable = 6,                                   // AAC Scalable
-	TwinVQ = 7,                                        // Twin VQ
-	CodeExcitedLinearPrediction = 8,                   // CELP
-	HarmonicVectorExcitationCoding = 9,                // HVXC
-	TextToSpeechtInterface = 12,                       // TTSI
-	MainSynthetic = 13,                                // Main Synthetic
-	WavetableSynthesis = 14,                           // Wavetable Synthesis
-	GeneralMIDI = 15,                                  // General MIDI
-	AlgorithmicSynthesis = 16,                         // Algorithmic Synthesis
-	ErrorResilientAacLowComplexity = 17,               // ER AAC LC
-	ErrorResilientAacLongTermPrediction = 19,          // ER AAC LTP
-	ErrorResilientAacScalable = 20,                    // ER AAC Scalable
-	ErrorResilientAacTwinVQ = 21,                      // ER AAC TwinVQ
-	ErrorResilientAacBitSlicedArithmeticCoding = 22,   // ER Bit Sliced Arithmetic Coding
-	ErrorResilientAacLowDelay = 23,                    // ER AAC Low Delay
-	ErrorResilientCodeExcitedLinearPrediction = 24,    // ER CELP
-	ErrorResilientHarmonicVectorExcitationCoding = 25, // ER HVXC
-	ErrorResilientHarmonicIndividualLinesNoise = 26,   // ER HILN
-	ErrorResilientParametric = 27,                     // ER Parametric
-	SinuSoidalCoding = 28,                             // SSC
-	ParametricStereo = 29,                             // PS
-	MpegSurround = 30,                                 // MPEG Surround
-	MpegLayer1 = 32,                                   // MPEG Layer 1
-	MpegLayer2 = 33,                                   // MPEG Layer 2
-	MpegLayer3 = 34,                                   // MPEG Layer 3
-	DirectStreamTransfer = 35,                         // DST Direct Stream Transfer
-	AudioLosslessCoding = 36,                          // ALS Audio Lossless Coding
-	ScalableLosslessCoding = 37,                       // SLC Scalable Lossless Coding
-	ScalableLosslessCodingNoneCore = 38,               // SLC non-core
-	ErrorResilientAacEnhancedLowDelay = 39,            // ER AAC ELD
-	SymbolicMusicRepresentationSimple = 40,            // SMR Simple
-	SymbolicMusicRepresentationMain = 41,              // SMR Main
-	UnifiedSpeechAudioCoding = 42,                     // USAC
-	SpatialAudioObjectCoding = 43,                     // SAOC
-	LowDelayMpegSurround = 44,                         // LD MPEG Surround
-	SpatialAudioObjectCodingDialogueEnhancement = 45,  // SAOC-DE
-	AudioSync = 46,                                    // Audio Sync
+	/// AAC Main Profile
+	AacMain = 1,
+	/// AAC Low Complexity
+	AacLowComplexity = 2,
+	/// AAC Scalable Sample Rate
+	AacScalableSampleRate = 3,
+	/// AAC Long Term Predictor
+	AacLongTermPrediction = 4,
+	/// Spectral Band Replication
+	SpectralBandReplication = 5,
+	/// AAC Scalable
+	AACScalable = 6,
+	/// Twin VQ
+	TwinVQ = 7,
+	/// Code Excited Linear Prediction (CELP)
+	CodeExcitedLinearPrediction = 8,
+	/// Harmonic Vector Excitation Coding (HVXC)
+	HarmonicVectorExcitationCoding = 9,
+	/// Text-To-Speech Interface (TTSI)
+	TextToSpeechtInterface = 12,
+	/// Main Synthetic
+	MainSynthetic = 13,
+	/// Wavetable Synthesis
+	WavetableSynthesis = 14,
+	/// General MIDI
+	GeneralMIDI = 15,
+	/// Algorithmic Synthesis and Audio FX
+	AlgorithmicSynthesis = 16,
+	/// Error Resilient AAC Low Complexity
+	ErrorResilientAacLowComplexity = 17,
+	/// Error Resilient AAC Long Term Prediction
+	ErrorResilientAacLongTermPrediction = 19,
+	/// Error Resilient AAC Scalable
+	ErrorResilientAacScalable = 20,
+	/// Error Resilient AAC TwinVQ
+	ErrorResilientAacTwinVQ = 21,
+	/// Error Resilient Bit Sliced Arithmetic Coding
+	ErrorResilientAacBitSlicedArithmeticCoding = 22,
+	/// Error Resilient AAC Low Delay
+	ErrorResilientAacLowDelay = 23,
+	/// Error Resilient Code Excited Linear Prediction
+	ErrorResilientCodeExcitedLinearPrediction = 24,
+	/// Error Resilient Harmonic Vector Excitation Coding
+	ErrorResilientHarmonicVectorExcitationCoding = 25,
+	/// Error Resilient Harmonic and Individual Lines plus Noise
+	ErrorResilientHarmonicIndividualLinesNoise = 26,
+	/// Error Resilient Parametric
+	ErrorResilientParametric = 27,
+	/// Sinusoidal Coding (SSC)
+	SinuSoidalCoding = 28,
+	/// Parametric Stereo
+	ParametricStereo = 29,
+	/// MPEG Surround
+	MpegSurround = 30,
+	/// MPEG Layer 1
+	MpegLayer1 = 32,
+	/// MPEG Layer 2
+	MpegLayer2 = 33,
+	/// MPEG Layer 3
+	MpegLayer3 = 34,
+	/// Direct Stream Transfer (DST)
+	DirectStreamTransfer = 35,
+	/// Audio Lossless Coding (ALS)
+	AudioLosslessCoding = 36,
+	/// Scalable Lossless Coding (SLS)
+	ScalableLosslessCoding = 37,
+	/// Scalable Lossless Coding non-core
+	ScalableLosslessCodingNoneCore = 38,
+	/// Error Resilient AAC Enhanced Low Delay
+	ErrorResilientAacEnhancedLowDelay = 39,
+	/// Symbolic Music Representation Simple
+	SymbolicMusicRepresentationSimple = 40,
+	/// Symbolic Music Representation Main
+	SymbolicMusicRepresentationMain = 41,
+	/// Unified Speech and Audio Coding (USAC)
+	UnifiedSpeechAudioCoding = 42,
+	/// Spatial Audio Object Coding (SAOC)
+	SpatialAudioObjectCoding = 43,
+	/// Low Delay MPEG Surround
+	LowDelayMpegSurround = 44,
+	/// Spatial Audio Object Coding - Dialogue Enhancement
+	SpatialAudioObjectCodingDialogueEnhancement = 45,
+	/// Audio Sync
+	AudioSync = 46,
 }
 
 impl TryFrom<u8> for AudioObjectType {

--- a/lofty/src/mpeg/header.rs
+++ b/lofty/src/mpeg/header.rs
@@ -159,46 +159,53 @@ where
 
 /// MPEG Audio version
 #[derive(Default, PartialEq, Eq, Copy, Clone, Debug)]
-#[allow(missing_docs)]
 pub enum MpegVersion {
+	/// MPEG Version 1
 	#[default]
 	V1,
+	/// MPEG Version 2
 	V2,
+	/// MPEG Version 2.5
 	V2_5,
-	/// Exclusive to AAC
+	/// MPEG-4 (exclusive to AAC)
 	V4,
 }
 
 /// MPEG layer
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
-#[allow(missing_docs)]
 pub enum Layer {
+	/// MPEG Audio Layer 1
 	Layer1 = 1,
+	/// MPEG Audio Layer 2
 	Layer2 = 2,
+	/// MPEG Audio Layer 3 (MP3)
 	#[default]
 	Layer3 = 3,
 }
 
 /// Channel mode
 #[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
-#[allow(missing_docs)]
 pub enum ChannelMode {
+	/// Standard stereo
 	#[default]
 	Stereo = 0,
+	/// Joint stereo (intensity and/or mid-side)
 	JointStereo = 1,
 	/// Two independent mono channels
 	DualChannel = 2,
+	/// Single mono channel
 	SingleChannel = 3,
 }
 
 /// A rarely-used decoder hint that the file must be de-emphasized
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[allow(missing_docs, non_camel_case_types)]
+#[allow(non_camel_case_types)]
 pub enum Emphasis {
-	/// 50/15 ms
+	/// 50/15 ms de-emphasis
 	MS5015,
+	/// Reserved
 	Reserved,
-	/// CCIT J.17
+	/// CCIT J.17 de-emphasis
 	CCIT_J17,
 }
 

--- a/lofty/src/musepack/sv8/properties.rs
+++ b/lofty/src/musepack/sv8/properties.rs
@@ -162,15 +162,16 @@ impl StreamHeader {
 /// * For 16-bit output (range \[-32767 32768]), the max is 68813 (out of range). It will be encoded as $ 20 * log10(68813) * 256 ~ 24769 = 0x60C1 $
 /// * For float output (range \[-1 1]), the max is 0.96. It will be encoded as $ 20 * log10(0.96 * 215) * 256 ~ 23029 = 0x59F5 $ (for peak values it is suggested to round to nearest higher integer)
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-#[allow(missing_docs)]
 pub struct ReplayGain {
 	/// The replay gain version
 	pub version: u8,
 	/// The loudness calculated for the title, and not the gain that the player must apply
 	pub title_gain: u16,
+	/// The peak title loudness level
 	pub title_peak: u16,
 	/// The loudness calculated for the album
 	pub album_gain: u16,
+	/// The peak album loudness level
 	pub album_peak: u16,
 }
 
@@ -203,10 +204,10 @@ impl ReplayGain {
 
 /// Information from an Encoder Info packet
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-#[allow(missing_docs)]
 pub struct EncoderInfo {
 	/// Quality in 4.3 format
 	pub profile: f32,
+	/// Whether the PNS (Perceptual Noise Substitution) tool is enabled
 	pub pns_tool: bool,
 	/// Major version
 	pub major: u8,

--- a/lofty/src/picture.rs
+++ b/lofty/src/picture.rs
@@ -129,33 +129,54 @@ impl Display for MimeType {
 }
 
 /// The picture type, according to ID3v2 APIC
-#[allow(missing_docs)]
 #[allow(clippy::unsafe_derive_deserialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[non_exhaustive]
 pub enum PictureType {
+	/// Other picture type not covered by the remaining variants
 	Other,
+	/// 32x32 pixels file icon (PNG only)
 	Icon,
+	/// Other file icon
 	OtherIcon,
+	/// Front cover
 	CoverFront,
+	/// Back cover
 	CoverBack,
+	/// Leaflet page
 	Leaflet,
+	/// Media (e.g. label side of CD)
 	Media,
+	/// Lead artist/lead performer/soloist
 	LeadArtist,
+	/// Artist/performer
 	Artist,
+	/// Conductor
 	Conductor,
+	/// Band/orchestra
 	Band,
+	/// Composer
 	Composer,
+	/// Lyricist/text writer
 	Lyricist,
+	/// Recording location
 	RecordingLocation,
+	/// During recording
 	DuringRecording,
+	/// During performance
 	DuringPerformance,
+	/// Movie/video screen capture
 	ScreenCapture,
+	/// A bright colored fish
 	BrightFish,
+	/// Illustration
 	Illustration,
+	/// Band/artist logotype
 	BandLogo,
+	/// Publisher/studio logotype
 	PublisherLogo,
+	/// Undefined picture type
 	Undefined(u8),
 }
 

--- a/lofty/src/properties/channel_mask.rs
+++ b/lofty/src/properties/channel_mask.rs
@@ -10,7 +10,6 @@ macro_rules! define_channels {
 		impl ChannelMask {
 			$(
 				$(#[$meta])?
-				#[allow(missing_docs)]
 				pub const $name: Self = Self(1 << $shift);
 			)+
 		}
@@ -31,23 +30,41 @@ pub struct ChannelMask(pub(crate) u32);
 
 define_channels! {
 	[
+		/// Front left speaker
 		FRONT_LEFT            => 0,
+		/// Front right speaker
 		FRONT_RIGHT           => 1,
+		/// Front center speaker
 		FRONT_CENTER          => 2,
+		/// Low frequency effects (subwoofer)
 		LOW_FREQUENCY         => 3,
+		/// Back left speaker (surround left)
 		BACK_LEFT             => 4,
+		/// Back right speaker (surround right)
 		BACK_RIGHT            => 5,
+		/// Front left of center speaker
 		FRONT_LEFT_OF_CENTER  => 6,
+		/// Front right of center speaker
 		FRONT_RIGHT_OF_CENTER => 7,
+		/// Back center speaker
 		BACK_CENTER           => 8,
+		/// Side left speaker
 		SIDE_LEFT             => 9,
+		/// Side right speaker
 		SIDE_RIGHT            => 10,
+		/// Top center speaker
 		TOP_CENTER            => 11,
+		/// Top front left speaker
 		TOP_FRONT_LEFT        => 12,
+		/// Top front center speaker
 		TOP_FRONT_CENTER      => 13,
+		/// Top front right speaker
 		TOP_FRONT_RIGHT       => 14,
+		/// Top back left speaker
 		TOP_BACK_LEFT         => 15,
+		/// Top back center speaker
 		TOP_BACK_CENTER       => 16,
+		/// Top back right speaker
 		TOP_BACK_RIGHT        => 17
 	]
 }

--- a/lofty/src/tag/item.rs
+++ b/lofty/src/tag/item.rs
@@ -186,7 +186,6 @@ gen_map!(
 	"TPE3"                                  => Conductor,
 	"DIRECTOR"                              => Director,
 	"TEXT"                                  => Lyricist,
-	"TMCL"                                  => MusicianCredits,
 	"TPUB"                                  => Publisher | Label,
 	"TRSN"                                  => InternetRadioStationName,
 	"TRSO"                                  => InternetRadioStationOwner,
@@ -210,7 +209,6 @@ gen_map!(
 	"MVIN"                                  => MovementTotal,
 	"TCMP"                                  => FlagCompilation,
 	"PCST"                                  => FlagPodcast,
-	"TFLT"                                  => FileType,
 	"TOWN"                                  => FileOwner,
 	"TDTG"                                  => TaggingTime,
 	"TLEN"                                  => Length,
@@ -480,7 +478,6 @@ macro_rules! gen_item_keys {
 		]
 	) => {
 		#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-		#[allow(missing_docs)]
 		#[non_exhaustive]
 		/// A generic representation of a tag's key
 		pub enum ItemKey {
@@ -539,27 +536,43 @@ gen_item_keys!(
 
 	KEYS => [
 		// Titles
+		/// The album title
 		AlbumTitle,
+		/// The subtitle of the set (e.g. box set title)
 		SetSubtitle,
+		/// The show name (for podcasts/TV series)
 		ShowName,
+		/// The content group description
 		ContentGroup,
+		/// The track title
 		TrackTitle,
+		/// The track subtitle
 		TrackSubtitle,
 
 		// Original names
+		/// The original album title
 		OriginalAlbumTitle,
+		/// The original artist
 		OriginalArtist,
+		/// The original lyricist/text writer
 		OriginalLyricist,
 
 		// Sorting
+		/// The album title sort order key
 		AlbumTitleSortOrder,
+		/// The album artist sort order key
 		AlbumArtistSortOrder,
+		/// The track title sort order key
 		TrackTitleSortOrder,
+		/// The track artist sort order key
 		TrackArtistSortOrder,
+		/// The show name sort order key
 		ShowNameSortOrder,
+		/// The composer sort order key
 		ComposerSortOrder,
 
 		// People & Organizations
+		/// The album artist
 		AlbumArtist,
 		/// The name of each credited album-level artist
 		///
@@ -569,6 +582,7 @@ gen_item_keys!(
 		/// [`Tag::get_strings`]: crate::tag::Tag::get_strings
 		/// [`Tag::take_strings`]: crate::tag::Tag::take_strings
 		AlbumArtists,
+		/// The track artist
 		TrackArtist,
 		/// The name of each credited artist
 		///
@@ -578,28 +592,47 @@ gen_item_keys!(
 		/// [`Tag::get_strings`]: crate::tag::Tag::get_strings
 		/// [`Tag::take_strings`]: crate::tag::Tag::take_strings
 		TrackArtists,
+		/// The arranger
 		Arranger,
+		/// The writer
 		Writer,
+		/// The composer
 		Composer,
+		/// The conductor
 		Conductor,
+		/// The director
 		Director,
+		/// The engineer
 		Engineer,
+		/// The lyricist/text writer
 		Lyricist,
+		/// The mix DJ
 		MixDj,
+		/// The mix engineer
 		MixEngineer,
-		MusicianCredits,
+		/// The performer
 		Performer,
+		/// The producer
 		Producer,
+		/// The publisher
 		Publisher,
+		/// The record label
 		Label,
+		/// The internet radio station name
 		InternetRadioStationName,
+		/// The internet radio station owner
 		InternetRadioStationOwner,
+		/// The remixer
 		Remixer,
 
 		// Counts & Indexes
+		/// The disc number
 		DiscNumber,
+		/// The total number of discs
 		DiscTotal,
+		/// The track number
 		TrackNumber,
+		/// The total number of tracks
 		TrackTotal,
 		/// User-specific ratings (a.k.a. "Popularimeter")
 		///
@@ -629,6 +662,7 @@ gen_item_keys!(
 		///
 		/// [`popularimeter`]: crate::tag::items::popularimeter
 		Popularimeter,
+		/// The parental advisory rating
 		ParentalAdvisory,
 
 		// Dates
@@ -669,7 +703,12 @@ gen_item_keys!(
 		OriginalReleaseDate,
 
 		// Identifiers
+		/// The International Standard Recording Code (ISRC)
 		Isrc,
+		/// The barcode (typically [UPC]/[EAN])
+		///
+		/// [UPC]: https://en.wikipedia.org/wiki/Universal_Product_Code
+		/// [EAN]: https://en.wikipedia.org/wiki/European_Article_Number
 		Barcode,
 		/// [AcoustID] audio identifiers
 		///
@@ -683,11 +722,21 @@ gen_item_keys!(
 		///
 		/// [AcoustID]: https://acoustid.org/
 		AcoustIdFingerprint,
+		/// The label catalog number
+		///
+		/// See also: <https://musicbrainz.org/doc/Release/Catalog_Number>
 		CatalogNumber,
+		/// The work title
 		Work,
+		/// The movement name
 		Movement,
+		/// The movement number
 		MovementNumber,
+		/// The total number of movements
 		MovementTotal,
+		/// The country in which this was released
+		///
+		/// NOTE: This should contain an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code.
 		ReleaseCountry,
 
 		///////////////////////////////////////////////////////////////
@@ -754,41 +803,71 @@ gen_item_keys!(
 		///////////////////////////////////////////////////////////////
 
 		// Flags
+		/// Whether the track is part of a compilation
+		///
+		/// NOTE: The value will always be `"1"` or `"0"` for `true` and `false`, respectively.
 		FlagCompilation,
+		/// Whether the track is a podcast
+		///
+		/// NOTE: The value will always be `"1"` or `"0"` for `true` and `false`, respectively.
 		FlagPodcast,
 
 		// File Information
-		FileType,
+		/// The file owner/licensee
 		FileOwner,
+		/// The tagging date/time
 		TaggingTime,
+		/// The audio length in milliseconds
 		Length,
+		/// The original file name
 		OriginalFileName,
+		/// The original media type
 		OriginalMediaType,
 
 		// Encoder information
+		/// The person or organization that encoded the audio
 		EncodedBy,
+		/// The encoder software/hardware and settings
 		EncoderSoftware,
+		/// The encoder settings
 		EncoderSettings,
+		/// The encoding date/time
 		EncodingTime,
+		/// The ReplayGain album gain value
 		ReplayGainAlbumGain,
+		/// The ReplayGain album peak value
 		ReplayGainAlbumPeak,
+		/// The ReplayGain track gain value
 		ReplayGainTrackGain,
+		/// The ReplayGain track peak value
 		ReplayGainTrackPeak,
 
 		// URLs
+		/// A URL link to the audio file
 		AudioFileUrl,
+		/// A URL link to the audio source
 		AudioSourceUrl,
+		/// A URL for commercial information
 		CommercialInformationUrl,
+		/// A URL for copyright/legal information
 		CopyrightUrl,
+		/// A URL for the track artist
 		TrackArtistUrl,
+		/// A URL for the internet radio station
 		RadioStationUrl,
+		/// A URL for payment
 		PaymentUrl,
+		/// A URL for the publisher
 		PublisherUrl,
 
 		// Style
+		/// The genre of the track
 		Genre,
+		/// The initial musical key
 		InitialKey,
+		/// The color associated with the track
 		Color,
+		/// The mood of the track
 		Mood,
 		/// Decimal BPM value with arbitrary precision
 		///
@@ -805,20 +884,37 @@ gen_item_keys!(
 		IntegerBpm,
 
 		// Legal
+		/// The copyright message
 		CopyrightMessage,
+		/// The license under which the release is available
+		///
+		/// NOTE: This is typically a URL to a license.
 		License,
 
 		// Podcast
+		/// The podcast episode description
 		PodcastDescription,
+		/// The podcast series category
 		PodcastSeriesCategory,
+		/// The podcast URL
 		PodcastUrl,
+		/// The podcast globally unique identifier
 		PodcastGlobalUniqueId,
+		/// The podcast keywords
 		PodcastKeywords,
 
 		// Miscellaneous
+		/// A comment
 		Comment,
+		/// A description
 		Description,
+		/// The language of the content ([ISO 639-2])
+		///
+		/// [ISO 639-2]: https://en.wikipedia.org/wiki/ISO_639-3
 		Language,
+		/// The script used to write the release and track titles ([ISO 15924])
+		///
+		/// [ISO 15924]: https://en.wikipedia.org/wiki/ISO_15924
 		Script,
 		/// (Possibly synchronized) lyrics text
 		///
@@ -851,7 +947,9 @@ gen_item_keys!(
 		UnsyncLyrics,
 
 		// Vendor-specific
+		/// Apple's XID identifier
 		AppleXid,
+		/// Apple's ID3v2 content group (GRP1 frame)
 		AppleId3v2ContentGroup, // GRP1
 	]
 );
@@ -863,7 +961,7 @@ pub enum ItemValue {
 	Text(String),
 	/// Any UTF-8 encoded locator of external information
 	///
-	/// This is only gets special treatment in `ID3v2` and `APE` tags, being written
+	/// This only gets special treatment in `ID3v2` and `APE` tags, being written
 	/// as a normal string in other tags
 	Locator(String),
 	/// Binary information
@@ -966,6 +1064,18 @@ impl TagItem {
 	}
 
 	/// Create a new [`TagItem`]
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use lofty::tag::{ItemKey, ItemValue, TagItem};
+	///
+	/// let item = TagItem::new(
+	/// 	ItemKey::TrackTitle,
+	/// 	ItemValue::Text(String::from("My Song")),
+	/// );
+	/// assert_eq!(item.key(), ItemKey::TrackTitle);
+	/// ```
 	#[must_use]
 	pub const fn new(item_key: ItemKey, item_value: ItemValue) -> Self {
 		Self {

--- a/lofty/src/tag/items/timestamp.rs
+++ b/lofty/src/tag/items/timestamp.rs
@@ -9,14 +9,30 @@ use std::str::FromStr;
 use byteorder::ReadBytesExt;
 
 /// A subset of the ISO 8601 timestamp format
+///
+/// # Examples
+///
+/// ```
+/// use lofty::tag::items::Timestamp;
+///
+/// let timestamp: Timestamp = "2024-06-15T14:30:00".parse().unwrap();
+/// assert_eq!(timestamp.year, 2024);
+/// assert_eq!(timestamp.month, Some(6));
+/// assert_eq!(timestamp.to_string(), "2024-06-15T14:30:00");
+/// ```
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
-#[allow(missing_docs)]
 pub struct Timestamp {
+	/// The year component (e.g. 2024)
 	pub year: u16,
+	/// The month component (1-12)
 	pub month: Option<u8>,
+	/// The day component (1-31)
 	pub day: Option<u8>,
+	/// The hour component (0-23)
 	pub hour: Option<u8>,
+	/// The minute component (0-59)
 	pub minute: Option<u8>,
+	/// The second component (0-59)
 	pub second: Option<u8>,
 }
 

--- a/lofty/src/tag/mod.rs
+++ b/lofty/src/tag/mod.rs
@@ -733,8 +733,8 @@ impl TagExt for Tag {
 	}
 }
 
+/// The remainder of a [`Tag`] after calling [`SplitTag::split_tag`]
 #[derive(Debug, Clone, Default)]
-#[allow(missing_docs)]
 pub struct SplitTagRemainder;
 
 impl SplitTag for Tag {


### PR DESCRIPTION
Typos & stale references:
Fixed grammar in doc/ISSUES.md and doc/PULL_REQUESTS.md
Fixed broken file path references in doc/NEW_FILE.md and doc/NEW_TAG.md (6 stale ../src/ paths → ../lofty/src/)
Fixed code example bugs in doc/NEW_TAG.md (missing &mut self, wrong return type)
Updated fuzz example imports in doc/NEW_FILE.md
Fixed typo in lofty/src/tag/item.rs

Removed ALL #[allow(missing_docs)] (previously 15+ files):
Added doc comments to ~200 items across: FileType, MpegVersion, Layer, ChannelMode, Emphasis, WavFormat, PictureType, Mp4Codec, AudioObjectType, ChannelType, EventType, SyncTextContentType, FrameHeader, TimestampFrame, Timestamp, ReplayGain, EncoderInfo, SplitTagRemainder, ItemKey (~88 variants), ChannelMask (18 constants)

Examples:
Added doc-tested examples to Timestamp and TagItem structs

Module docs:
Added/improved //! module docs for ape/tag, id3/v2/tag, iff, id3