### PR TITLE
MP4: Make optional `Mp4Properties` fields `Option`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **MP4**: `Mp4File::ftyp()` was moved to `Mp4Properties::ftyp()` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/650))
+- **MP4**: `Mp4Properties` accessors that may be unavailable are now `Option`-wrapped
+  to reflect that audio properties are absent for codecs Lofty does not dispatch
+  to a specialized parser ([issue](https://github.com/Serial-ATA/lofty-rs/issues/661)):
+  - `codec()` now returns `Option<&Mp4Codec>`
+  - `overall_bitrate()`, `audio_bitrate()`, `sample_rate()` now return `Option<u32>`
+  - `channels()` now returns `Option<u8>`
 - **MSRV**: Bumped to **1.89.0** ([PR](https://github.com/Serial-ATA/lofty-rs/pull/652))
 
 ### Fixed
 
+- **MP4**: `channels()` and `sample_rate()` no longer report `0` placeholder values
+  for codecs Lofty does not dispatch (e.g. `ec-3`); they correctly report `None`
+  ([issue](https://github.com/Serial-ATA/lofty-rs/issues/661))
 - **IFF**: Undersized ID3v2 chunks will no longer error outside of strict mode ([PR](https://github.com/Serial-ATA/lofty-rs/pull/644))
 - **Timestamp**: Support dot-separated dates (e.g. `2024.06.03`) ([issue](https://github.com/Serial-ATA/lofty-rs/issues/647)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/648))
 - **ID3v2**:

--- a/lofty/src/mp4/properties.rs
+++ b/lofty/src/mp4/properties.rs
@@ -179,17 +179,23 @@ impl TryFrom<u8> for AudioObjectType {
 }
 
 /// An MP4 file's audio properties
+///
+/// Only [`duration`](Self::duration), [`is_drm_protected`](Self::is_drm_protected),
+/// and [`ftyp`](Self::ftyp) are guaranteed to be set. Every other field is
+/// `Option`-wrapped because the underlying value may be absent for codecs
+/// Lofty does not currently dispatch to a specialized parser (the
+/// QuickTime sample-entry slots carry placeholder zeros for those codecs).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub struct Mp4Properties {
-	pub(crate) codec: Mp4Codec,
+	pub(crate) codec: Option<Mp4Codec>,
 	pub(crate) extended_audio_object_type: Option<AudioObjectType>,
 	pub(crate) duration: Duration,
-	pub(crate) overall_bitrate: u32,
-	pub(crate) audio_bitrate: u32,
-	pub(crate) sample_rate: u32,
+	pub(crate) overall_bitrate: Option<u32>,
+	pub(crate) audio_bitrate: Option<u32>,
+	pub(crate) sample_rate: Option<u32>,
 	pub(crate) bit_depth: Option<u8>,
-	pub(crate) channels: u8,
+	pub(crate) channels: Option<u8>,
 	pub(crate) drm_protected: bool,
 	pub(crate) ftyp: String,
 }
@@ -198,11 +204,11 @@ impl From<Mp4Properties> for FileProperties {
 	fn from(input: Mp4Properties) -> Self {
 		Self {
 			duration: input.duration,
-			overall_bitrate: Some(input.overall_bitrate),
-			audio_bitrate: Some(input.audio_bitrate),
-			sample_rate: Some(input.sample_rate),
+			overall_bitrate: input.overall_bitrate,
+			audio_bitrate: input.audio_bitrate,
+			sample_rate: input.sample_rate,
 			bit_depth: input.bit_depth,
-			channels: Some(input.channels),
+			channels: input.channels,
 			channel_mask: None,
 		}
 	}
@@ -215,17 +221,17 @@ impl Mp4Properties {
 	}
 
 	/// Overall bitrate (kbps)
-	pub fn overall_bitrate(&self) -> u32 {
+	pub fn overall_bitrate(&self) -> Option<u32> {
 		self.overall_bitrate
 	}
 
 	/// Audio bitrate (kbps)
-	pub fn audio_bitrate(&self) -> u32 {
+	pub fn audio_bitrate(&self) -> Option<u32> {
 		self.audio_bitrate
 	}
 
 	/// Sample rate (Hz)
-	pub fn sample_rate(&self) -> u32 {
+	pub fn sample_rate(&self) -> Option<u32> {
 		self.sample_rate
 	}
 
@@ -235,13 +241,16 @@ impl Mp4Properties {
 	}
 
 	/// Channel count
-	pub fn channels(&self) -> u8 {
+	pub fn channels(&self) -> Option<u8> {
 		self.channels
 	}
 
 	/// Audio codec
-	pub fn codec(&self) -> &Mp4Codec {
-		&self.codec
+	///
+	/// Returns `None` when the codec FourCC was not one Lofty dispatches to a
+	/// specialized parser (e.g. `ec-3`, `opus`).
+	pub fn codec(&self) -> Option<&Mp4Codec> {
+		self.codec.as_ref()
 	}
 
 	/// Extended audio object type
@@ -530,7 +539,7 @@ where
 		// Vendor (4)
 		reader.seek(SeekFrom::Current(6))?;
 
-		properties.channels = reader.read_u16()? as u8;
+		properties.channels = Some(reader.read_u16()? as u8);
 
 		// Skipping 6 bytes
 		// Sample size (2)
@@ -539,7 +548,7 @@ where
 		reader.seek(SeekFrom::Current(6))?;
 
 		// 16.16 fixed point number
-		properties.sample_rate = reader.read_u32()? >> 16;
+		properties.sample_rate = Some(reader.read_u32()? >> 16);
 
 		let mut offset = reader.stream_position()?;
 		if stsd_version == 1 {
@@ -583,6 +592,11 @@ where
 					"Found unsupported sample entry: {:?}",
 					descriptor_format.escape_ascii().to_string()
 				);
+				// The QuickTime sample-entry slots above carry placeholders for
+				// codecs we don't dispatch (e.g. `ec-3`). Discard them rather
+				// than leak zeros into `FileProperties`.
+				properties.channels = None;
+				properties.sample_rate = None;
 				skip_atom(reader, false, offset - atom.start)?;
 				continue;
 			},
@@ -664,7 +678,7 @@ where
 					/ u128::from(duration)) as u32;
 
 				// kb/s
-				properties.audio_bitrate = audio_bitrate_bps / 1000;
+				properties.audio_bitrate = Some(audio_bitrate_bps / 1000);
 			}
 		}
 
@@ -677,12 +691,12 @@ where
 		}
 
 		let overall_bitrate = u128::from(file_length * 8) / duration_millis;
-		properties.overall_bitrate = overall_bitrate as u32;
+		properties.overall_bitrate = Some(overall_bitrate as u32);
 
-		if properties.audio_bitrate == 0 {
+		if properties.audio_bitrate.is_none_or(|b| b == 0) {
 			log::warn!("Estimating audio bitrate from 'mdat' size");
 
-			properties.audio_bitrate = (u128::from(mdat_len * 8) / duration_millis) as u32;
+			properties.audio_bitrate = Some((u128::from(mdat_len * 8) / duration_millis) as u32);
 		}
 	}
 
@@ -703,7 +717,7 @@ where
 	const DECODER_SPECIFIC_DESCRIPTOR_TAG: u8 = 0x05;
 
 	// Set the codec to AAC, which is a good guess if we fail before reaching the `esds`
-	properties.codec = Mp4Codec::AAC;
+	properties.codec = Some(Mp4Codec::AAC);
 
 	// This information is often followed by an esds (elementary stream descriptor) atom containing the bitrate
 	let Ok(Some(esds)) = stsd.next() else {
@@ -735,11 +749,11 @@ where
 		if descriptor.tag == DECODER_CONFIG_TAG {
 			let codec = stsd.read_u8()?;
 
-			properties.codec = match codec {
+			properties.codec = Some(match codec {
 				0x40 | 0x41 | 0x66 | 0x67 | 0x68 => Mp4Codec::AAC,
 				0x69 | 0x6B => Mp4Codec::MP3,
 				_ => Mp4Codec::Unknown,
-			};
+			});
 
 			// Skipping 8 bytes
 			// Stream type (1)
@@ -797,11 +811,11 @@ where
 
 						// Just use the sample rate we already read above if this is invalid
 						if sample_rate > 0 {
-							properties.sample_rate = sample_rate;
+							properties.sample_rate = Some(sample_rate);
 						}
 					},
 					i if i < SAMPLE_RATES.len() as u8 => {
-						properties.sample_rate = SAMPLE_RATES[i as usize];
+						properties.sample_rate = Some(SAMPLE_RATES[i as usize]);
 
 						if extended_object_type {
 							let byte_c = stsd.read_u8()?;
@@ -817,7 +831,7 @@ where
 				// The channel configuration isn't always set, at least when testing with
 				// the Audio Lossless Coding reference software
 				if channel_conf > 0 {
-					properties.channels = channel_conf;
+					properties.channels = Some(channel_conf);
 				}
 
 				// We just check for ALS here, might extend it for more codes eventually
@@ -826,17 +840,17 @@ where
 					stsd.read_exact(&mut ident)?;
 
 					if &ident == b"\0ALS\0" {
-						properties.sample_rate = stsd.read_u32()?;
+						properties.sample_rate = Some(stsd.read_u32()?);
 
 						// Sample count
 						stsd.seek(SeekFrom::Current(4))?;
-						properties.channels = stsd.read_u16()? as u8 + 1;
+						properties.channels = Some(stsd.read_u16()? as u8 + 1);
 					}
 				}
 			}
 
 			if average_bitrate > 0 || properties.duration.is_zero() {
-				properties.audio_bitrate = average_bitrate / 1000;
+				properties.audio_bitrate = Some(average_bitrate / 1000);
 			}
 		}
 	}
@@ -864,7 +878,7 @@ where
 		return Ok(());
 	}
 
-	properties.codec = Mp4Codec::ALAC;
+	properties.codec = Some(Mp4Codec::ALAC);
 
 	// Skipping 9 bytes
 	// Version (4)
@@ -882,15 +896,15 @@ where
 	// Rice parameter limit (1)
 	stsd.seek(SeekFrom::Current(3))?;
 
-	properties.channels = stsd.read_u8()?;
+	properties.channels = Some(stsd.read_u8()?);
 
 	// Skipping 6 bytes
 	// Max run (2)
 	// Max frame size (4)
 	stsd.seek(SeekFrom::Current(6))?;
 
-	properties.audio_bitrate = stsd.read_u32()? / 1000;
-	properties.sample_rate = stsd.read_u32()?;
+	properties.audio_bitrate = Some(stsd.read_u32()? / 1000);
+	properties.sample_rate = Some(stsd.read_u32()?);
 
 	Ok(())
 }
@@ -899,7 +913,7 @@ fn flac_properties<R>(stsd: &mut AtomReader<R>, properties: &mut Mp4Properties) 
 where
 	R: Read + Seek,
 {
-	properties.codec = Mp4Codec::FLAC;
+	properties.codec = Some(Mp4Codec::FLAC);
 
 	// There should be a dfla atom, but it's not worth erroring if absent.
 	let Some(dfla) = stsd.next()? else {
@@ -925,9 +939,9 @@ where
 	let flac_properties =
 		crate::flac::properties::read_properties(&mut &stream_info_block.content[..], 0, 0)?;
 
-	properties.sample_rate = flac_properties.sample_rate;
+	properties.sample_rate = Some(flac_properties.sample_rate);
 	properties.bit_depth = Some(flac_properties.bit_depth);
-	properties.channels = flac_properties.channels;
+	properties.channels = Some(flac_properties.channels);
 
 	// Bitrate values are calculated later...
 

--- a/lofty/src/properties/tests.rs
+++ b/lofty/src/properties/tests.rs
@@ -114,14 +114,14 @@ const MP3_PROPERTIES: MpegProperties = MpegProperties {
 
 fn expected_mp4_aac_properties() -> Mp4Properties {
 	Mp4Properties {
-		codec: Mp4Codec::AAC,
+		codec: Some(Mp4Codec::AAC),
 		extended_audio_object_type: Some(AudioObjectType::AacLowComplexity),
 		duration: Duration::from_millis(1449),
-		overall_bitrate: 135,
-		audio_bitrate: 124,
-		sample_rate: 48000,
+		overall_bitrate: Some(135),
+		audio_bitrate: Some(124),
+		sample_rate: Some(48000),
 		bit_depth: None,
-		channels: 2,
+		channels: Some(2),
 		drm_protected: false,
 		ftyp: String::from("M4A "),
 	}
@@ -129,14 +129,14 @@ fn expected_mp4_aac_properties() -> Mp4Properties {
 
 fn expected_mp4_alac_properties() -> Mp4Properties {
 	Mp4Properties {
-		codec: Mp4Codec::ALAC,
+		codec: Some(Mp4Codec::ALAC),
 		extended_audio_object_type: None,
 		duration: Duration::from_millis(1428),
-		overall_bitrate: 331,
-		audio_bitrate: 326,
-		sample_rate: 48000,
+		overall_bitrate: Some(331),
+		audio_bitrate: Some(326),
+		sample_rate: Some(48000),
 		bit_depth: Some(16),
-		channels: 2,
+		channels: Some(2),
 		drm_protected: false,
 		ftyp: String::from("M4A "),
 	}
@@ -144,14 +144,14 @@ fn expected_mp4_alac_properties() -> Mp4Properties {
 
 fn expected_mp4_als_properties() -> Mp4Properties {
 	Mp4Properties {
-		codec: Mp4Codec::AAC,
+		codec: Some(Mp4Codec::AAC),
 		extended_audio_object_type: Some(AudioObjectType::AudioLosslessCoding),
 		duration: Duration::from_millis(1429),
-		overall_bitrate: 1083,
-		audio_bitrate: 1078,
-		sample_rate: 48000,
+		overall_bitrate: Some(1083),
+		audio_bitrate: Some(1078),
+		sample_rate: Some(48000),
 		bit_depth: None,
-		channels: 2,
+		channels: Some(2),
 		drm_protected: false,
 		ftyp: String::from("mp42"),
 	}
@@ -159,14 +159,14 @@ fn expected_mp4_als_properties() -> Mp4Properties {
 
 fn expected_mp4_flac_properties() -> Mp4Properties {
 	Mp4Properties {
-		codec: Mp4Codec::FLAC,
+		codec: Some(Mp4Codec::FLAC),
 		extended_audio_object_type: None,
 		duration: Duration::from_millis(1428),
-		overall_bitrate: 280,
-		audio_bitrate: 275,
-		sample_rate: 48000,
+		overall_bitrate: Some(280),
+		audio_bitrate: Some(275),
+		sample_rate: Some(48000),
 		bit_depth: Some(16),
-		channels: 2,
+		channels: Some(2),
 		drm_protected: false,
 		ftyp: String::from("isom"),
 	}

--- a/lofty/tests/taglib/test_mp4.rs
+++ b/lofty/tests/taglib/test_mp4.rs
@@ -15,13 +15,13 @@ fn test_properties_aac() {
 	let f = get_file::<Mp4File>("tests/taglib/data/has-tags.m4a");
 	assert_eq!(f.properties().duration().as_secs(), 3);
 	assert_eq!(f.properties().duration().as_millis(), 3708);
-	assert_eq!(f.properties().audio_bitrate(), 3);
-	assert_eq!(f.properties().channels(), 2);
-	assert_eq!(f.properties().sample_rate(), 44100);
+	assert_eq!(f.properties().audio_bitrate(), Some(3));
+	assert_eq!(f.properties().channels(), Some(2));
+	assert_eq!(f.properties().sample_rate(), Some(44100));
 	// NOTE: TagLib reports 16, but the stream is a lossy codec. We ignore it in this case.
 	assert!(f.properties().bit_depth().is_none());
 	assert!(!f.properties().is_drm_protected());
-	assert_eq!(f.properties().codec(), &Mp4Codec::AAC);
+	assert_eq!(f.properties().codec(), Some(&Mp4Codec::AAC));
 }
 
 #[test_log::test]
@@ -41,12 +41,12 @@ fn test_properties_aac_without_bitrate() {
 	let f = Mp4File::read_from(&mut std::io::Cursor::new(aac_data), ParseOptions::new()).unwrap();
 	assert_eq!(f.properties().duration().as_secs(), 3);
 	assert_eq!(f.properties().duration().as_millis(), 3708);
-	assert_eq!(f.properties().audio_bitrate(), 3);
-	assert_eq!(f.properties().channels(), 2);
-	assert_eq!(f.properties().sample_rate(), 44100);
+	assert_eq!(f.properties().audio_bitrate(), Some(3));
+	assert_eq!(f.properties().channels(), Some(2));
+	assert_eq!(f.properties().sample_rate(), Some(44100));
 	assert_eq!(f.properties().bit_depth(), None); // TagLib reports 16, but the stream is a lossy codec
 	assert!(!f.properties().is_drm_protected());
-	assert_eq!(f.properties().codec(), &Mp4Codec::AAC);
+	assert_eq!(f.properties().codec(), Some(&Mp4Codec::AAC));
 }
 
 #[test_log::test]
@@ -54,12 +54,12 @@ fn test_properties_alac() {
 	let f = get_file::<Mp4File>("tests/taglib/data/empty_alac.m4a");
 	assert_eq!(f.properties().duration().as_secs(), 3);
 	assert_eq!(f.properties().duration().as_millis(), 3705);
-	assert_eq!(f.properties().audio_bitrate(), 2); // TagLib is off by one (reports 3)
-	assert_eq!(f.properties().channels(), 2);
-	assert_eq!(f.properties().sample_rate(), 44100);
+	assert_eq!(f.properties().audio_bitrate(), Some(2)); // TagLib is off by one (reports 3)
+	assert_eq!(f.properties().channels(), Some(2));
+	assert_eq!(f.properties().sample_rate(), Some(44100));
 	assert_eq!(f.properties().bit_depth(), Some(16));
 	assert!(!f.properties().is_drm_protected());
-	assert_eq!(f.properties().codec(), &Mp4Codec::ALAC);
+	assert_eq!(f.properties().codec(), Some(&Mp4Codec::ALAC));
 }
 
 #[test_log::test]
@@ -79,12 +79,12 @@ fn test_properties_alac_without_bitrate() {
 	let f = Mp4File::read_from(&mut std::io::Cursor::new(alac_data), ParseOptions::new()).unwrap();
 	assert_eq!(f.properties().duration().as_secs(), 3);
 	assert_eq!(f.properties().duration().as_millis(), 3705);
-	assert_eq!(f.properties().audio_bitrate(), 2); // TagLib is off by one (reports 3)
-	assert_eq!(f.properties().channels(), 2);
-	assert_eq!(f.properties().sample_rate(), 44100);
+	assert_eq!(f.properties().audio_bitrate(), Some(2)); // TagLib is off by one (reports 3)
+	assert_eq!(f.properties().channels(), Some(2));
+	assert_eq!(f.properties().sample_rate(), Some(44100));
 	assert_eq!(f.properties().bit_depth(), Some(16));
 	assert!(!f.properties().is_drm_protected());
-	assert_eq!(f.properties().codec(), &Mp4Codec::ALAC);
+	assert_eq!(f.properties().codec(), Some(&Mp4Codec::ALAC));
 }
 
 // TODO: FFmpeg reports a bitrate of 95kb/s, we report 104
@@ -94,12 +94,12 @@ fn test_properties_m4v() {
 	let f = get_file::<Mp4File>("tests/taglib/data/blank_video.m4v");
 	assert_eq!(f.properties().duration().as_secs(), 0);
 	assert_eq!(f.properties().duration().as_millis(), 975);
-	assert_eq!(f.properties().audio_bitrate(), 95); // TagLib is off by one (reports 96)
-	assert_eq!(f.properties().channels(), 2);
-	assert_eq!(f.properties().sample_rate(), 44100);
+	assert_eq!(f.properties().audio_bitrate(), Some(95)); // TagLib is off by one (reports 96)
+	assert_eq!(f.properties().channels(), Some(2));
+	assert_eq!(f.properties().sample_rate(), Some(44100));
 	assert_eq!(f.properties().bit_depth(), None); // TagLib reports 16, but the stream is a lossy codec
 	assert!(!f.properties().is_drm_protected());
-	assert_eq!(f.properties().codec(), &Mp4Codec::AAC);
+	assert_eq!(f.properties().codec(), Some(&Mp4Codec::AAC));
 }
 
 #[test_log::test]
@@ -403,7 +403,35 @@ fn test_repeated_save() {
 fn test_with_zero_length_atom() {
 	let f = get_file::<Mp4File>("tests/taglib/data/zero-length-mdat.m4a");
 	assert_eq!(f.properties().duration().as_millis(), 1115);
-	assert_eq!(f.properties().sample_rate(), 22050);
+	assert_eq!(f.properties().sample_rate(), Some(22050));
+}
+
+// Regression for https://github.com/Serial-ATA/lofty-rs/issues/661.
+//
+// For unsupported sample-entry codecs (anything outside `mp4a`/`alac`/`fLaC`/
+// `drms`), the QuickTime sound sample-entry slots Lofty reads up front are
+// just placeholders. Lofty used to surface those placeholder zeros as
+// `Some(0)` for channels and sample rate, masking the fact that nothing was
+// actually parsed. Now they read as `None`.
+#[test_log::test]
+#[allow(clippy::needless_range_loop)]
+fn test_properties_unsupported_codec_reports_none() {
+	let mut file = temp_file!("tests/taglib/data/has-tags.m4a");
+	let mut data = Vec::new();
+	file.read_to_end(&mut data).unwrap();
+
+	// Rewrite the `mp4a` sample-entry FourCC as an unsupported codec.
+	assert_eq!(&data[1890..1894], b"mp4a");
+	data[1890..1894].copy_from_slice(b"ec-3");
+
+	let f = Mp4File::read_from(&mut std::io::Cursor::new(data), ParseOptions::new()).unwrap();
+	assert_eq!(f.properties().duration().as_secs(), 3);
+	assert_eq!(f.properties().codec(), None);
+	assert_eq!(f.properties().channels(), None);
+	assert_eq!(f.properties().sample_rate(), None);
+	assert_eq!(f.properties().bit_depth(), None);
+	assert_eq!(f.properties().audio_object_type(), None);
+	assert!(!f.properties().is_drm_protected());
 }
 
 #[test_log::test]


### PR DESCRIPTION
closes #661

For codecs Lofty does not dispatch to a specialized parser (anything outside `mp4a`/`alac`/`fLaC`/`drms`), the QuickTime sound sample-entry slots Lofty reads up front are placeholders, not real values. They were previously surfacing as `0` for `channels()` / `sample_rate()` and as `Some(0)` through `FileProperties`.

Two changes:

- `codec`, `overall_bitrate`, `audio_bitrate`, `sample_rate`, and `channels` are now `Option`-wrapped on `Mp4Properties`. `duration`, `is_drm_protected`, and `ftyp` stay infallible per the issue thread.
- In the `_` arm of `read_stsd`'s descriptor match, `channels` and `sample_rate` are explicitly cleared to `None` so the placeholder slot reads above don't leak.

Regression test in `tests/taglib/test_mp4.rs` patches an existing AAC fixture's `mp4a` FourCC to `ec-3` and asserts the audio fields are `None`.

---
Written by an agent (Truffle, claude-opus-4-7). Phantom is what runs me (github.com/ghostwright/phantom).