### PR TITLE
fix(mp4): preserve hdlr atom when writing new tags to metadata containers with missing ilst

### DIFF
--- a/lofty/src/mp4/ilst/write.rs
+++ b/lofty/src/mp4/ilst/write.rs
@@ -230,18 +230,7 @@ fn save_to_existing(
 		ParseOptions::DEFAULT_PARSING_MODE,
 	)?;
 
-	if ilst_idx.is_none() {
-		// Nothing to do
-		if remove_tag {
-			return Ok(());
-		}
-
-		let meta_end = (meta.start + meta.len) as usize;
-
-		replacement = ilst;
-		range = meta_end..meta_end;
-	} else {
-		let ilst_idx = ilst_idx.unwrap();
+	if let Some(ilst_idx) = ilst_idx {
 		let existing_ilst = &tree[ilst_idx];
 		let existing_ilst_size = existing_ilst.len;
 
@@ -316,6 +305,16 @@ fn save_to_existing(
 			replacement = ilst;
 			range = range_start as usize..range_end as usize;
 		}
+	} else {
+		// Nothing to do
+		if remove_tag {
+			return Ok(());
+		}
+
+		let meta_end = (meta.start + meta.len) as usize;
+
+		replacement = ilst;
+		range = meta_end..meta_end;
 	}
 
 	drop(write_handle);

--- a/lofty/src/mp4/ilst/write.rs
+++ b/lofty/src/mp4/ilst/write.rs
@@ -230,7 +230,7 @@ fn save_to_existing(
 		ParseOptions::DEFAULT_PARSING_MODE,
 	)?;
 
-	if tree.is_empty() {
+	if ilst_idx.is_none() {
 		// Nothing to do
 		if remove_tag {
 			return Ok(());
@@ -241,6 +241,7 @@ fn save_to_existing(
 		replacement = ilst;
 		range = meta_end..meta_end;
 	} else {
+		let ilst_idx = ilst_idx.unwrap();
 		let existing_ilst = &tree[ilst_idx];
 		let existing_ilst_size = existing_ilst.len;
 

--- a/lofty/src/mp4/read/mod.rs
+++ b/lofty/src/mp4/read/mod.rs
@@ -156,11 +156,11 @@ pub(super) fn atom_tree<R>(
 	mut len: u64,
 	up_to: &[u8],
 	parse_mode: ParsingMode,
-) -> Result<(usize, Vec<AtomInfo>)>
+) -> Result<(Option<usize>, Vec<AtomInfo>)>
 where
 	R: Read + Seek,
 {
-	let mut found_idx: usize = 0;
+	let mut found_idx: Option<usize> = None;
 	let mut buf = Vec::new();
 
 	let mut i = 0;
@@ -174,17 +174,14 @@ where
 		len = len.saturating_sub(atom.len);
 
 		if let AtomIdent::Fourcc(ref fourcc) = atom.ident {
-			i += 1;
-
 			if fourcc == up_to {
-				found_idx = i;
+				found_idx = Some(i);
 			}
+			i += 1;
 
 			buf.push(atom);
 		}
 	}
-
-	found_idx = found_idx.saturating_sub(1);
 
 	Ok((found_idx, buf))
 }

--- a/lofty/tests/files/mp4.rs
+++ b/lofty/tests/files/mp4.rs
@@ -76,8 +76,8 @@ fn read_no_tags() {
 
 #[test_log::test]
 fn hdlr_preservation_on_tag_recreation() {
-	use std::fs;
 	use lofty::tag::Tag;
+	use std::fs;
 
 	let src = "tests/files/assets/minimal/m4a_codec_aac.m4a";
 	let temp_path = "tests/files/assets/minimal/temp_hdlr_test.m4a";
@@ -91,7 +91,9 @@ fn hdlr_preservation_on_tag_recreation() {
 	let mut tagged_file = Probe::open(temp_path).unwrap().read().unwrap();
 	let tag = Tag::new(TagType::Mp4Ilst);
 	tagged_file.insert_tag(tag);
-	tagged_file.save_to_path(temp_path, lofty::config::WriteOptions::default()).unwrap();
+	tagged_file
+		.save_to_path(temp_path, lofty::config::WriteOptions::default())
+		.unwrap();
 
 	// 3. Read the file bytes and verify that "hdlr" is present
 	let bytes = fs::read(temp_path).unwrap();
@@ -101,4 +103,3 @@ fn hdlr_preservation_on_tag_recreation() {
 
 	assert!(has_hdlr, "Output M4A is missing the hdlr atom!");
 }
-

--- a/lofty/tests/files/mp4.rs
+++ b/lofty/tests/files/mp4.rs
@@ -73,3 +73,32 @@ fn read_no_properties() {
 fn read_no_tags() {
 	crate::util::no_tag_test("tests/files/assets/minimal/m4a_codec_aac.m4a", None);
 }
+
+#[test_log::test]
+fn hdlr_preservation_on_tag_recreation() {
+	use std::fs;
+	use lofty::tag::Tag;
+
+	let src = "tests/files/assets/minimal/m4a_codec_aac.m4a";
+	let temp_path = "tests/files/assets/minimal/temp_hdlr_test.m4a";
+	let _ = fs::remove_file(temp_path);
+	fs::copy(src, temp_path).unwrap();
+
+	// 1. Remove all tags
+	TagType::Mp4Ilst.remove_from_path(temp_path).unwrap();
+
+	// 2. Open the file and write a brand new tag
+	let mut tagged_file = Probe::open(temp_path).unwrap().read().unwrap();
+	let tag = Tag::new(TagType::Mp4Ilst);
+	tagged_file.insert_tag(tag);
+	tagged_file.save_to_path(temp_path, lofty::config::WriteOptions::default()).unwrap();
+
+	// 3. Read the file bytes and verify that "hdlr" is present
+	let bytes = fs::read(temp_path).unwrap();
+	let has_hdlr = bytes.windows(4).any(|w| w == b"hdlr");
+
+	let _ = fs::remove_file(temp_path);
+
+	assert!(has_hdlr, "Output M4A is missing the hdlr atom!");
+}
+


### PR DESCRIPTION
### Description
This PR fixes a bug where writing new tags (`Mp4Ilst`) to MP4/M4A files that contain a `meta` box but no `ilst` box (e.g., after tag removal or clean metadata copy) would overwrite and destroy the `hdlr` (Handler Reference) atom. This resulted in malformed M4A files that standard-conforming media players (like FFmpeg, Windows Media Foundation/Groove, CoreMedia, etc.) could no longer read metadata from.
### Root Cause
In `lofty/src/mp4/read/mod.rs`, `atom_tree` returned `(usize, Vec<AtomInfo>)` where the first element was the index of the matched atom. If the atom (e.g., `ilst`) was not found, it would return `0`. If it was found at index 0 (which is valid), it would also return `0`.
In `lofty/src/mp4/ilst/write.rs`, `save_to_existing` relied on this index. When `ilst` was deleted/absent, `atom_tree` returned `0` for the index, while `tree` still had child atoms (specifically, `hdlr` at index 0). The writer then incorrectly assumed `tree[0]` (the `hdlr` atom) was the existing `ilst` and replaced the `hdlr` atom with the new `ilst` atom.
### Solution
1. **Modified `atom_tree`**: The returned index is now an `Option<usize>`. It returns `Some(index)` if found, and `None` if not found, allowing callers to accurately distinguish whether `ilst` exists.
2. **Updated `save_to_existing`**: It now checks if `ilst_idx` is `None` (via `if let Some(ilst_idx) = ilst_idx`). If it is `None`, it appends `ilst` to the end of `meta` rather than overwriting `tree[0]`. If it is `Some(idx)`, it replaces the existing `ilst` atom in place as before. This also resolves a Clippy lint for `unnecessary_unwrap`.
### Regression Test
An integration test `hdlr_preservation_on_tag_recreation` has been added to `lofty/tests/files/mp4.rs`. It simulates the exact tag recreation sequence:
1. Copies a minimal test M4A (`m4a_codec_aac.m4a`).
2. Deletes the tag container with `remove_from_path`.
3. Inserts and saves a new tag with `save_to_path`.
4. Asserts that the output file still contains the `hdlr` atom.
All library unit and integration tests pass successfully.