### PR TITLE
Opus: Add `OpusProperties::output_gain_db()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **OPUS**: Store Opus output gain in `OpusProperties` and add function `OpusProperties::output_gain_db`
+
 ### Changed
 
 - **MP4**: `Mp4File::ftyp()` was moved to `Mp4Properties::ftyp()` ([PR](https://github.com/Serial-ATA/lofty-rs/pull/650))

--- a/lofty/src/ogg/opus/properties.rs
+++ b/lofty/src/ogg/opus/properties.rs
@@ -21,6 +21,7 @@ pub struct OpusProperties {
 	pub(crate) channel_mask: ChannelMask,
 	pub(crate) version: u8,
 	pub(crate) input_sample_rate: u32,
+	pub(crate) output_gain: i16,
 }
 
 impl From<OpusProperties> for FileProperties {
@@ -76,6 +77,11 @@ impl OpusProperties {
 	pub fn input_sample_rate(&self) -> u32 {
 		self.input_sample_rate
 	}
+
+	/// Output gain in dB
+	pub fn output_gain_db(&self) -> f32 {
+		self.output_gain as f32 / 256.0
+	}
 }
 
 pub(in crate::ogg) fn read_properties<R>(
@@ -101,8 +107,7 @@ where
 	let pre_skip = identification_packet_reader.read_u16::<LittleEndian>()?;
 
 	properties.input_sample_rate = identification_packet_reader.read_u32::<LittleEndian>()?;
-
-	let _output_gain = identification_packet_reader.read_u16::<LittleEndian>()?;
+	properties.output_gain = identification_packet_reader.read_i16::<LittleEndian>()?;
 
 	let channel_mapping_family = identification_packet_reader.read_u8()?;
 

--- a/lofty/src/ogg/opus/properties.rs
+++ b/lofty/src/ogg/opus/properties.rs
@@ -80,7 +80,7 @@ impl OpusProperties {
 
 	/// Output gain in dB
 	pub fn output_gain_db(&self) -> f32 {
-		self.output_gain as f32 / 256.0
+		f32::from(self.output_gain) / 256.0
 	}
 }
 

--- a/lofty/src/properties/tests.rs
+++ b/lofty/src/properties/tests.rs
@@ -244,6 +244,7 @@ const OPUS_PROPERTIES: OpusProperties = OpusProperties {
 	channel_mask: ChannelMask::stereo(),
 	version: 1,
 	input_sample_rate: 48000,
+	output_gain: 0,
 };
 
 const SPEEX_PROPERTIES: SpeexProperties = SpeexProperties {


### PR DESCRIPTION
Save the Opus output gain in `OpusProperties` and add a function for returning that value converted to dB.