### PR TITLE
docs: improve utility method docs, clarify remove_<tag> vs TagType::remove_from

### DIFF
--- a/lofty/src/config/parse_options.rs
+++ b/lofty/src/config/parse_options.rs
@@ -201,7 +201,7 @@ pub enum ParsingMode {
 	///
 	/// This mode will attempt to fill in any holes where possible in otherwise valid, spec-compliant input.
 	///
-	/// NOTE: A readable input does *not* necessarily make it writeable.
+	/// NOTE: A readable input does *not* necessarily make it writable.
 	///
 	/// ## Examples of behavior
 	///

--- a/lofty/src/file/tagged_file.rs
+++ b/lofty/src/file/tagged_file.rs
@@ -273,6 +273,8 @@ pub trait TaggedFileExt {
 
 	/// Removes a specific [`TagType`] and returns it
 	///
+	/// NOTE: This doesn't remove the tag from the file on disk. See [`TagType::remove_from()`].
+	///
 	/// # Examples
 	///
 	/// ```rust
@@ -538,7 +540,7 @@ impl<F> BoundTaggedFile<F> {
 	/// Consume this tagged file and return the internal file "buffer".
 	/// This allows you to reuse the internal file.
 	///
-	/// Any changes that haven't been commited will be discarded once you
+	/// Any changes that haven't been committed will be discarded once you
 	/// call this function.
 	pub fn into_inner(self) -> F {
 		self.file_handle

--- a/lofty/src/tag/accessor.rs
+++ b/lofty/src/tag/accessor.rs
@@ -3,7 +3,10 @@ use crate::tag::items::Timestamp;
 use std::borrow::Cow;
 
 #[cfg(doc)]
-use crate::{ogg::tag::VorbisComments, tag::Tag};
+use crate::{
+	ogg::tag::VorbisComments,
+	tag::{ItemKey, Tag, TagType},
+};
 
 // This defines the `Accessor` trait, used to define unified getters/setters for commonly
 // accessed tag values.
@@ -27,14 +30,14 @@ use crate::{ogg::tag::VorbisComments, tag::Tag};
 // }
 macro_rules! accessor_trait {
 	($([$($name:tt)+] < $($ty:ty),+ >),+ $(,)?) => {
-		/// Provides accessors for common items
+		/// Provides convenience accessors for metadata fields common across tag formats.
 		///
-		/// This attempts to only provide methods for items that all tags have in common,
-		/// but there may be exceptions.
+		/// For tag formats supporting multiple values, setter methods **overwrite** existing
+		/// values, rather than append. If multi-value support is needed, consider using the
+		/// format-specific methods. For example: [`Tag::push()`] or [`VorbisComments::push()`].
 		///
-		/// Note that for tag formats supporting multiple values, the behavior of any setter methods is
-		/// to **overwrite**, not append. If multi-value support is needed, consider using the format-specific methods.
-		/// For example: [`Tag::push()`] or [`VorbisComments::push()`].
+		/// `Accessor` intentionally exposes only a small set of common tag metadata. Additional standard fields
+		/// remain available using [`ItemKey`] through the [`Tag`]'s item APIs.
 		pub trait Accessor {
 			$(
 				accessor_trait! { @GETTER [$($name)+] $($ty),+ }
@@ -66,8 +69,8 @@ macro_rules! accessor_trait {
 			///
 			/// For formats that support multiple definitions of the same item, this will only return the first occurrence.
 			///
-			/// To retrieve all occurrences of a given item, consider using the format-specific methods.
-			/// For example: [`Tag::get_items()`] or [`VorbisComments::get_all()`].
+			/// To retrieve all occurrences of an item, use [`Tag::get_items()`] or format-specific
+			/// methods such as [`VorbisComments::get_all()`].
 			///
 			/// # Example
 			///
@@ -111,6 +114,7 @@ macro_rules! accessor_trait {
 	(@REMOVE_METHOD [$name:tt $($other:tt)*], $ty:ty) => {
 		paste::paste! {
 			#[doc = "Removes the " $name $(" " $other)*]
+			///
 			/// # Example
 			///
 			/// ```rust,ignore

--- a/lofty/src/tag/item.rs
+++ b/lofty/src/tag/item.rs
@@ -482,6 +482,15 @@ macro_rules! gen_item_keys {
 		#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 		#[non_exhaustive]
 		/// A generic representation of a tag's key
+		///
+		/// Unlike [`Accessor`](crate::tag::Accessor), which exposes only a handful of common fields,
+		/// [`ItemKey`] represents every supported metadata field.
+		///
+		/// Fields not covered by [`Accessor`](crate::tag::Accessor) can still be read or written
+		/// directly with methods such as [`Tag::get`](crate::tag::Tag::get),
+		/// [`Tag::get_string`](crate::tag::Tag::get_string), or [`Tag::insert`](crate::tag::Tag::insert).
+		///
+		/// NOTE: Some fields may have special behavior, check the documentation for each variant.
 		pub enum ItemKey {
 			$(
 				$(#[$variant_meta])*

--- a/lofty/src/tag/mod.rs
+++ b/lofty/src/tag/mod.rs
@@ -479,7 +479,10 @@ impl Tag {
 		self.items.drain(..split_idx)
 	}
 
-	/// Removes all items with the specified [`ItemKey`], and filters them through [`ItemValue::into_string`]
+	/// Removes all items with the specified [`ItemKey`], and filters them through [`ItemValue::into_string()`]
+	///
+	/// Prefer this over manually calling [`Tag::take()`] when only the text values of an item are needed.
+	/// Unlike [`Tag::get_strings()`], this method consumes the matching items instead of borrowing them.
 	pub fn take_strings(&mut self, key: ItemKey) -> impl Iterator<Item = String> + use<'_> {
 		self.take(key).filter_map(|i| i.item_value.into_string())
 	}
@@ -489,7 +492,9 @@ impl Tag {
 		self.items.iter().filter(move |i| i.key() == key)
 	}
 
-	/// Returns references to all texts of [`TagItem`]s with the specified key, and [`ItemValue::Text`]
+	/// Returns references to the text values of all [`TagItem`]s with the specified key.
+	///
+	/// Prefer this over manually matching [`ItemValue`] variants when only text is needed.
 	pub fn get_strings(&self, key: ItemKey) -> impl Iterator<Item = &str> + Clone {
 		self.items.iter().filter_map(move |i| {
 			if i.key() == key {
@@ -550,6 +555,9 @@ impl Tag {
 	}
 
 	/// Returns the first occurrence of the [`PictureType`]
+	///
+	/// This is a convenience method for retrieving a picture by type without
+	/// manually searching through the slice returned by [`Tag::pictures`].
 	pub fn get_picture_type(&self, picture_type: PictureType) -> Option<&Picture> {
 		self.pictures
 			.iter()

--- a/lofty_attr/src/lofty_file.rs
+++ b/lofty_attr/src/lofty_file.rs
@@ -381,7 +381,11 @@ fn get_getters<'a>(
 					#setter
 				}
 
-				/// Removes the tag
+				/// Removes the tag from the file, in memory
+				///
+				/// NOTE: This doesn't remove the tag from the file on disk. See [`TagType::remove_from()`].
+				///
+				/// [`TagType::remove_from()`]: crate::tag::TagType::remove_from
 				pub fn #remove_ident(&mut self) -> #ty_prefix #field_ty #ty_suffix {
 					#remover
 				}


### PR DESCRIPTION
closes #357 and #610 and did a tiny spelling pass (2 additional files affected)

The goal was to document the intended usage of the convenience APIs.

never written docs before so pls shoot down if not up to spec.