### PR TITLE
refactor(mp4): move ftyp field to Mp4Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MP4**: `Mp4File::ftyp()` was moved to `Mp4Properties::ftyp()` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/650))
+
 ### Fixed
 
 - **IFF**: Undersized ID3v2 chunks will no longer error outside of strict mode ([PR](https://github.com/Serial-ATA/lofty-rs/pull/644))

--- a/doc/NEW_FILE.md
+++ b/doc/NEW_FILE.md
@@ -124,9 +124,6 @@ const LOFTY_FILE_TYPES: [&str; N] = [
 
 Now we can define our file struct in `src/foo/mod.rs`.
 
-Unless there is additional information to provide from the format, such as [`Mp4Properties::ftyp()`](https://docs.rs/lofty/latest/lofty/mp4/struct.Mp4Properties.html#method.ftyp),
-this file can simply be a struct definition (with exports as necessary).
-
 ```rust
 mod read;
 mod properties;

--- a/doc/NEW_FILE.md
+++ b/doc/NEW_FILE.md
@@ -124,7 +124,7 @@ const LOFTY_FILE_TYPES: [&str; N] = [
 
 Now we can define our file struct in `src/foo/mod.rs`.
 
-Unless there is additional information to provide from the format, such as [`Mp4File::ftyp()`](https://docs.rs/lofty/latest/lofty/mp4/struct.Mp4File.html#method.ftyp),
+Unless there is additional information to provide from the format, such as [`Mp4Properties::ftyp()`](https://docs.rs/lofty/latest/lofty/mp4/struct.Mp4Properties.html#method.ftyp),
 this file can simply be a struct definition (with exports as necessary).
 
 ```rust

--- a/lofty/src/mp4/mod.rs
+++ b/lofty/src/mp4/mod.rs
@@ -34,8 +34,6 @@ pub(crate) use properties::SAMPLE_RATES;
 #[derive(LoftyFile)]
 #[lofty(read_fn = "read::read_from")]
 pub struct Mp4File {
-	/// The file format from ftyp's "major brand" (Ex. "M4A ")
-	pub(crate) ftyp: String,
 	#[lofty(tag_type = "Mp4Ilst")]
 	/// The parsed `ilst` (metadata) atom, if it exists
 	pub(crate) ilst_tag: Option<Ilst>,
@@ -61,6 +59,6 @@ impl Mp4File {
 	/// # Ok(()) }
 	/// ```
 	pub fn ftyp(&self) -> &str {
-		self.ftyp.as_ref()
+		self.properties.ftyp()
 	}
 }

--- a/lofty/src/mp4/properties.rs
+++ b/lofty/src/mp4/properties.rs
@@ -191,6 +191,7 @@ pub struct Mp4Properties {
 	pub(crate) bit_depth: Option<u8>,
 	pub(crate) channels: u8,
 	pub(crate) drm_protected: bool,
+	pub(crate) ftyp: String,
 }
 
 impl From<Mp4Properties> for FileProperties {
@@ -255,6 +256,26 @@ impl Mp4Properties {
 	/// Whether or not the file is DRM protected
 	pub fn is_drm_protected(&self) -> bool {
 		self.drm_protected
+	}
+
+	/// The file format from ftyp's "major brand" (Ex. "M4A ")
+	///
+	/// # Examples
+	///
+	/// ```rust,no_run
+	/// use lofty::config::ParseOptions;
+	/// use lofty::file::AudioFile;
+	/// use lofty::mp4::Mp4File;
+	///
+	/// # fn main() -> lofty::error::Result<()> {
+	/// # let mut m4a_reader = std::io::Cursor::new(&[]);
+	/// let m4a_file = Mp4File::read_from(&mut m4a_reader, ParseOptions::new())?;
+	///
+	/// assert_eq!(m4a_file.properties().ftyp(), "M4A ");
+	/// # Ok(()) }
+	/// ```
+	pub fn ftyp(&self) -> &str {
+		self.ftyp.as_ref()
 	}
 }
 

--- a/lofty/src/mp4/read/mod.rs
+++ b/lofty/src/mp4/read/mod.rs
@@ -65,21 +65,23 @@ where
 
 	let moov = Moov::parse(&mut reader, parse_options)?;
 
+	let mut properties = if parse_options.read_properties {
+		// Remove the length restriction
+		reader.reset_bounds(0, file_length);
+		super::properties::read_properties(
+			&mut reader,
+			&moov.traks,
+			file_length,
+			parse_options.parsing_mode,
+		)?
+	} else {
+		Mp4Properties::default()
+	};
+	properties.ftyp = ftyp;
+
 	Ok(Mp4File {
-		ftyp,
 		ilst_tag: moov.ilst,
-		properties: if parse_options.read_properties {
-			// Remove the length restriction
-			reader.reset_bounds(0, file_length);
-			super::properties::read_properties(
-				&mut reader,
-				&moov.traks,
-				file_length,
-				parse_options.parsing_mode,
-			)?
-		} else {
-			Mp4Properties::default()
-		},
+		properties,
 	})
 }
 

--- a/lofty/src/properties/tests.rs
+++ b/lofty/src/properties/tests.rs
@@ -112,53 +112,65 @@ const MP3_PROPERTIES: MpegProperties = MpegProperties {
 	emphasis: None,
 };
 
-const MP4_AAC_PROPERTIES: Mp4Properties = Mp4Properties {
-	codec: Mp4Codec::AAC,
-	extended_audio_object_type: Some(AudioObjectType::AacLowComplexity),
-	duration: Duration::from_millis(1449),
-	overall_bitrate: 135,
-	audio_bitrate: 124,
-	sample_rate: 48000,
-	bit_depth: None,
-	channels: 2,
-	drm_protected: false,
-};
+fn expected_mp4_aac_properties() -> Mp4Properties {
+	Mp4Properties {
+		codec: Mp4Codec::AAC,
+		extended_audio_object_type: Some(AudioObjectType::AacLowComplexity),
+		duration: Duration::from_millis(1449),
+		overall_bitrate: 135,
+		audio_bitrate: 124,
+		sample_rate: 48000,
+		bit_depth: None,
+		channels: 2,
+		drm_protected: false,
+		ftyp: String::from("M4A "),
+	}
+}
 
-const MP4_ALAC_PROPERTIES: Mp4Properties = Mp4Properties {
-	codec: Mp4Codec::ALAC,
-	extended_audio_object_type: None,
-	duration: Duration::from_millis(1428),
-	overall_bitrate: 331,
-	audio_bitrate: 326,
-	sample_rate: 48000,
-	bit_depth: Some(16),
-	channels: 2,
-	drm_protected: false,
-};
+fn expected_mp4_alac_properties() -> Mp4Properties {
+	Mp4Properties {
+		codec: Mp4Codec::ALAC,
+		extended_audio_object_type: None,
+		duration: Duration::from_millis(1428),
+		overall_bitrate: 331,
+		audio_bitrate: 326,
+		sample_rate: 48000,
+		bit_depth: Some(16),
+		channels: 2,
+		drm_protected: false,
+		ftyp: String::from("M4A "),
+	}
+}
 
-const MP4_ALS_PROPERTIES: Mp4Properties = Mp4Properties {
-	codec: Mp4Codec::AAC,
-	extended_audio_object_type: Some(AudioObjectType::AudioLosslessCoding),
-	duration: Duration::from_millis(1429),
-	overall_bitrate: 1083,
-	audio_bitrate: 1078,
-	sample_rate: 48000,
-	bit_depth: None,
-	channels: 2,
-	drm_protected: false,
-};
+fn expected_mp4_als_properties() -> Mp4Properties {
+	Mp4Properties {
+		codec: Mp4Codec::AAC,
+		extended_audio_object_type: Some(AudioObjectType::AudioLosslessCoding),
+		duration: Duration::from_millis(1429),
+		overall_bitrate: 1083,
+		audio_bitrate: 1078,
+		sample_rate: 48000,
+		bit_depth: None,
+		channels: 2,
+		drm_protected: false,
+		ftyp: String::from("mp42"),
+	}
+}
 
-const MP4_FLAC_PROPERTIES: Mp4Properties = Mp4Properties {
-	codec: Mp4Codec::FLAC,
-	extended_audio_object_type: None,
-	duration: Duration::from_millis(1428),
-	overall_bitrate: 280,
-	audio_bitrate: 275,
-	sample_rate: 48000,
-	bit_depth: Some(16),
-	channels: 2,
-	drm_protected: false,
-};
+fn expected_mp4_flac_properties() -> Mp4Properties {
+	Mp4Properties {
+		codec: Mp4Codec::FLAC,
+		extended_audio_object_type: None,
+		duration: Duration::from_millis(1428),
+		overall_bitrate: 280,
+		audio_bitrate: 275,
+		sample_rate: 48000,
+		bit_depth: Some(16),
+		channels: 2,
+		drm_protected: false,
+		ftyp: String::from("isom"),
+	}
+}
 
 // Properties verified with libmpcdec 1.2.2
 const MPC_SV5_PROPERTIES: MpcSv4to6Properties = MpcSv4to6Properties {
@@ -353,7 +365,7 @@ fn mp3_properties() {
 fn mp4_aac_properties() {
 	assert_eq!(
 		get_properties::<Mp4File>("tests/files/assets/minimal/m4a_codec_aac.m4a"),
-		MP4_AAC_PROPERTIES
+		expected_mp4_aac_properties()
 	)
 }
 
@@ -361,7 +373,7 @@ fn mp4_aac_properties() {
 fn mp4_alac_properties() {
 	assert_eq!(
 		get_properties::<Mp4File>("tests/files/assets/minimal/m4a_codec_alac.m4a"),
-		MP4_ALAC_PROPERTIES
+		expected_mp4_alac_properties()
 	)
 }
 
@@ -369,7 +381,7 @@ fn mp4_alac_properties() {
 fn mp4_als_properties() {
 	assert_eq!(
 		get_properties::<Mp4File>("tests/files/assets/minimal/mp4_codec_als.mp4"),
-		MP4_ALS_PROPERTIES
+		expected_mp4_als_properties()
 	)
 }
 
@@ -377,7 +389,7 @@ fn mp4_als_properties() {
 fn mp4_flac_properties() {
 	assert_eq!(
 		get_properties::<Mp4File>("tests/files/assets/minimal/mp4_codec_flac.mp4"),
-		MP4_FLAC_PROPERTIES
+		expected_mp4_flac_properties()
 	)
 }
 


### PR DESCRIPTION
The `ftyp` field is moved from `Mp4File` to `Mp4Properties` to ensure consistency in how format-specific properties are stored and accessed. This change also updates documentation and tests to reflect the new structure.

I had to update the MP4 test property constants to functions, since `String` can't  be  constructed with `const`.

Fixes #287 