### PR TITLE
examples: Collapse nested `if`s in `tag_stripper`

### DIFF
--- a/examples/tag_stripper.rs
+++ b/examples/tag_stripper.rs
@@ -41,14 +41,13 @@ fn main() {
 		print!("\nNumber to remove: ");
 		std::io::stdout().flush().unwrap();
 
-		if std::io::stdin().read_line(&mut input).is_ok() {
-			if let Ok(num) = str::parse::<usize>(input.trim()) {
-				if num < available_tag_types.len() {
-					to_remove = Some(num);
-					println!();
-					break;
-				}
-			}
+		if std::io::stdin().read_line(&mut input).is_ok()
+			&& let Ok(num) = str::parse::<usize>(input.trim())
+			&& num < available_tag_types.len()
+		{
+			to_remove = Some(num);
+			println!();
+			break;
 		}
 
 		input.clear();


### PR DESCRIPTION
Following the `cargo fmt`/`cargo clippy`/`cargo doc` step in
CONTRIBUTING.md before opening a PR, the command`cargo clippy --all-targets` fails on current stable (clippy 0.1.97) with two issues:

```
clippy::collapsible_if` errors in `examples/tag_stripper.rs`. Since let-chains
are available on the current MSRV (1.89, edition 2024), the nested conditions
collapse into a single `if`.
```

CI does not currently catch this, as it runs `cargo clippy --all-features`
without `--all-targets`, so the examples are never linted. 

No behavioral change - a failure at any step still falls through to the
"Unexpected input" branch.
