### PR TITLE
ItemKey: Add EBU-R128 mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `R128_TRACK_GAIN` and `R128_ALBUM_GAIN` ReplayGain tags
-   - [Opus specific field](https://datatracker.ietf.org/doc/html/rfc7845#section-5.2.1)
-     used by music players for adjusting header gain depending on playback type.
+- **ItemKey**: `ItemKey::R128{Track,Album}Gain` for EBU-R128 loudness normalization tags ([PR](https://github.com/Serial-ATA/lofty-rs/pull/665))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `R128_TRACK_GAIN` and `R128_ALBUM_GAIN` ReplayGain tags
+   - [Opus specific field](https://datatracker.ietf.org/doc/html/rfc7845#section-5.2.1)
+     used by music players for adjusting header gain depending on playback type.
+
 ### Changed
 
 - **MP4**: `Mp4File::ftyp()` was moved to `Mp4Properties::ftyp()` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/650))

--- a/lofty/src/tag/item.rs
+++ b/lofty/src/tag/item.rs
@@ -843,9 +843,9 @@ gen_item_keys!(
 		ReplayGainTrackGain,
 		/// The ReplayGain track peak value
 		ReplayGainTrackPeak,
-		/// The ReplayGain track R128 value
+		/// The EBU R128 track gain
 		R128TrackGain,
-		/// The ReplayGain album R128 value
+		/// The EBU R128 album gain
 		R128AlbumGain,
 
 		// URLs

--- a/lofty/src/tag/item.rs
+++ b/lofty/src/tag/item.rs
@@ -429,6 +429,8 @@ gen_map!(
 	"REPLAYGAIN_ALBUM_PEAK"                   => ReplayGainAlbumPeak,
 	"REPLAYGAIN_TRACK_GAIN"                   => ReplayGainTrackGain,
 	"REPLAYGAIN_TRACK_PEAK"                   => ReplayGainTrackPeak,
+	"R128_TRACK_GAIN"                         => R128TrackGain,
+	"R128_ALBUM_GAIN"                         => R128AlbumGain,
 	"GENRE"                                   => Genre,
 	"COLOR"                                   => Color,
 	"MOOD"                                    => Mood,
@@ -841,6 +843,10 @@ gen_item_keys!(
 		ReplayGainTrackGain,
 		/// The ReplayGain track peak value
 		ReplayGainTrackPeak,
+		/// The ReplayGain track R128 value
+		R128TrackGain,
+		/// The ReplayGain album R128 value
+		R128AlbumGain,
 
 		// URLs
 		/// A URL link to the audio file


### PR DESCRIPTION
Opus defines the tags R128_TRACK_GAIN and R128_ALBUM_GAIN for usage with their header gain values ([RFC](https://datatracker.ietf.org/doc/html/rfc7845#section-5.2.1)).
I added the tags to the Vorbis comment tag map, seemed to work fine with my test file.
