### PR TITLE
FLAC: Avoid buffering the entire file during tag writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **FLAC**: Writes will no longer read the entire file into memory ([issue](https://github.com/Serial-ATA/lofty-rs/issues/694)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/695))
+
 ### Fixed
 
 - **ID3v2**: Fixed unconditional BOM stripping when parsing UTF-16 `KeyValueFrame`s ([issue](https://github.com/Serial-ATA/lofty-rs/issues/696)) ([PR](https://github.com/Serial-ATA/lofty-rs/pull/697))

--- a/lofty/src/flac/write.rs
+++ b/lofty/src/flac/write.rs
@@ -145,40 +145,27 @@ where
 	if will_write_padding && let Some(preferred_padding) = write_options.preferred_padding {
 		log::warn!("File is missing a PADDING block. Adding one");
 
+		let metadata_len = blocks
+			.iter()
+			.map(|block| u64::from(block.len()))
+			.sum::<u64>();
+		let old_metadata_len = metadata_range.end - metadata_range.start;
+		let available_padding = old_metadata_len
+			.saturating_sub(metadata_len)
+			.saturating_sub(Block::BLOCK_HEADER_SIZE as u64);
+		let padding_len = available_padding
+			.max(u64::from(preferred_padding))
+			.min(u64::from(Block::MAX_CONTENT_SIZE));
+		let padding_len = usize::try_from(padding_len).map_err(|_| SizeMismatchError)?;
+
 		// `PADDING` always goes last
-		let mut padding_block = Block::new_padding(preferred_padding as usize)?;
-		padding_block.last = true;
-
-		blocks.push(padding_block);
+		blocks.push(Block::new_padding(padding_len)?);
 	}
 
-	let mut encoded_metadata = encode_blocks(&blocks)?;
-
-	if will_write_padding
-		&& let Some(preferred_padding) = write_options.preferred_padding
-		&& (encoded_metadata.len() as u64) < metadata_range.end - metadata_range.start
-	{
-		// Keep the metadata region with the PADDING block already created above. Its header is
-		// part of the retained span, so only the remaining bytes become block content.
-		let padding_index = blocks.len() - 1;
-		let non_padding_len = encoded_metadata.len() - blocks[padding_index].len() as usize;
-		let available = metadata_range.end - metadata_range.start - non_padding_len as u64;
-		let padding_span = available.max(u64::from(preferred_padding) + 4).max(4);
-		let padding_content = usize::try_from(padding_span - 4).map_err(|_| SizeMismatchError)?;
-		let mut padding_block = Block::new_padding(padding_content)?;
-		padding_block.last = true;
-		blocks[padding_index] = padding_block;
-
-		encoded_metadata = encode_blocks(&blocks)?;
-	} else if let Some(block) = blocks.last_mut() {
+	if let Some(block) = blocks.last_mut() {
 		block.last = true;
-		encoded_metadata = encode_blocks(&blocks)?;
 	}
 
-	Ok(replace_range(&mut file, metadata_range, &encoded_metadata)?)
-}
-
-fn encode_blocks(blocks: &[Block]) -> Result<Vec<u8>, FileEncodingError> {
 	let mut encoded_metadata = Vec::new();
 	for block in blocks {
 		block.write_to(&mut encoded_metadata)?;
@@ -189,7 +176,9 @@ fn encode_blocks(blocks: &[Block]) -> Result<Vec<u8>, FileEncodingError> {
 		);
 	}
 
-	Ok(encoded_metadata)
+	replace_range(&mut file, metadata_range, &encoded_metadata)?;
+
+	Ok(())
 }
 
 const MOVE_BUFFER_SIZE: usize = 64 * 1024;

--- a/lofty/src/flac/write.rs
+++ b/lofty/src/flac/write.rs
@@ -152,10 +152,33 @@ where
 		blocks.push(padding_block);
 	}
 
-	if let Some(block) = blocks.last_mut() {
-		block.last = true
+	let mut encoded_metadata = encode_blocks(&blocks)?;
+
+	if will_write_padding
+		&& let Some(preferred_padding) = write_options.preferred_padding
+		&& (encoded_metadata.len() as u64) < metadata_range.end - metadata_range.start
+	{
+		// Keep the metadata region with the PADDING block already created above. Its header is
+		// part of the retained span, so only the remaining bytes become block content.
+		let padding_index = blocks.len() - 1;
+		let non_padding_len = encoded_metadata.len() - blocks[padding_index].len() as usize;
+		let available = metadata_range.end - metadata_range.start - non_padding_len as u64;
+		let padding_span = available.max(u64::from(preferred_padding) + 4).max(4);
+		let padding_content = usize::try_from(padding_span - 4).map_err(|_| SizeMismatchError)?;
+		let mut padding_block = Block::new_padding(padding_content)?;
+		padding_block.last = true;
+		blocks[padding_index] = padding_block;
+
+		encoded_metadata = encode_blocks(&blocks)?;
+	} else if let Some(block) = blocks.last_mut() {
+		block.last = true;
+		encoded_metadata = encode_blocks(&blocks)?;
 	}
 
+	Ok(replace_range(&mut file, metadata_range, &encoded_metadata)?)
+}
+
+fn encode_blocks(blocks: &[Block]) -> Result<Vec<u8>, FileEncodingError> {
 	let mut encoded_metadata = Vec::new();
 	for block in blocks {
 		block.write_to(&mut encoded_metadata)?;
@@ -166,9 +189,7 @@ where
 		);
 	}
 
-	replace_range(&mut file, metadata_range, &encoded_metadata)?;
-
-	Ok(())
+	Ok(encoded_metadata)
 }
 
 const MOVE_BUFFER_SIZE: usize = 64 * 1024;

--- a/lofty/src/flac/write.rs
+++ b/lofty/src/flac/write.rs
@@ -3,7 +3,7 @@ use super::read::verify_flac;
 use crate::config::WriteOptions;
 use crate::error::{FileEncodingError, FileParseError, SizeMismatchError, TagParseError};
 use crate::id3::{FindId3v2Config, find_id3v2};
-use crate::io::{Truncate, VerifiedFile};
+use crate::io::{Length, VerifiedFile};
 use crate::macros::try_vec;
 use crate::ogg::tag::VorbisCommentsRef;
 use crate::picture::{Picture, PictureInformation};
@@ -11,8 +11,9 @@ use crate::tag::{Tag, TagType};
 use crate::util::io::FileLike;
 
 use std::borrow::Cow;
-use std::io::{Cursor, Read, Seek, Write};
+use std::io::{ErrorKind, Read, Seek, SeekFrom};
 use std::iter::Peekable;
+use std::ops::Range;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
@@ -56,15 +57,12 @@ where
 {
 	let mut file = file.into_inner();
 
-	let mut file_bytes = Vec::new();
-	file.read_to_end(&mut file_bytes)?;
-
-	let mut cursor = Cursor::new(file_bytes);
+	file.rewind()?;
 
 	// We don't actually need the ID3v2 tag, but reading it will seek to the end of it if it exists
-	find_id3v2(&mut cursor, FindId3v2Config::NO_READ_TAG).map_err(TagParseError::from)?;
+	find_id3v2(&mut file, FindId3v2Config::NO_READ_TAG).map_err(TagParseError::from)?;
 
-	let mut stream_info = verify_flac(&mut cursor).map_err(FileParseError::from)?;
+	let mut stream_info = verify_flac(&mut file).map_err(FileParseError::from)?;
 
 	let mut is_last_block = stream_info.last;
 	let mut has_blocks_to_remove = false;
@@ -72,11 +70,11 @@ where
 
 	stream_info.last = false; // Determined later
 
-	let mut metadata_range = (stream_info.start as usize)..(stream_info.end as usize);
+	let mut metadata_range = stream_info.start..stream_info.end;
 	let mut blocks = vec![stream_info];
 	while !is_last_block {
 		let mut skip = false;
-		let mut block = Block::read(&mut cursor, |ty| match ty {
+		let mut block = Block::read(&mut file, |ty| match ty {
 			BLOCK_ID_PICTURE => {
 				has_blocks_to_remove = true;
 				skip = true;
@@ -116,7 +114,7 @@ where
 		}
 
 		is_last_block = block.last;
-		metadata_range.end = block.end as usize;
+		metadata_range.end = block.end;
 
 		if !skip {
 			// Last block determined later
@@ -139,7 +137,6 @@ where
 
 	// TODO: We need to actually use padding (https://github.com/Serial-ATA/lofty-rs/issues/445)
 	let will_write_padding = !has_padding && write_options.preferred_padding.is_some();
-	let mut file_bytes = cursor.into_inner();
 
 	let metadata_blocks = encode_tag(&tag.vendor, comments_peek, pictures_peek)?;
 
@@ -169,11 +166,130 @@ where
 		);
 	}
 
-	file_bytes.splice(metadata_range, encoded_metadata);
+	replace_range(&mut file, metadata_range, &encoded_metadata)?;
 
-	file.rewind()?;
-	file.truncate(0)?;
-	file.write_all(&file_bytes)?;
+	Ok(())
+}
+
+const MOVE_BUFFER_SIZE: usize = 64 * 1024;
+
+fn replace_range<F>(file: &mut F, range: Range<u64>, replacement: &[u8]) -> std::io::Result<()>
+where
+	F: FileLike,
+{
+	if range.start > range.end {
+		return Err(std::io::Error::new(
+			ErrorKind::InvalidInput,
+			"range start exceeds range end",
+		));
+	}
+
+	let file_len = Length::len(file)?;
+	if range.end > file_len {
+		return Err(std::io::Error::new(
+			ErrorKind::InvalidInput,
+			"range extends beyond file length",
+		));
+	}
+
+	let old_len = range.end - range.start;
+	let replacement_len = u64::try_from(replacement.len())
+		.map_err(|_| std::io::Error::new(ErrorKind::InvalidInput, "replacement is too large"))?;
+
+	let mut buffer = vec![0_u8; MOVE_BUFFER_SIZE];
+
+	match replacement_len.cmp(&old_len) {
+		std::cmp::Ordering::Greater => {
+			let difference = replacement_len - old_len;
+			// The ranges overlap, so move the tail backwards from EOF before writing metadata.
+			extend_storage(file, difference, &buffer)?;
+			shift_right(file, range.end, file_len, difference, &mut buffer)?;
+		},
+		std::cmp::Ordering::Less => {
+			let difference = old_len - replacement_len;
+			// Move forwards from the metadata boundary so writes cannot clobber unread tail data.
+			shift_left(file, range.end, file_len, difference, &mut buffer)?;
+			file.truncate(file_len - difference)?;
+		},
+		std::cmp::Ordering::Equal => {},
+	}
+
+	file.seek(SeekFrom::Start(range.start))?;
+	file.write_all(replacement)?;
+
+	Ok(())
+}
+
+fn extend_storage<F>(file: &mut F, amount: u64, zeros: &[u8]) -> std::io::Result<()>
+where
+	F: FileLike,
+{
+	file.seek(SeekFrom::End(0))?;
+
+	let mut remaining = amount;
+	while remaining != 0 {
+		let chunk_len = usize::try_from(remaining.min(zeros.len() as u64))
+			.expect("chunk length is bounded by the in-memory buffer");
+		file.write_all(&zeros[..chunk_len])?;
+		remaining -= chunk_len as u64;
+	}
+
+	Ok(())
+}
+
+fn shift_right<F>(
+	file: &mut F,
+	start: u64,
+	end: u64,
+	amount: u64,
+	buffer: &mut [u8],
+) -> std::io::Result<()>
+where
+	F: FileLike,
+{
+	let mut cursor = end;
+
+	while cursor > start {
+		let chunk_len = usize::try_from((cursor - start).min(buffer.len() as u64))
+			.expect("chunk length is bounded by the in-memory buffer");
+		let source = cursor - chunk_len as u64;
+
+		file.seek(SeekFrom::Start(source))?;
+		file.read_exact(&mut buffer[..chunk_len])?;
+
+		file.seek(SeekFrom::Start(source + amount))?;
+		file.write_all(&buffer[..chunk_len])?;
+
+		cursor = source;
+	}
+
+	Ok(())
+}
+
+fn shift_left<F>(
+	file: &mut F,
+	start: u64,
+	end: u64,
+	amount: u64,
+	buffer: &mut [u8],
+) -> std::io::Result<()>
+where
+	F: FileLike,
+{
+	let mut cursor = start;
+
+	while cursor < end {
+		let chunk_len = usize::try_from((end - cursor).min(buffer.len() as u64))
+			.expect("chunk length is bounded by the in-memory buffer");
+
+		file.seek(SeekFrom::Start(cursor))?;
+		file.read_exact(&mut buffer[..chunk_len])?;
+
+		file.seek(SeekFrom::Start(cursor - amount))?;
+		file.write_all(&buffer[..chunk_len])?;
+
+		cursor += chunk_len as u64;
+	}
 
 	Ok(())
 }
@@ -198,4 +314,58 @@ where
 	}
 
 	Ok(metadata_blocks)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	use std::io::Cursor;
+
+	fn apply_range(input: Vec<u8>, range: Range<usize>, replacement: &[u8]) {
+		let mut expected = input.clone();
+		drop(expected.splice(range.clone(), replacement.iter().copied()));
+
+		let mut cursor = Cursor::new(input);
+		replace_range(
+			&mut cursor,
+			(range.start as u64)..(range.end as u64),
+			replacement,
+		)
+		.expect("range replacement should succeed");
+
+		let actual = cursor.into_inner();
+		assert_eq!(actual, expected);
+	}
+
+	#[test]
+	fn replace_range_equal_size() {
+		apply_range(b"0123456789".to_vec(), 2..5, b"XYZ");
+	}
+
+	#[test]
+	fn replace_range_grows() {
+		apply_range(b"0123456789".to_vec(), 2..5, b"abcdef");
+	}
+
+	#[test]
+	fn replace_range_shrinks() {
+		apply_range(b"0123456789".to_vec(), 2..8, b"X");
+	}
+
+	#[test]
+	fn replace_range_grows_across_multiple_buffers() {
+		let mut input = b"prefix".to_vec();
+		input.extend((0..(MOVE_BUFFER_SIZE * 3 + 17)).map(|index| (index % 251) as u8));
+
+		apply_range(input, 1..4, b"a much longer metadata replacement");
+	}
+
+	#[test]
+	fn replace_range_shrinks_across_multiple_buffers() {
+		let mut input = b"prefix".to_vec();
+		input.extend((0..(MOVE_BUFFER_SIZE * 3 + 17)).map(|index| (index % 251) as u8));
+
+		apply_range(input, 1..4, b"x");
+	}
 }

--- a/lofty/tests/files/resize.rs
+++ b/lofty/tests/files/resize.rs
@@ -2,12 +2,13 @@
 
 use crate::util::{named_temp_file, tool_installed};
 
-use std::io::Seek;
+use std::fs::File;
+use std::io::{Read, Seek};
 use std::path::Path;
 use std::process::Command;
 
 use lofty::config::WriteOptions;
-use lofty::file::TaggedFileExt;
+use lofty::file::{AudioFile, TaggedFileExt};
 use lofty::tag::{Accessor, Tag, TagExt, TagType};
 
 fn tag(ty: TagType, size: usize) -> Tag {
@@ -122,6 +123,95 @@ fn flac_resize() {
 		"tests/files/assets/minimal/full_test.flac",
 		TagType::VorbisComments,
 	);
+}
+
+fn flac_metadata_end(file: &mut File) -> (u64, Vec<usize>) {
+	file.rewind().unwrap();
+	let mut data = Vec::new();
+	file.read_to_end(&mut data).unwrap();
+	assert_eq!(&data[..4], b"fLaC");
+
+	let mut offset = 4;
+	let mut padding = Vec::new();
+	loop {
+		let header = &data[offset..offset + 4];
+		let is_last = header[0] & 0x80 != 0;
+		let block_type = header[0] & 0x7f;
+		let content_len =
+			usize::from(header[1]) << 16 | usize::from(header[2]) << 8 | usize::from(header[3]);
+		if block_type == 1 {
+			padding.push(content_len);
+		}
+		offset += 4 + content_len;
+		if is_last {
+			break;
+		}
+	}
+
+	(offset as u64, padding)
+}
+
+fn flac_with_large_tag() -> File {
+	let mut file = crate::util::temp_file("tests/files/assets/stream_info_last.flac");
+	tag(TagType::VorbisComments, 1000)
+		.save_to(&mut file, WriteOptions::default().preferred_padding(0))
+		.unwrap();
+	file.rewind().unwrap();
+	file
+}
+
+#[test_log::test]
+fn flac_preferred_padding_keeps_a_larger_shrink_gap() {
+	let mut file = flac_with_large_tag();
+	let original_len = file.metadata().unwrap().len();
+	let (original_metadata_end, _) = flac_metadata_end(&mut file);
+	file.rewind().unwrap();
+
+	tag(TagType::VorbisComments, 1)
+		.save_to(&mut file, WriteOptions::default().preferred_padding(16))
+		.unwrap();
+
+	let (metadata_end, padding) = flac_metadata_end(&mut file);
+	assert_eq!(file.metadata().unwrap().len(), original_len);
+	assert_eq!(metadata_end, original_metadata_end);
+	assert!(padding.iter().sum::<usize>() > 16);
+
+	file.rewind().unwrap();
+	lofty::flac::FlacFile::read_from(&mut file, lofty::config::ParseOptions::new()).unwrap();
+}
+
+#[test_log::test]
+fn flac_preferred_padding_grows_when_shrink_gap_is_smaller() {
+	let mut file = flac_with_large_tag();
+	let original_len = file.metadata().unwrap().len();
+	file.rewind().unwrap();
+
+	tag(TagType::VorbisComments, 1)
+		.save_to(
+			&mut file,
+			WriteOptions::default().preferred_padding(100_000),
+		)
+		.unwrap();
+
+	let (_, padding) = flac_metadata_end(&mut file);
+	assert!(file.metadata().unwrap().len() > original_len);
+	assert!(padding.iter().sum::<usize>() >= 100_000);
+
+	file.rewind().unwrap();
+	lofty::flac::FlacFile::read_from(&mut file, lofty::config::ParseOptions::new()).unwrap();
+}
+
+#[test_log::test]
+fn flac_without_preferred_padding_still_shrinks() {
+	let mut file = flac_with_large_tag();
+	let original_len = file.metadata().unwrap().len();
+	file.rewind().unwrap();
+
+	tag(TagType::VorbisComments, 1)
+		.save_to(&mut file, WriteOptions::default().preferred_padding(0))
+		.unwrap();
+
+	assert!(file.metadata().unwrap().len() < original_len);
 }
 
 #[test_log::test]

--- a/lofty/tests/files/resize.rs
+++ b/lofty/tests/files/resize.rs
@@ -202,6 +202,23 @@ fn flac_preferred_padding_grows_when_shrink_gap_is_smaller() {
 }
 
 #[test_log::test]
+fn flac_preferred_padding_is_written_when_metadata_grows() {
+	let mut file = crate::util::temp_file("tests/files/assets/stream_info_last.flac");
+	let original_len = file.metadata().unwrap().len();
+
+	tag(TagType::VorbisComments, 1000)
+		.save_to(&mut file, WriteOptions::default().preferred_padding(16))
+		.unwrap();
+
+	let (_, padding) = flac_metadata_end(&mut file);
+	assert!(file.metadata().unwrap().len() > original_len);
+	assert!(padding.iter().sum::<usize>() >= 16);
+
+	file.rewind().unwrap();
+	lofty::flac::FlacFile::read_from(&mut file, lofty::config::ParseOptions::new()).unwrap();
+}
+
+#[test_log::test]
 fn flac_without_preferred_padding_still_shrinks() {
 	let mut file = flac_with_large_tag();
 	let original_len = file.metadata().unwrap().len();

--- a/lofty/tests/files/resize.rs
+++ b/lofty/tests/files/resize.rs
@@ -7,8 +7,9 @@ use std::io::{Read, Seek};
 use std::path::Path;
 use std::process::Command;
 
-use lofty::config::WriteOptions;
+use lofty::config::{ParseOptions, WriteOptions};
 use lofty::file::{AudioFile, TaggedFileExt};
+use lofty::flac::FlacFile;
 use lofty::tag::{Accessor, Tag, TagExt, TagType};
 
 fn tag(ty: TagType, size: usize) -> Tag {
@@ -136,7 +137,7 @@ fn flac_metadata_end(file: &mut File) -> (u64, Vec<usize>) {
 	loop {
 		let header = &data[offset..offset + 4];
 		let is_last = header[0] & 0x80 != 0;
-		let block_type = header[0] & 0x7f;
+		let block_type = header[0] & 0x7F;
 		let content_len =
 			usize::from(header[1]) << 16 | usize::from(header[2]) << 8 | usize::from(header[3]);
 		if block_type == 1 {
@@ -177,7 +178,7 @@ fn flac_preferred_padding_keeps_a_larger_shrink_gap() {
 	assert!(padding.iter().sum::<usize>() > 16);
 
 	file.rewind().unwrap();
-	lofty::flac::FlacFile::read_from(&mut file, lofty::config::ParseOptions::new()).unwrap();
+	FlacFile::read_from(&mut file, ParseOptions::new()).unwrap();
 }
 
 #[test_log::test]
@@ -198,7 +199,7 @@ fn flac_preferred_padding_grows_when_shrink_gap_is_smaller() {
 	assert!(padding.iter().sum::<usize>() >= 100_000);
 
 	file.rewind().unwrap();
-	lofty::flac::FlacFile::read_from(&mut file, lofty::config::ParseOptions::new()).unwrap();
+	FlacFile::read_from(&mut file, ParseOptions::new()).unwrap();
 }
 
 #[test_log::test]
@@ -215,7 +216,7 @@ fn flac_preferred_padding_is_written_when_metadata_grows() {
 	assert!(padding.iter().sum::<usize>() >= 16);
 
 	file.rewind().unwrap();
-	lofty::flac::FlacFile::read_from(&mut file, lofty::config::ParseOptions::new()).unwrap();
+	FlacFile::read_from(&mut file, ParseOptions::new()).unwrap();
 }
 
 #[test_log::test]

--- a/lofty/tests/files/resize.rs
+++ b/lofty/tests/files/resize.rs
@@ -117,6 +117,14 @@ fn riff_info_resize() {
 }
 
 #[test_log::test]
+fn flac_resize() {
+	tag_resize_test(
+		"tests/files/assets/minimal/full_test.flac",
+		TagType::VorbisComments,
+	);
+}
+
+#[test_log::test]
 fn vorbis_comments_resize() {
 	tag_resize_test(
 		"tests/files/assets/minimal/full_test.opus",


### PR DESCRIPTION
closes #694

This keeps the existing FLAC parsing and metadata encoding, but replaces the final whole-file buffer/splice with a bounded in-place range replacement.

- Equal-sized metadata is overwritten in place.
- When metadata grows, the file is extended and the remaining contents are moved backwards in 64 KiB chunks before writing the replacement.
- When metadata shrinks, the remaining contents are moved forwards and the file is truncated afterward.

The FLAC resize regression now covers FLAC directly. I also checked the historical #549/#607/#608/#640 failure modes, including no-padding/minimal layouts, last-metadata-block handling, leading ID3 data, and metadata shrink/grow. The large-file reproducer from #694 still passes `flac -t` with the audio signature preserved while avoiding whole-file memory use.

This does not try to solve #445: existing FLAC padding is still handled the same way, so audio may still need to move when metadata size changes.

AI disclosure: I used AI assistance during investigation, prototyping, test design, and drafting. I reviewed the behavior and failure modes, reproduced the tests and measurements locally, and will participate directly in review.
